### PR TITLE
Rust duration type

### DIFF
--- a/.github/workflows/tmp-expected.yml
+++ b/.github/workflows/tmp-expected.yml
@@ -1,0 +1,93 @@
+name: Manually selected tests for this PR
+env:
+  DEBUG: napi:*
+  APP_NAME: scylladb-javascript-driver
+"on":
+  push:
+    branches:
+      - "**"
+    tags-ignore:
+      - "**"
+    paths-ignore:
+      - "**/*.md"
+      - LICENSE
+      - "**/*.gitignore"
+      - .editorconfig
+      - docs/**
+  pull_request: null
+jobs:
+  build-and-run-tests:
+    strategy:
+      fail-fast: false
+      matrix:
+        settings:
+          - host: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+            build: npm run build -- --target x86_64-unknown-linux-gnu
+    name: Build and run tests - ${{ matrix.settings.target }} - node@20
+    runs-on: ${{ matrix.settings.host }}
+    outputs:
+      OPENSSL_DIR: ${{ steps.install_openssl.outputs.OPENSSL_DIR }}
+      OPENSSL_STATIC: ${{ steps.install_openssl.outputs.OPENSSL_STATIC }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup 3-node Scylla cluster
+        run: |
+          sudo sh -c "echo 2097152 >> /proc/sys/fs/aio-max-nr"
+          docker compose -f .github/docker-compose.yml up -d --wait
+      - name: Setup node
+        uses: actions/setup-node@v4
+        if: ${{ !matrix.settings.docker }}
+        with:
+          node-version: 20
+          cache: npm
+      - name: Install
+        uses: dtolnay/rust-toolchain@stable
+        if: ${{ !matrix.settings.docker }}
+        with:
+          toolchain: stable
+          targets: ${{ matrix.settings.target }}
+      - name: Cache cargo
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            ~/.napi-rs
+            .cargo-cache
+            target/
+          key: ${{ matrix.settings.target }}-cargo-${{ matrix.settings.host }}
+      - name: Install dependencies
+        run: npm i
+      - name: Build in docker
+        uses: addnab/docker-run-action@v3
+        if: ${{ matrix.settings.docker }}
+        with:
+          image: ${{ matrix.settings.docker }}
+          options: "--user 0:0 -v ${{ github.workspace }}/.cargo-cache/git/db:/usr/local/cargo/git/db -v ${{ github.workspace }}/.cargo/registry/cache:/usr/local/cargo/registry/cache -v ${{ github.workspace }}/.cargo/registry/index:/usr/local/cargo/registry/index -v ${{ github.workspace }}:/build -w /build"
+          run: |
+            apt update
+            apt install -y pkg-config libssl-dev
+            ${{ matrix.settings.build }}
+      - name: Build
+        run: ${{ matrix.settings.build }}
+        if: ${{ !matrix.settings.docker }}
+        shell: bash
+      - name: Run examples
+        run: |
+          cd examples/DataStax
+          npm i
+          SCYLLA_URI=172.42.0.2:9042 node basic/basic-connect.js
+          SCYLLA_URI=172.42.0.2:9042 node basic/basic-execute.js
+      - name: Run tests
+        run: |
+          ./node_modules/.bin/mocha test/unit/duration-type-tests.js
+      - name: Stop the cluster
+        if: ${{ always() }}
+        run: docker compose -f .github/docker-compose.yml stop
+      - name: Print the cluster logs
+        if: ${{ always() }}
+        run: docker compose -f .github/docker-compose.yml logs
+      - name: Remove cluster
+        run: docker compose -f .github/docker-compose.yml down

--- a/index.d.ts
+++ b/index.d.ts
@@ -34,11 +34,9 @@ export const enum CqlTypes {
 }
 
 export declare class Duration {
-  static new(months: number, days: number, nanoseconds: number): Duration
-  toBuffer(): Buffer
-  toString(): string
+  static new(months: number, days: number, ns1: number, ns2: number, filler: number): Duration
+  getObject(): Array<number>
   static fromBuffer(buffer: Buffer): Duration
-  static fromString(input: string): Duration
 }
 export declare class PlainTextAuthProvider {
   id: number

--- a/index.d.ts
+++ b/index.d.ts
@@ -34,9 +34,11 @@ export const enum CqlTypes {
 }
 
 export declare class Duration {
-  static new(months: number, days: number, ns1: number, ns2: number, filler: number): Duration
-  getObject(): Array<number>
-  static fromBuffer(buffer: Buffer): Duration
+  months: number
+  days: number
+  nanoseconds: number
+  static new(months: number, days: number, nsBigint: bigint): Duration
+  getNanoseconds(): bigint
 }
 export declare class PlainTextAuthProvider {
   id: number

--- a/index.d.ts
+++ b/index.d.ts
@@ -32,6 +32,14 @@ export const enum CqlTypes {
   Uuid = 24,
   Varint = 25
 }
+
+export declare class Duration {
+  static new(months: number, days: number, nanoseconds: number): Duration
+  toBuffer(): Buffer
+  toString(): string
+  static fromBuffer(buffer: Buffer): Duration
+  static fromString(input: string): Duration
+}
 export declare class PlainTextAuthProvider {
   id: number
   static new(): PlainTextAuthProvider

--- a/index.d.ts
+++ b/index.d.ts
@@ -32,14 +32,6 @@ export const enum CqlTypes {
   Uuid = 24,
   Varint = 25
 }
-
-export declare class Duration {
-  months: number
-  days: number
-  nanoseconds: number
-  static new(months: number, days: number, nsBigint: bigint): Duration
-  getNanoseconds(): bigint
-}
 export declare class PlainTextAuthProvider {
   id: number
   static new(): PlainTextAuthProvider
@@ -60,6 +52,7 @@ export declare class CqlValueWrapper {
   getBlob(): Buffer
   getCounter(): bigint
   getDouble(): number
+  getDuration(): DurationWrapper
   getFloat(): number
   getInt(): number
   getText(): string
@@ -74,4 +67,11 @@ export declare class SessionOptions {
 export declare class SessionWrapper {
   static createSession(options: SessionOptions): Promise<SessionWrapper>
   queryUnpagedNoValues(query: string): Promise<QueryResultWrapper>
+}
+export declare class DurationWrapper {
+  months: number
+  days: number
+  nanoseconds: number
+  static new(months: number, days: number, nsBigint: bigint): DurationWrapper
+  getNanoseconds(): bigint
 }

--- a/index.js
+++ b/index.js
@@ -310,9 +310,8 @@ if (!nativeBinding) {
   throw new Error(`Failed to load native binding`)
 }
 
-const { Duration, testConnection, PlainTextAuthProvider, QueryResultWrapper, RowWrapper, CqlValueWrapper, CqlTypes, SessionOptions, SessionWrapper } = nativeBinding
+const { testConnection, PlainTextAuthProvider, QueryResultWrapper, RowWrapper, CqlValueWrapper, CqlTypes, SessionOptions, SessionWrapper, DurationWrapper } = nativeBinding
 
-module.exports.Duration = Duration
 module.exports.testConnection = testConnection
 module.exports.PlainTextAuthProvider = PlainTextAuthProvider
 module.exports.QueryResultWrapper = QueryResultWrapper
@@ -321,3 +320,4 @@ module.exports.CqlValueWrapper = CqlValueWrapper
 module.exports.CqlTypes = CqlTypes
 module.exports.SessionOptions = SessionOptions
 module.exports.SessionWrapper = SessionWrapper
+module.exports.DurationWrapper = DurationWrapper

--- a/index.js
+++ b/index.js
@@ -310,8 +310,9 @@ if (!nativeBinding) {
   throw new Error(`Failed to load native binding`)
 }
 
-const { testConnection, PlainTextAuthProvider, QueryResultWrapper, RowWrapper, CqlValueWrapper, CqlTypes, SessionOptions, SessionWrapper } = nativeBinding
+const { Duration, testConnection, PlainTextAuthProvider, QueryResultWrapper, RowWrapper, CqlValueWrapper, CqlTypes, SessionOptions, SessionWrapper } = nativeBinding
 
+module.exports.Duration = Duration
 module.exports.testConnection = testConnection
 module.exports.PlainTextAuthProvider = PlainTextAuthProvider
 module.exports.QueryResultWrapper = QueryResultWrapper

--- a/lib/new-utils.js
+++ b/lib/new-utils.js
@@ -1,0 +1,24 @@
+"use strict";
+
+const Long = require("long");
+
+/**
+ * Converts from bigint provided by napi into Long type used by the datastax library
+ * @param {bigint} from
+ * @returns {Long}
+ */
+function bigint_to_long(from) {
+  return Long.fromString(from.toString());
+}
+
+/**
+ * Converts from Long type used by the datastax library into bigint used by napi
+ * @param {Long} from
+ * @returns {bigint}
+ */
+function long_to_bigint(from) {
+  return BigInt(from.toString());
+}
+
+exports.bigint_to_long = bigint_to_long;
+exports.long_to_bigint = long_to_bigint;

