### PR TITLE
Refactor examples & CI

### DIFF
--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -54,7 +54,7 @@ jobs:
         shell: bash
       - name: Install examples dependencies
         run: |
-          cd examples/DataStax
+          cd examples
           npm i
       - name: Run all examples
         run: SCYLLA_URI=172.42.0.2:9042 npm run examples

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -1,4 +1,5 @@
-name: Tests
+# The goal of this workflow is to check if examples run without any errors
+name: Run examples
 env:
   DEBUG: napi:*
   APP_NAME: scylladb-javascript-driver
@@ -7,7 +8,7 @@ env:
     branches:
       - "**"
 jobs:
-  build-and-run-tests:
+  build-and-run-examples:
     strategy:
       fail-fast: false
       matrix:
@@ -15,26 +16,23 @@ jobs:
           - host: ubuntu-latest
             target: x86_64-unknown-linux-gnu
             build: npm run build -- --target x86_64-unknown-linux-gnu
-    name: Build and run tests - ${{ matrix.settings.target }} - node@20
+        node: [ 16, 18, 20 ]
+    name: Build and run examples - ${{ matrix.settings.target }} - node@${{ matrix.node }}
     runs-on: ${{ matrix.settings.host }}
-    outputs:
-      OPENSSL_DIR: ${{ steps.install_openssl.outputs.OPENSSL_DIR }}
-      OPENSSL_STATIC: ${{ steps.install_openssl.outputs.OPENSSL_STATIC }}
     steps:
       - uses: actions/checkout@v4
+      # Scylla docker setup copied from https://github.com/scylladb/scylla-rust-driver/blob/main/.github/workflows/rust.yml
       - name: Setup 3-node Scylla cluster
         run: |
           sudo sh -c "echo 2097152 >> /proc/sys/fs/aio-max-nr"
           docker compose -f .github/docker-compose.yml up -d --wait
       - name: Setup node
         uses: actions/setup-node@v4
-        if: ${{ !matrix.settings.docker }}
         with:
-          node-version: 20
+          node-version: ${{ matrix.node }}
           cache: npm
       - name: Install
         uses: dtolnay/rust-toolchain@stable
-        if: ${{ !matrix.settings.docker }}
         with:
           toolchain: stable
           targets: ${{ matrix.settings.target }}
@@ -54,13 +52,12 @@ jobs:
       - name: Build
         run: ${{ matrix.settings.build }}
         shell: bash
-      - name: Run examples
+      - name: Install examples dependencies
         run: |
           cd examples/DataStax
           npm i
-          SCYLLA_URI=172.42.0.2:9042 node runner.js
-      - name: Run tests
-        run: npm test
+      - name: Run all examples
+        run: SCYLLA_URI=172.42.0.2:9042 npm run examples
       - name: Stop the cluster
         if: ${{ always() }}
         run: docker compose -f .github/docker-compose.yml stop

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,0 +1,46 @@
+# The goal of this workflow is to check if unit test run correctly
+# This includes both datastax unit tests and tests specific for this driver
+name: Unit tests
+env:
+  DEBUG: napi:*
+"on":
+  push:
+    branches:
+      - "**"
+jobs:
+  build-and-run-tests:
+    strategy:
+      fail-fast: false
+    name: Build and run unit tests - node@20
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - name: Install
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: stable
+          targets: x86_64-unknown-linux-gnu
+      - name: Cache cargo
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            ~/.napi-rs
+            .cargo-cache
+            target/
+          key: x86_64-unknown-linux-gnu-cargo-ubuntu-latest
+      - name: Install dependencies
+        run: npm i
+      - name: Build
+        run: npm run build -- --target x86_64-unknown-linux-gnu
+        shell: bash
+      - name: Run unit tests
+        run: npm test
+

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,5 @@
+# Examples
+
+Currently there is no examples showing usage of the driver. For examples from the DataStax driver, see ``./DataStax`` directory.
+
+The ``basic.js`` example is a proof of concept connection to the database. It call the Rust layer directly, which will not be possible in the final package, as the rust layer will not be exposed in the API.

--- a/examples/package-lock.json
+++ b/examples/package-lock.json
@@ -10,7 +10,32 @@
       "license": "Apache-2.0",
       "dependencies": {
         "async": "^1.5.2",
-        "scylladb-javascript-driver": "file:./../../"
+        "scylladb-javascript-driver": "file:./../"
+      }
+    },
+    "..": {
+      "version": "0.0.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/long": "~5.0.0",
+        "@types/node": ">=8",
+        "adm-zip": "~0.5.10",
+        "long": "~5.2.3"
+      },
+      "devDependencies": {
+        "@napi-rs/cli": "^2.18.4",
+        "ava": "^6.0.1",
+        "chai": "~4.3.8",
+        "kerberos": "~2.0.3",
+        "mocha": "~10.2.0",
+        "mocha-jenkins-reporter": "~0.4.8",
+        "prettier": "~3.3.3",
+        "proxyquire": "~2.1.3",
+        "sinon": "~15.2.0",
+        "temp": ">= 0.8.3"
+      },
+      "engines": {
+        "node": ">=16"
       }
     },
     "../..": {
@@ -30,7 +55,7 @@
       "integrity": "sha512-nSVgobk4rv61R9PUSDtYt7mPVB2olxNR5RWJcAsH676/ef11bUZwvu7+RGYrYauVdDPcO519v68wRhXQtxsV9w=="
     },
     "node_modules/scylladb-javascript-driver": {
-      "resolved": "../..",
+      "resolved": "..",
       "link": true
     }
   }

--- a/examples/package.json
+++ b/examples/package.json
@@ -1,11 +1,11 @@
 {
   "name": "scylladb-javascript-driver-examples",
-  "description": "Examples for the DataStax Node.js Driver for Apache Cassandra",
+  "description": "Example usage of the driver",
   "version": "0.0.1",
   "license": "Apache-2.0",
   "private": true,
   "dependencies": {
-    "scylladb-javascript-driver": "file:./../../",
+    "scylladb-javascript-driver": "file:./../",
     "async": "^1.5.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "build": "napi build --platform --release",
     "test": "./node_modules/.bin/mocha test/unit -R spec -t 5000 --recursive",
     "unit": "./node_modules/.bin/mocha test/unit -R spec -t 5000 --recursive",
-    "examples": "node ./examples/DataStax/runner.js",
+    "examples": "node ./examples/runner.js",
     "prettier": "npx prettier \"{lib,examples,test}/**/*.js\" --write",
     "full-clippy": "cargo clippy --all-targets --all-features -- -D warnings",
     "pre-push": "npm run prettier && cargo fmt && npm run full-clippy && napi build --platform",


### PR DESCRIPTION
Split examples and unit tests into two CI tasks
Refactor examples: Update runner, and allow for running not only Datastax example
To ensure some testing on different theoretically supported node version updated the examples CI so they run on all major supported versions up to node20. 