--- a/lib/new-utils.js
+++ b/lib/new-utils.js
@@ -1,8 +1,10 @@
 "use strict";
 
 const Long = require("long");
+
+// maxInt value is based on how does Long splits values between internal high and low fields.
 const maxInt = BigInt(0x100000000);
-const minuOne = BigInt(-1);
+const minusOne = BigInt(-1);
 
 /**
  * Converts from bigint provided by napi into Long type used by the datastax library

--- a/lib/new-utils.js
+++ b/lib/new-utils.js
@@ -1,14 +1,21 @@
 "use strict";
 
 const Long = require("long");
+const maxInt = BigInt(0x100000000);
+const minuOne = BigInt(-1);
 
 /**
  * Converts from bigint provided by napi into Long type used by the datastax library
+ * BigInt is the way napi handles values too big for js Number type,
+ * while Long is the way datastax parts of the code handle 64-bit integers.
  * @param {bigint} from
  * @returns {Long}
  */
-function bigint_to_long(from) {
-  return Long.fromString(from.toString());
+function bigintToLong(from) {
+  let lo = from % maxInt;
+  let hi = from / maxInt;
+  if (lo < 0) hi += minusOne;
+  return Long.fromValue({ low: Number(lo), high: Number(hi), unsigned: false });
 }
 
 /**
@@ -16,9 +23,13 @@ function bigint_to_long(from) {
  * @param {Long} from
  * @returns {bigint}
  */
-function long_to_bigint(from) {
-  return BigInt(from.toString());
+function longToBigint(from) {
+  let lo = BigInt(from.low);
+  let hi = BigInt(from.high);
+  let r = lo + maxInt * hi;
+  if (lo < 0) r += maxInt;
+  return r;
 }
 
-exports.bigint_to_long = bigint_to_long;
-exports.long_to_bigint = long_to_bigint;
+exports.bigintToLong = bigintToLong;
+exports.longToBigint = longToBigint;

--- a/lib/types/duration.js
+++ b/lib/types/duration.js
@@ -3,10 +3,11 @@ const Long = require("long");
 const util = require("util");
 const utils = require("../utils");
 const rust = require("../../index");
-const { bigint_to_long, long_to_bigint } = require("../new-utils");
+const { bigintToLong, longToBigint } = require("../new-utils");
 
 /** @module types */
 
+// Reuse the same buffers that should perform slightly better than built-in buffer pool
 const reusableBuffers = {
   months: utils.allocBuffer(9),
   days: utils.allocBuffer(9),
@@ -44,7 +45,7 @@ function Duration(months, days, nanoseconds) {
     this.internal = rust.DurationWrapper.new(
       months,
       days,
-      long_to_bigint(nanoseconds),
+      longToBigint(nanoseconds),
     );
   else if (isNumber(nanoseconds))
     this.internal = rust.DurationWrapper.new(months, days, BigInt(nanoseconds));
@@ -70,7 +71,7 @@ Duration.prototype.equals = function (other) {
  * @returns {Buffer}
  */
 Duration.prototype.toBuffer = function () {
-  let nanoseconds = bigint_to_long(this.internal.getNanoseconds());
+  let nanoseconds = bigintToLong(this.internal.getNanoseconds());
   const lengthMonths = VIntCoding.writeVInt(
     Long.fromNumber(this.internal.months),
     reusableBuffers.months,
@@ -99,7 +100,7 @@ Duration.prototype.toBuffer = function () {
  * @return {string}
  */
 Duration.prototype.toString = function () {
-  let nanoseconds = bigint_to_long(this.internal.getNanoseconds());
+  let nanoseconds = bigintToLong(this.internal.getNanoseconds());
   let value = "";
   function append(dividend, divisor, unit) {
     if (dividend === 0 || dividend < divisor) {
@@ -146,7 +147,6 @@ Duration.prototype.toString = function () {
  * @returns {Duration}
  */
 Duration.fromBuffer = function (buffer) {
-  if ((!buffer) instanceof Buffer) throw new TypeError("Expected Buffer type");
   const offset = { value: 0 };
   const months = VIntCoding.readVInt(buffer, offset).toNumber();
   const days = VIntCoding.readVInt(buffer, offset).toNumber();

--- a/lib/types/duration.js
+++ b/lib/types/duration.js
@@ -30,172 +30,179 @@ const iso8601WeekRegex = /P(\d+)W/;
 const iso8601AlternateRegex =
   /P(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})/;
 
-/**
- * Creates a new instance of {@link Duration}.
- * @classdesc
- * Represents a duration. A duration stores separately months, days, and seconds due to the fact that the number of
- * days in a month varies, and a day can have 23 or 25 hours if a daylight saving is involved.
- * @param {Number} months The number of months.
- * @param {Number} days The number of days.
- * @param {Number|Long} nanoseconds The number of nanoseconds.
- * @constructor
- */
-function Duration(months, days, nanoseconds) {
-  if (nanoseconds instanceof Long)
-    this.internal = rust.DurationWrapper.new(
-      months,
-      days,
-      longToBigint(nanoseconds),
+class Duration {
+  /**
+   * Creates a new instance of {@link Duration}.
+   * @classdesc
+   * Represents a duration. A duration stores separately months, days, and seconds due to the fact that the number of
+   * days in a month varies, and a day can have 23 or 25 hours if a daylight saving is involved.
+   * @param {Number} months The number of months.
+   * @param {Number} days The number of days.
+   * @param {Number|Long} nanoseconds The number of nanoseconds.
+   * @constructor
+   */
+  constructor(months, days, nanoseconds) {
+    if (nanoseconds instanceof Long)
+      this.internal = rust.DurationWrapper.new(
+        months,
+        days,
+        longToBigint(nanoseconds),
+      );
+    else if (typeof nanoseconds === "number")
+      this.internal = rust.DurationWrapper.new(
+        months,
+        days,
+        BigInt(nanoseconds),
+      );
+    else
+      throw new TypeError(
+        `Invalid nanosecond argument type: ${typeof nanoseconds}`,
+      );
+  }
+
+  equals(other) {
+    if (!(other instanceof Duration)) {
+      return false;
+    }
+    return (
+      this.internal.months === other.internal.months &&
+      this.internal.days === other.internal.days &&
+      this.internal.getNanoseconds() === other.internal.getNanoseconds()
     );
-  else if (typeof nanoseconds === "number")
-    this.internal = rust.DurationWrapper.new(months, days, BigInt(nanoseconds));
-  else
-    throw new TypeError(
-      `Invalid nanosecond argument type: ${typeof nanoseconds}`,
+  }
+
+  /**
+   * Serializes the duration and returns the representation of the value in bytes.
+   * @returns {Buffer}
+   */
+  toBuffer() {
+    let nanoseconds = bigintToLong(this.internal.getNanoseconds());
+    const lengthMonths = VIntCoding.writeVInt(
+      Long.fromNumber(this.internal.months),
+      reusableBuffers.months,
     );
+    const lengthDays = VIntCoding.writeVInt(
+      Long.fromNumber(this.internal.days),
+      reusableBuffers.days,
+    );
+    const lengthNanoseconds = VIntCoding.writeVInt(
+      nanoseconds,
+      reusableBuffers.nanoseconds,
+    );
+    const buffer = utils.allocBufferUnsafe(
+      lengthMonths + lengthDays + lengthNanoseconds,
+    );
+    reusableBuffers.months.copy(buffer, 0, 0, lengthMonths);
+    let offset = lengthMonths;
+    reusableBuffers.days.copy(buffer, offset, 0, lengthDays);
+    offset += lengthDays;
+    reusableBuffers.nanoseconds.copy(buffer, offset, 0, lengthNanoseconds);
+    return buffer;
+  }
+
+  /**
+   * Returns the string representation of the value.
+   * @return {string}
+   */
+  toString() {
+    let nanoseconds = bigintToLong(this.internal.getNanoseconds());
+    let value = "";
+    function append(dividend, divisor, unit) {
+      if (dividend === 0 || dividend < divisor) {
+        return dividend;
+      }
+      // string concatenation is supposed to be fasted than join()
+      value += (dividend / divisor).toFixed(0) + unit;
+      return dividend % divisor;
+    }
+    function append64(dividend, divisor, unit) {
+      if (dividend.equals(Long.ZERO) || dividend.lessThan(divisor)) {
+        return dividend;
+      }
+      // string concatenation is supposed to be fasted than join()
+      value += dividend.divide(divisor).toString() + unit;
+      return dividend.modulo(divisor);
+    }
+    if (
+      this.internal.months < 0 ||
+      this.internal.days < 0 ||
+      nanoseconds.isNegative()
+    ) {
+      value = "-";
+    }
+    let remainder = append(Math.abs(this.internal.months), monthsPerYear, "y");
+    append(remainder, 1, "mo");
+    append(Math.abs(this.internal.days), 1, "d");
+
+    if (!nanoseconds.equals(Long.ZERO)) {
+      const nanos = nanoseconds.isNegative()
+        ? nanoseconds.negate()
+        : nanoseconds;
+      remainder = append64(nanos, nanosPerHour, "h");
+      remainder = append64(remainder, nanosPerMinute, "m");
+      remainder = append64(remainder, nanosPerSecond, "s");
+      remainder = append64(remainder, nanosPerMilli, "ms");
+      remainder = append64(remainder, nanosPerMicro, "us");
+      append64(remainder, Long.ONE, "ns");
+    }
+    return value;
+  }
+
+  /**
+   * Creates a new {@link Duration} instance from the binary representation of the value.
+   * @param {Buffer} buffer
+   * @returns {Duration}
+   */
+  static fromBuffer(buffer) {
+    const offset = { value: 0 };
+    const months = VIntCoding.readVInt(buffer, offset).toNumber();
+    const days = VIntCoding.readVInt(buffer, offset).toNumber();
+    const nanoseconds = VIntCoding.readVInt(buffer, offset);
+    return new Duration(months, days, nanoseconds);
+  }
+
+  /**
+   * Creates a new {@link Duration} instance from the string representation of the value.
+   * <p>
+   *   Accepted formats:
+   * </p>
+   * <ul>
+   * <li>multiple digits followed by a time unit like: 12h30m where the time unit can be:
+   *   <ul>
+   *     <li>{@code y}: years</li>
+   *     <li>{@code m}: months</li>
+   *     <li>{@code w}: weeks</li>
+   *     <li>{@code d}: days</li>
+   *     <li>{@code h}: hours</li>
+   *     <li>{@code m}: minutes</li>
+   *     <li>{@code s}: seconds</li>
+   *     <li>{@code ms}: milliseconds</li>
+   *     <li>{@code us} or {@code µs}: microseconds</li>
+   *     <li>{@code ns}: nanoseconds</li>
+   *   </ul>
+   * </li>
+   * <li>ISO 8601 format:  <code>P[n]Y[n]M[n]DT[n]H[n]M[n]S or P[n]W</code></li>
+   * <li>ISO 8601 alternative format: <code>P[YYYY]-[MM]-[DD]T[hh]:[mm]:[ss]</code></li>
+   * </ul>
+   * @param {String} input
+   * @returns {Duration}
+   */
+  static fromString(input) {
+    // This does a lot of stuff. Is it nesesery to implement it in rust, or should we just keep it as is?
+    const isNegative = input.charAt(0) === "-";
+    const source = isNegative ? input.substr(1) : input;
+    if (source.charAt(0) === "P") {
+      if (source.charAt(source.length - 1) === "W") {
+        return parseIso8601WeekFormat(isNegative, source);
+      }
+      if (source.indexOf("-") > 0) {
+        return parseIso8601AlternativeFormat(isNegative, source);
+      }
+      return parseIso8601Format(isNegative, source);
+    }
+    return parseStandardFormat(isNegative, source);
+  }
 }
-
-Duration.prototype.equals = function (other) {
-  if (!(other instanceof Duration)) {
-    return false;
-  }
-  return (
-    this.internal.months === other.internal.months &&
-    this.internal.days === other.internal.days &&
-    this.internal.getNanoseconds() === other.internal.getNanoseconds()
-  );
-};
-
-/**
- * Serializes the duration and returns the representation of the value in bytes.
- * @returns {Buffer}
- */
-Duration.prototype.toBuffer = function () {
-  let nanoseconds = bigintToLong(this.internal.getNanoseconds());
-  const lengthMonths = VIntCoding.writeVInt(
-    Long.fromNumber(this.internal.months),
-    reusableBuffers.months,
-  );
-  const lengthDays = VIntCoding.writeVInt(
-    Long.fromNumber(this.internal.days),
-    reusableBuffers.days,
-  );
-  const lengthNanoseconds = VIntCoding.writeVInt(
-    nanoseconds,
-    reusableBuffers.nanoseconds,
-  );
-  const buffer = utils.allocBufferUnsafe(
-    lengthMonths + lengthDays + lengthNanoseconds,
-  );
-  reusableBuffers.months.copy(buffer, 0, 0, lengthMonths);
-  let offset = lengthMonths;
-  reusableBuffers.days.copy(buffer, offset, 0, lengthDays);
-  offset += lengthDays;
-  reusableBuffers.nanoseconds.copy(buffer, offset, 0, lengthNanoseconds);
-  return buffer;
-};
-
-/**
- * Returns the string representation of the value.
- * @return {string}
- */
-Duration.prototype.toString = function () {
-  let nanoseconds = bigintToLong(this.internal.getNanoseconds());
-  let value = "";
-  function append(dividend, divisor, unit) {
-    if (dividend === 0 || dividend < divisor) {
-      return dividend;
-    }
-    // string concatenation is supposed to be fasted than join()
-    value += (dividend / divisor).toFixed(0) + unit;
-    return dividend % divisor;
-  }
-  function append64(dividend, divisor, unit) {
-    if (dividend.equals(Long.ZERO) || dividend.lessThan(divisor)) {
-      return dividend;
-    }
-    // string concatenation is supposed to be fasted than join()
-    value += dividend.divide(divisor).toString() + unit;
-    return dividend.modulo(divisor);
-  }
-  if (
-    this.internal.months < 0 ||
-    this.internal.days < 0 ||
-    nanoseconds.isNegative()
-  ) {
-    value = "-";
-  }
-  let remainder = append(Math.abs(this.internal.months), monthsPerYear, "y");
-  append(remainder, 1, "mo");
-  append(Math.abs(this.internal.days), 1, "d");
-
-  if (!nanoseconds.equals(Long.ZERO)) {
-    const nanos = nanoseconds.isNegative() ? nanoseconds.negate() : nanoseconds;
-    remainder = append64(nanos, nanosPerHour, "h");
-    remainder = append64(remainder, nanosPerMinute, "m");
-    remainder = append64(remainder, nanosPerSecond, "s");
-    remainder = append64(remainder, nanosPerMilli, "ms");
-    remainder = append64(remainder, nanosPerMicro, "us");
-    append64(remainder, Long.ONE, "ns");
-  }
-  return value;
-};
-
-/**
- * Creates a new {@link Duration} instance from the binary representation of the value.
- * @param {Buffer} buffer
- * @returns {Duration}
- */
-Duration.fromBuffer = function (buffer) {
-  const offset = { value: 0 };
-  const months = VIntCoding.readVInt(buffer, offset).toNumber();
-  const days = VIntCoding.readVInt(buffer, offset).toNumber();
-  const nanoseconds = VIntCoding.readVInt(buffer, offset);
-  return new Duration(months, days, nanoseconds);
-};
-
-/**
- * Creates a new {@link Duration} instance from the string representation of the value.
- * <p>
- *   Accepted formats:
- * </p>
- * <ul>
- * <li>multiple digits followed by a time unit like: 12h30m where the time unit can be:
- *   <ul>
- *     <li>{@code y}: years</li>
- *     <li>{@code m}: months</li>
- *     <li>{@code w}: weeks</li>
- *     <li>{@code d}: days</li>
- *     <li>{@code h}: hours</li>
- *     <li>{@code m}: minutes</li>
- *     <li>{@code s}: seconds</li>
- *     <li>{@code ms}: milliseconds</li>
- *     <li>{@code us} or {@code µs}: microseconds</li>
- *     <li>{@code ns}: nanoseconds</li>
- *   </ul>
- * </li>
- * <li>ISO 8601 format:  <code>P[n]Y[n]M[n]DT[n]H[n]M[n]S or P[n]W</code></li>
- * <li>ISO 8601 alternative format: <code>P[YYYY]-[MM]-[DD]T[hh]:[mm]:[ss]</code></li>
- * </ul>
- * @param {String} input
- * @returns {Duration}
- */
-Duration.fromString = function (input) {
-  // This does a lot of stuff. Is it nesesery to implement it in rust, or should we just keep it as is?
-  const isNegative = input.charAt(0) === "-";
-  const source = isNegative ? input.substr(1) : input;
-  if (source.charAt(0) === "P") {
-    if (source.charAt(source.length - 1) === "W") {
-      return parseIso8601WeekFormat(isNegative, source);
-    }
-    if (source.indexOf("-") > 0) {
-      return parseIso8601AlternativeFormat(isNegative, source);
-    }
-    return parseIso8601Format(isNegative, source);
-  }
-  return parseStandardFormat(isNegative, source);
-};
-
 /**
  * @param {Boolean} isNegative
  * @param {String} source

--- a/lib/types/duration.js
+++ b/lib/types/duration.js
@@ -47,7 +47,7 @@ function Duration(months, days, nanoseconds) {
       days,
       longToBigint(nanoseconds),
     );
-  else if (isNumber(nanoseconds))
+  else if (typeof nanoseconds === "number")
     this.internal = rust.DurationWrapper.new(months, days, BigInt(nanoseconds));
   else
     throw new TypeError(

--- a/lib/types/duration.js
+++ b/lib/types/duration.js
@@ -1,16 +1,9 @@
 "use strict";
 const Long = require("long");
 const util = require("util");
-const utils = require("../utils");
+const rust = require("../../index");
 
 /** @module types */
-
-// Reuse the same buffers that should perform slightly better than built-in buffer pool
-const reusableBuffers = {
-  months: utils.allocBuffer(9),
-  days: utils.allocBuffer(9),
-  nanoseconds: utils.allocBuffer(9),
-};
 
 const maxInt32 = 0x7fffffff;
 const longOneThousand = Long.fromInt(1000);
@@ -39,35 +32,15 @@ const iso8601AlternateRegex =
  * @constructor
  */
 function Duration(months, days, nanoseconds) {
-  /**
-   * Gets the number of months.
-   * @type {Number}
-   */
-  this.months = months;
-  /**
-   * Gets the number of days.
-   * @type {Number}
-   */
-  this.days = days;
-  /**
-   * Gets the number of nanoseconds represented as a <code>int64</code>.
-   * @type {Long}
-   */
-  this.nanoseconds =
-    typeof nanoseconds === "number"
-      ? Long.fromNumber(nanoseconds)
-      : nanoseconds;
+  // ToDo: Check types
+  this.internal = rust.Duration.new(months, days, nanoseconds);
 }
 
 Duration.prototype.equals = function (other) {
   if (!(other instanceof Duration)) {
     return false;
   }
-  return (
-    this.months === other.months &&
-    this.days === other.days &&
-    this.nanoseconds.equals(other.nanoseconds)
-  );
+  return this == other;
 };
 
 /**
@@ -75,27 +48,7 @@ Duration.prototype.equals = function (other) {
  * @returns {Buffer}
  */
 Duration.prototype.toBuffer = function () {
-  const lengthMonths = VIntCoding.writeVInt(
-    Long.fromNumber(this.months),
-    reusableBuffers.months,
-  );
-  const lengthDays = VIntCoding.writeVInt(
-    Long.fromNumber(this.days),
-    reusableBuffers.days,
-  );
-  const lengthNanoseconds = VIntCoding.writeVInt(
-    this.nanoseconds,
-    reusableBuffers.nanoseconds,
-  );
-  const buffer = utils.allocBufferUnsafe(
-    lengthMonths + lengthDays + lengthNanoseconds,
-  );
-  reusableBuffers.months.copy(buffer, 0, 0, lengthMonths);
-  let offset = lengthMonths;
-  reusableBuffers.days.copy(buffer, offset, 0, lengthDays);
-  offset += lengthDays;
-  reusableBuffers.nanoseconds.copy(buffer, offset, 0, lengthNanoseconds);
-  return buffer;
+  return this.internal.toBuffer();
 };
 
 /**
@@ -103,42 +56,7 @@ Duration.prototype.toBuffer = function () {
  * @return {string}
  */
 Duration.prototype.toString = function () {
-  let value = "";
-  function append(dividend, divisor, unit) {
-    if (dividend === 0 || dividend < divisor) {
-      return dividend;
-    }
-    // string concatenation is supposed to be fasted than join()
-    value += (dividend / divisor).toFixed(0) + unit;
-    return dividend % divisor;
-  }
-  function append64(dividend, divisor, unit) {
-    if (dividend.equals(Long.ZERO) || dividend.lessThan(divisor)) {
-      return dividend;
-    }
-    // string concatenation is supposed to be fasted than join()
-    value += dividend.divide(divisor).toString() + unit;
-    return dividend.modulo(divisor);
-  }
-  if (this.months < 0 || this.days < 0 || this.nanoseconds.isNegative()) {
-    value = "-";
-  }
-  let remainder = append(Math.abs(this.months), monthsPerYear, "y");
-  append(remainder, 1, "mo");
-  append(Math.abs(this.days), 1, "d");
-
-  if (!this.nanoseconds.equals(Long.ZERO)) {
-    const nanos = this.nanoseconds.isNegative()
-      ? this.nanoseconds.negate()
-      : this.nanoseconds;
-    remainder = append64(nanos, nanosPerHour, "h");
-    remainder = append64(remainder, nanosPerMinute, "m");
-    remainder = append64(remainder, nanosPerSecond, "s");
-    remainder = append64(remainder, nanosPerMilli, "ms");
-    remainder = append64(remainder, nanosPerMicro, "us");
-    append64(remainder, Long.ONE, "ns");
-  }
-  return value;
+  return this.toString();
 };
 
 /**
@@ -147,11 +65,8 @@ Duration.prototype.toString = function () {
  * @returns {Duration}
  */
 Duration.fromBuffer = function (buffer) {
-  const offset = { value: 0 };
-  const months = VIntCoding.readVInt(buffer, offset).toNumber();
-  const days = VIntCoding.readVInt(buffer, offset).toNumber();
-  const nanoseconds = VIntCoding.readVInt(buffer, offset);
-  return new Duration(months, days, nanoseconds);
+  // ToDo: Check types
+  return rust.Duration.fromBuffer(buffer);
 };
 
 /**
@@ -181,6 +96,7 @@ Duration.fromBuffer = function (buffer) {
  * @returns {Duration}
  */
 Duration.fromString = function (input) {
+  // This does a lot of stuff. Is it nesesery to implement it in rust, or should we just keep it as is?
   const isNegative = input.charAt(0) === "-";
   const source = isNegative ? input.substr(1) : input;
   if (source.charAt(0) === "P") {

--- a/lib/types/duration.js
+++ b/lib/types/duration.js
@@ -41,13 +41,13 @@ const iso8601AlternateRegex =
  */
 function Duration(months, days, nanoseconds) {
   if (nanoseconds instanceof Long)
-    this.internal = rust.Duration.new(
+    this.internal = rust.DurationWrapper.new(
       months,
       days,
       long_to_bigint(nanoseconds),
     );
   else if (isNumber(nanoseconds))
-    this.internal = rust.Duration.new(months, days, BigInt(nanoseconds));
+    this.internal = rust.DurationWrapper.new(months, days, BigInt(nanoseconds));
   else
     throw new TypeError(
       `Invalid nanosecond argument type: ${typeof nanoseconds}`,

--- a/lib/types/duration.js
+++ b/lib/types/duration.js
@@ -1,9 +1,16 @@
 "use strict";
 const Long = require("long");
 const util = require("util");
+const utils = require("../utils");
 const rust = require("../../index");
 
 /** @module types */
+
+const reusableBuffers = {
+  months: utils.allocBuffer(9),
+  days: utils.allocBuffer(9),
+  nanoseconds: utils.allocBuffer(9),
+};
 
 const maxInt32 = 0x7fffffff;
 const longOneThousand = Long.fromInt(1000);
@@ -33,14 +40,27 @@ const iso8601AlternateRegex =
  */
 function Duration(months, days, nanoseconds) {
   // ToDo: Check types
-  this.internal = rust.Duration.new(months, days, nanoseconds);
+  let ns1 = nanoseconds.modulo(maxInt32);
+  let ns2 = nanoseconds.div(maxInt32);
+  this.internal = rust.Duration.new(
+    Math.trunc(months),
+    Math.trunc(days),
+    Math.trunc(ns1),
+    Math.trunc(ns2),
+    Math.trunc(maxInt32),
+  );
 }
 
 Duration.prototype.equals = function (other) {
   if (!(other instanceof Duration)) {
     return false;
   }
-  return this == other;
+  let me = this.internal.getObject();
+  let other_me = other.internal.getObject();
+  for (let i = 0; i < me.length; i++) {
+    if (me[i] != other_me[i]) return false;
+  }
+  return true;
 };
 
 /**
@@ -48,7 +68,29 @@ Duration.prototype.equals = function (other) {
  * @returns {Buffer}
  */
 Duration.prototype.toBuffer = function () {
-  return this.internal.toBuffer();
+  let data = this.internal.getObject();
+  let nanoseconds = Long.fromNumber(data[2]).multiply(data[4]).add(data[3]);
+  const lengthMonths = VIntCoding.writeVInt(
+    Long.fromNumber(data[0]),
+    reusableBuffers.months,
+  );
+  const lengthDays = VIntCoding.writeVInt(
+    Long.fromNumber(data[1]),
+    reusableBuffers.days,
+  );
+  const lengthNanoseconds = VIntCoding.writeVInt(
+    nanoseconds,
+    reusableBuffers.nanoseconds,
+  );
+  const buffer = utils.allocBufferUnsafe(
+    lengthMonths + lengthDays + lengthNanoseconds,
+  );
+  reusableBuffers.months.copy(buffer, 0, 0, lengthMonths);
+  let offset = lengthMonths;
+  reusableBuffers.days.copy(buffer, offset, 0, lengthDays);
+  offset += lengthDays;
+  reusableBuffers.nanoseconds.copy(buffer, offset, 0, lengthNanoseconds);
+  return buffer;
 };
 
 /**
@@ -56,7 +98,43 @@ Duration.prototype.toBuffer = function () {
  * @return {string}
  */
 Duration.prototype.toString = function () {
-  return this.toString();
+  let data = this.internal.getObject();
+  let value = "";
+  console.log(data);
+  let nanoseconds = Long.fromNumber(data[2]).multiply(data[4]).add(data[3]);
+  function append(dividend, divisor, unit) {
+    if (dividend === 0 || dividend < divisor) {
+      return dividend;
+    }
+    // string concatenation is supposed to be fasted than join()
+    value += (dividend / divisor).toFixed(0) + unit;
+    return dividend % divisor;
+  }
+  function append64(dividend, divisor, unit) {
+    if (dividend.equals(Long.ZERO) || dividend.lessThan(divisor)) {
+      return dividend;
+    }
+    // string concatenation is supposed to be fasted than join()
+    value += dividend.divide(divisor).toString() + unit;
+    return dividend.modulo(divisor);
+  }
+  if (data[0] < 0 || data[1] < 0 || nanoseconds.isNegative()) {
+    value = "-";
+  }
+  let remainder = append(Math.abs(data[0]), monthsPerYear, "y");
+  append(remainder, 1, "mo");
+  append(Math.abs(data[1]), 1, "d");
+
+  if (!nanoseconds.equals(Long.ZERO)) {
+    const nanos = nanoseconds.isNegative() ? nanoseconds.negate() : nanoseconds;
+    remainder = append64(nanos, nanosPerHour, "h");
+    remainder = append64(remainder, nanosPerMinute, "m");
+    remainder = append64(remainder, nanosPerSecond, "s");
+    remainder = append64(remainder, nanosPerMilli, "ms");
+    remainder = append64(remainder, nanosPerMicro, "us");
+    append64(remainder, Long.ONE, "ns");
+  }
+  return value;
 };
 
 /**
@@ -65,8 +143,12 @@ Duration.prototype.toString = function () {
  * @returns {Duration}
  */
 Duration.fromBuffer = function (buffer) {
-  // ToDo: Check types
-  return rust.Duration.fromBuffer(buffer);
+  if ((!buffer) instanceof Buffer) throw new TypeError("Expected Buffer type");
+  const offset = { value: 0 };
+  const months = VIntCoding.readVInt(buffer, offset).toNumber();
+  const days = VIntCoding.readVInt(buffer, offset).toNumber();
+  const nanoseconds = VIntCoding.readVInt(buffer, offset);
+  return new Duration(months, days, nanoseconds);
 };
 
 /**

--- a/lib/types/duration.js
+++ b/lib/types/duration.js
@@ -3,6 +3,7 @@ const Long = require("long");
 const util = require("util");
 const utils = require("../utils");
 const rust = require("../../index");
+const { bigint_to_long, long_to_bigint } = require("../new-utils");
 
 /** @module types */
 
@@ -39,28 +40,29 @@ const iso8601AlternateRegex =
  * @constructor
  */
 function Duration(months, days, nanoseconds) {
-  // ToDo: Check types
-  let ns1 = nanoseconds.modulo(maxInt32);
-  let ns2 = nanoseconds.div(maxInt32);
-  this.internal = rust.Duration.new(
-    Math.trunc(months),
-    Math.trunc(days),
-    Math.trunc(ns1),
-    Math.trunc(ns2),
-    Math.trunc(maxInt32),
-  );
+  if (nanoseconds instanceof Long)
+    this.internal = rust.Duration.new(
+      months,
+      days,
+      long_to_bigint(nanoseconds),
+    );
+  else if (isNumber(nanoseconds))
+    this.internal = rust.Duration.new(months, days, BigInt(nanoseconds));
+  else
+    throw new TypeError(
+      `Invalid nanosecond argument type: ${typeof nanoseconds}`,
+    );
 }
 
 Duration.prototype.equals = function (other) {
   if (!(other instanceof Duration)) {
     return false;
   }
-  let me = this.internal.getObject();
-  let other_me = other.internal.getObject();
-  for (let i = 0; i < me.length; i++) {
-    if (me[i] != other_me[i]) return false;
-  }
-  return true;
+  return (
+    this.internal.months === other.internal.months &&
+    this.internal.days === other.internal.days &&
+    this.internal.getNanoseconds() === other.internal.getNanoseconds()
+  );
 };
 
 /**
@@ -68,14 +70,13 @@ Duration.prototype.equals = function (other) {
  * @returns {Buffer}
  */
 Duration.prototype.toBuffer = function () {
-  let data = this.internal.getObject();
-  let nanoseconds = Long.fromNumber(data[2]).multiply(data[4]).add(data[3]);
+  let nanoseconds = bigint_to_long(this.internal.getNanoseconds());
   const lengthMonths = VIntCoding.writeVInt(
-    Long.fromNumber(data[0]),
+    Long.fromNumber(this.internal.months),
     reusableBuffers.months,
   );
   const lengthDays = VIntCoding.writeVInt(
-    Long.fromNumber(data[1]),
+    Long.fromNumber(this.internal.days),
     reusableBuffers.days,
   );
   const lengthNanoseconds = VIntCoding.writeVInt(
@@ -98,10 +99,8 @@ Duration.prototype.toBuffer = function () {
  * @return {string}
  */
 Duration.prototype.toString = function () {
-  let data = this.internal.getObject();
+  let nanoseconds = bigint_to_long(this.internal.getNanoseconds());
   let value = "";
-  console.log(data);
-  let nanoseconds = Long.fromNumber(data[2]).multiply(data[4]).add(data[3]);
   function append(dividend, divisor, unit) {
     if (dividend === 0 || dividend < divisor) {
       return dividend;
@@ -118,12 +117,16 @@ Duration.prototype.toString = function () {
     value += dividend.divide(divisor).toString() + unit;
     return dividend.modulo(divisor);
   }
-  if (data[0] < 0 || data[1] < 0 || nanoseconds.isNegative()) {
+  if (
+    this.internal.months < 0 ||
+    this.internal.days < 0 ||
+    nanoseconds.isNegative()
+  ) {
     value = "-";
   }
-  let remainder = append(Math.abs(data[0]), monthsPerYear, "y");
+  let remainder = append(Math.abs(this.internal.months), monthsPerYear, "y");
   append(remainder, 1, "mo");
-  append(Math.abs(data[1]), 1, "d");
+  append(Math.abs(this.internal.days), 1, "d");
 
   if (!nanoseconds.equals(Long.ZERO)) {
     const nanos = nanoseconds.isNegative() ? nanoseconds.negate() : nanoseconds;

--- a/lib/types/result-set.js
+++ b/lib/types/result-set.js
@@ -147,6 +147,8 @@ function getCqlObject(field) {
       return field.getCounter();
     case rust.CqlTypes.Double:
       return field.getDouble();
+    case rust.CqlTypes.Duration:
+      return field.getDuration();
     case rust.CqlTypes.Float:
       return field.getFloat();
     case rust.CqlTypes.Int:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,3 @@
-
 use scylla::SessionBuilder;
 
 #[macro_use]
@@ -9,7 +8,7 @@ extern crate napi_derive;
 #[napi]
 pub async fn test_connection(uri: String) -> String {
   println!("Connecting to {} ...", uri);
-  
+
   match SessionBuilder::new().known_node(uri).build().await {
     Ok(data) => data,
     Err(_) => {
@@ -21,6 +20,6 @@ pub async fn test_connection(uri: String) -> String {
 
 // Link other file
 pub mod auth;
-pub mod types;
 pub mod result;
 pub mod session;
+pub mod types;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+
 use scylla::SessionBuilder;
 
 #[macro_use]
@@ -8,7 +9,7 @@ extern crate napi_derive;
 #[napi]
 pub async fn test_connection(uri: String) -> String {
   println!("Connecting to {} ...", uri);
-
+  
   match SessionBuilder::new().known_node(uri).build().await {
     Ok(data) => data,
     Err(_) => {
@@ -20,5 +21,6 @@ pub async fn test_connection(uri: String) -> String {
 
 // Link other file
 pub mod auth;
+pub mod types;
 pub mod result;
 pub mod session;

--- a/src/result.rs
+++ b/src/result.rs
@@ -1,6 +1,8 @@
 use napi::{bindgen_prelude::Buffer, Error, Status};
 use scylla::{frame::response::result::CqlValue, QueryResult};
 
+use crate::types::duration::DurationWrapper;
+
 #[napi]
 pub struct QueryResultWrapper {
   internal: QueryResult,
@@ -139,12 +141,22 @@ impl CqlValueWrapper {
     }
   }
 
+  fn generic_error(expected_type: &str) -> Error<Status> {
+    Error::new(
+      Status::GenericFailure,
+      format!(
+        "Could not get value of type {} from CqlValueWrapper",
+        expected_type
+      ),
+    )
+  }
+
   #[napi]
   pub fn get_ascii(&self) -> napi::Result<String> {
     // We want to fore napi to use big num
     match self.internal.as_ascii() {
       Some(r) => Ok(r.clone()),
-      None => Err(Error::new(Status::GenericFailure, "Error")),
+      None => Err(Self::generic_error("ascii")),
     }
   }
 
@@ -152,7 +164,7 @@ impl CqlValueWrapper {
   pub fn get_boolean(&self) -> napi::Result<bool> {
     match self.internal.as_boolean() {
       Some(r) => Ok(r),
-      None => Err(Error::new(Status::GenericFailure, "Error")),
+      None => Err(Self::generic_error("boolean")),
     }
   }
 
@@ -160,7 +172,7 @@ impl CqlValueWrapper {
   pub fn get_blob(&self) -> napi::Result<Buffer> {
     match self.internal.as_blob() {
       Some(r) => Ok(r.clone().into()),
-      None => Err(Error::new(Status::GenericFailure, "Error")),
+      None => Err(Self::generic_error("blob")),
     }
   }
 
@@ -169,7 +181,7 @@ impl CqlValueWrapper {
     // Is this correct?
     match self.internal.as_counter() {
       Some(r) => Ok(r.0.into()),
-      None => Err(Error::new(Status::GenericFailure, "Error")),
+      None => Err(Self::generic_error("counter")),
     }
   }
 
@@ -177,7 +189,15 @@ impl CqlValueWrapper {
   pub fn get_double(&self) -> napi::Result<f64> {
     match self.internal.as_double() {
       Some(r) => Ok(r),
-      None => Err(Error::new(Status::GenericFailure, "Error")),
+      None => Err(Self::generic_error("double")),
+    }
+  }
+
+  #[napi]
+  pub fn get_duration(&self) -> napi::Result<DurationWrapper> {
+    match self.internal.as_cql_duration() {
+      Some(r) => Ok(DurationWrapper::from_cql_duration(r)),
+      None => Err(Self::generic_error("ascii")),
     }
   }
 
@@ -185,7 +205,7 @@ impl CqlValueWrapper {
   pub fn get_float(&self) -> napi::Result<f32> {
     match self.internal.as_float() {
       Some(r) => Ok(r),
-      None => Err(Error::new(Status::GenericFailure, "Error")),
+      None => Err(Self::generic_error("float")),
     }
   }
 
@@ -193,7 +213,7 @@ impl CqlValueWrapper {
   pub fn get_int(&self) -> napi::Result<i32> {
     match self.internal.as_int() {
       Some(r) => Ok(r),
-      None => Err(Error::new(Status::GenericFailure, "Error")),
+      None => Err(Self::generic_error("int")),
     }
   }
 
@@ -201,7 +221,7 @@ impl CqlValueWrapper {
   pub fn get_text(&self) -> napi::Result<String> {
     match self.internal.as_text() {
       Some(r) => Ok(r.clone()),
-      None => Err(Error::new(Status::GenericFailure, "Error")),
+      None => Err(Self::generic_error("text")),
     }
   }
 
@@ -215,14 +235,14 @@ impl CqlValueWrapper {
           })
           .collect(),
       ),
-      None => Err(Error::new(Status::GenericFailure, "Error")),
+      None => Err(Self::generic_error("set")),
     }
   }
   #[napi]
   pub fn get_small_int(&self) -> napi::Result<i16> {
     match self.internal.as_smallint() {
       Some(r) => Ok(r),
-      None => Err(Error::new(Status::GenericFailure, "Error")),
+      None => Err(Self::generic_error("small_int")),
     }
   }
 
@@ -230,7 +250,7 @@ impl CqlValueWrapper {
   pub fn get_tiny_int(&self) -> napi::Result<i8> {
     match self.internal.as_tinyint() {
       Some(r) => Ok(r),
-      None => Err(Error::new(Status::GenericFailure, "Error")),
+      None => Err(Self::generic_error("tiny_int")),
     }
   }
 }

--- a/src/types/duration.rs
+++ b/src/types/duration.rs
@@ -16,7 +16,7 @@ impl DurationWrapper {
     if !is_lossless {
       return Err(Error::new(
         Status::GenericFailure,
-        "Nanoseconds cannot overflow i64",
+        "Nanoseconds must not overflow i64",
       ));
     }
     let nanoseconds: i64 = ns_value

--- a/src/types/duration.rs
+++ b/src/types/duration.rs
@@ -10,18 +10,11 @@ pub struct Duration {
   internal: CqlDuration,
 }
 
-const LONG_ONE_THOUSAND: i64 = 1000;
-const NANOS_PER_MICRO: i64 = LONG_ONE_THOUSAND;
-const NANOS_PER_MILLI: i64 = LONG_ONE_THOUSAND * NANOS_PER_MICRO;
-const NANOS_PER_SECOND: i64 = LONG_ONE_THOUSAND * NANOS_PER_MILLI;
-const NANOS_PER_MINUTE: i64 = 60 * NANOS_PER_SECOND;
-const NANOS_PER_HOUR: i64 = 60 * NANOS_PER_MINUTE;
-const MONTHS_PER_YEAR: i32 = 12;
-
 #[napi]
 impl Duration {
   #[napi]
-  pub fn new(months: i32, days: i32, nanoseconds: i64) -> Self {
+  pub fn new(months: i32, days: i32, ns1: i64, ns2: i64, filler: i64) -> Self {
+    let nanoseconds = ns1 + ns2 * filler;
     Duration {
       internal: CqlDuration {
         months,
@@ -32,70 +25,22 @@ impl Duration {
   }
 
   #[napi]
-  pub fn to_buffer(&self) -> Buffer {
-    let months = self.internal.months.to_ne_bytes();
-    let months = months.as_slice();
-
-    let days = self.internal.days.to_ne_bytes();
-    let days = days.as_slice();
-
-    let nanoseconds = self.internal.nanoseconds.to_ne_bytes();
-    let nanoseconds = nanoseconds.as_slice();
-    [months, days, nanoseconds].concat().into()
-  }
-
-  #[napi]
-  #[allow(clippy::inherent_to_string)]
-  pub fn to_string(&self) -> String {
-    let reminder = self.internal.nanoseconds.abs();
-
-    let hours = reminder / NANOS_PER_HOUR;
-    let reminder = reminder % NANOS_PER_HOUR;
-
-    let minutes = reminder / NANOS_PER_MINUTE;
-    let reminder = reminder % NANOS_PER_MINUTE;
-
-    let seconds = reminder / NANOS_PER_SECOND;
-    let reminder = reminder % NANOS_PER_SECOND;
-
-    let milliseconds = reminder / NANOS_PER_MILLI;
-    let reminder = reminder % NANOS_PER_MILLI;
-
-    let microseconds = reminder / NANOS_PER_MICRO;
-    let reminder = reminder % NANOS_PER_MICRO;
-    let negative_part = if min(
-      self.internal.nanoseconds,
-      min(self.internal.days, self.internal.months).into(),
-    ) < 0
-    {
-      "-"
-    } else {
-      ""
-    };
-
-    let days_part: String = format!(
-      "{}y{}mo{}d",
-      self.internal.months.abs() / MONTHS_PER_YEAR,
-      self.internal.months.abs() % MONTHS_PER_YEAR,
-      self.internal.days.abs(),
-    );
-
-    let ns_part: String = if self.internal.nanoseconds > 0 {
-      format!(
-        "{}h{}m{}s{}ms{}us{}ns",
-        hours, minutes, seconds, milliseconds, microseconds, reminder
-      )
-    } else {
-      "".into()
-    };
-
-    format!("{}{}{}", negative_part, days_part, ns_part)
+  pub fn get_object(&self) -> napi::Result<Vec<i64>> {
+    let re: i64 = i32::MAX.into();
+    // println!("ns in rust: {}", self.internal.nanoseconds);
+    Ok(vec![
+      self.internal.months.into(),
+      self.internal.days.into(),
+      (self.internal.nanoseconds / re),
+      (self.internal.nanoseconds % re),
+      re,
+    ])
   }
 
   #[napi]
   // Consider BufferRef
   pub fn from_buffer(buffer: Buffer) -> napi::Result<Duration> {
-    let tmp = Duration::new(0, 0, 0);
+    let tmp = Duration::new(2, 0, 0, 0, 0);
     let arg: Vec<u8> = buffer.into();
     tmp
       .internal

--- a/src/types/duration.rs
+++ b/src/types/duration.rs
@@ -1,0 +1,106 @@
+use std::cmp::min;
+
+use napi::{bindgen_prelude::Buffer, Status};
+use scylla::frame::value::{CqlDuration, Value};
+
+#[napi]
+// Will PartialEq or Eq be exposed to napi?
+#[derive(Clone, Debug, Copy, PartialEq, Eq)]
+pub struct Duration {
+  internal: CqlDuration,
+}
+
+const LONG_ONE_THOUSAND: i64 = 1000;
+const NANOS_PER_MICRO: i64 = LONG_ONE_THOUSAND;
+const NANOS_PER_MILLI: i64 = LONG_ONE_THOUSAND * NANOS_PER_MICRO;
+const NANOS_PER_SECOND: i64 = LONG_ONE_THOUSAND * NANOS_PER_MILLI;
+const NANOS_PER_MINUTE: i64 = 60 * NANOS_PER_SECOND;
+const NANOS_PER_HOUR: i64 = 60 * NANOS_PER_MINUTE;
+const MONTHS_PER_YEAR: i32 = 12;
+
+#[napi]
+impl Duration {
+  #[napi]
+  pub fn new(months: i32, days: i32, nanoseconds: i64) -> Self {
+    Duration {
+      internal: CqlDuration {
+        months,
+        days,
+        nanoseconds,
+      },
+    }
+  }
+
+  #[napi]
+  pub fn to_buffer(&self) -> Buffer {
+    let months = self.internal.months.to_ne_bytes();
+    let months = months.as_slice();
+
+    let days = self.internal.days.to_ne_bytes();
+    let days = days.as_slice();
+
+    let nanoseconds = self.internal.nanoseconds.to_ne_bytes();
+    let nanoseconds = nanoseconds.as_slice();
+    [months, days, nanoseconds].concat().into()
+  }
+
+  #[napi]
+  #[allow(clippy::inherent_to_string)]
+  pub fn to_string(&self) -> String {
+    let reminder = self.internal.nanoseconds.abs();
+
+    let hours = reminder / NANOS_PER_HOUR;
+    let reminder = reminder % NANOS_PER_HOUR;
+
+    let minutes = reminder / NANOS_PER_MINUTE;
+    let reminder = reminder % NANOS_PER_MINUTE;
+
+    let seconds = reminder / NANOS_PER_SECOND;
+    let reminder = reminder % NANOS_PER_SECOND;
+
+    let milliseconds = reminder / NANOS_PER_MILLI;
+    let reminder = reminder % NANOS_PER_MILLI;
+
+    let microseconds = reminder / NANOS_PER_MICRO;
+    let reminder = reminder % NANOS_PER_MICRO;
+    let negative_part = if min(
+      self.internal.nanoseconds,
+      min(self.internal.days, self.internal.months).into(),
+    ) < 0
+    {
+      "-"
+    } else {
+      ""
+    };
+
+    let days_part: String = format!(
+      "{}y{}mo{}d",
+      self.internal.months.abs() / MONTHS_PER_YEAR,
+      self.internal.months.abs() % MONTHS_PER_YEAR,
+      self.internal.days.abs(),
+    );
+
+    let ns_part: String = if self.internal.nanoseconds > 0 {
+      format!(
+        "{}h{}m{}s{}ms{}us{}ns",
+        hours, minutes, seconds, milliseconds, microseconds, reminder
+      )
+    } else {
+      "".into()
+    };
+
+    format!("{}{}{}", negative_part, days_part, ns_part)
+  }
+
+  #[napi]
+  // Consider BufferRef
+  pub fn from_buffer(buffer: Buffer) -> napi::Result<Duration> {
+    let tmp = Duration::new(0, 0, 0);
+    let arg: Vec<u8> = buffer.into();
+    tmp
+      .internal
+      .serialize(&mut arg.clone())
+      .map_err(|e| napi::Error::new(Status::GenericFailure, format!("{}", e)))?;
+    Ok(tmp)
+  }
+}

--- a/src/types/duration.rs
+++ b/src/types/duration.rs
@@ -12,7 +12,7 @@ pub struct DurationWrapper {
 impl DurationWrapper {
   #[napi]
   pub fn new(months: i32, days: i32, ns_bigint: BigInt) -> napi::Result<Self> {
-    let (ns_value,is_lossless) = ns_bigint.get_i64();
+    let (ns_value, is_lossless) = ns_bigint.get_i64();
     if !is_lossless {
       return Err(Error::new(
         Status::GenericFailure,

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -1,0 +1,1 @@
+pub mod duration;

--- a/test/unit/duration-type-tests.js
+++ b/test/unit/duration-type-tests.js
@@ -124,6 +124,31 @@ describe("Duration", function () {
       });
     });
   });
+  describe(" constructor type validation", function () {
+    it("should create duration type correctly", function () {
+      let keys = [0, Long.ZERO, 123];
+      keys.forEach(function (item) {
+        new Duration(0, 0, item);
+      });
+      new Duration(0, 0, 0);
+    });
+  });
+  describe(" constructor type validation (invalid types)", function () {
+    it("should throw error when creating from invalid types", function () {
+      let ns_keys = ["0", 0xfffffffffffffffff, BigInt(0), { _: 1 }, [0]];
+      ns_keys.forEach(function (item) {
+        assert.throws(() => {
+          new Duration(0, 0, item);
+        }, Error);
+      });
+      let days_keys = ["0", Long.ZERO, BigInt(0), { _: 1 }, [0]];
+      days_keys.forEach(function (item) {
+        assert.throws(() => {
+          new Duration(0, item, 0);
+        }, Error);
+      });
+    });
+  });
 });
 
 /**

--- a/test/unit/duration-type-tests.js
+++ b/test/unit/duration-type-tests.js
@@ -43,6 +43,10 @@ const values = [
     new Duration(0, 0, Long.fromString("9223372036854775807")),
     "0000fffffffffffffffffe",
   ],
+  [
+    new Duration(0, 0, Long.fromString("-9223372036854775")),
+    "0000fe4189374bc6a7ed",
+  ],
 ];
 
 describe("Duration", function () {


### PR DESCRIPTION
This is an implementation of one of the datatype used by the database. The current approch keeps the internal data of the type in object created in rust, while all the processing of this object is done in JS part (it usses mostly unchanged datastax code).  Appart from diffrent behaviour in case of providing unexpected type in the constructor, everything should work the same way as in old implementation. If not, treat it as a bug.

This is a example implementation. The goal is to have some kind of example how to implement datastax custom types.
Current approach keeps the data in the rust object, but leaves all the processing that is done in the js part unchanged.
As this type is analog to ``CqlDuration`` used by the rust driver, there should be a way to create ``Duration`` object from ``CqlDuration``, which is implemented. 

Both comments about this specific implementation, and general approach are welcomed.

Tests expected to pass:
[There is new, temporary workflow with just the tests expected to pass]
``test/unit/duration-type-tests.js``