### PR TITLE
Add type conversion helper function

### DIFF
--- a/lib/new-utils.js
+++ b/lib/new-utils.js
@@ -1,0 +1,41 @@
+"use strict";
+
+const Long = require("long");
+
+// maxInt value is based on how does Long split values between internal high and low fields.
+const maxInt = BigInt(0x100000000);
+const minusOne = BigInt(-1);
+
+/**
+ * Converts from bigint provided by napi into Long type used by the datastax library
+ * BigInt is the way napi handles values too big for js Number type,
+ * while Long is the way datastax code handles 64-bit integers.
+ * @param {bigint} from
+ * @returns {Long}
+ */
+function bigintToLong(from) {
+    let lo = from % maxInt;
+    let hi = from / maxInt;
+    if (lo < 0) hi += minusOne;
+    return Long.fromValue({
+        low: Number(lo),
+        high: Number(hi),
+        unsigned: false,
+    });
+}
+
+/**
+ * Converts from Long type used by the datastax library into bigint used by napi
+ * @param {Long} from
+ * @returns {bigint}
+ */
+function longToBigint(from) {
+    let lo = BigInt(from.low);
+    let hi = BigInt(from.high);
+    let r = lo + maxInt * hi;
+    if (lo < 0) r += maxInt;
+    return r;
+}
+
+exports.bigintToLong = bigintToLong;
+exports.longToBigint = longToBigint;

--- a/test/unit/new-utils.js.js
+++ b/test/unit/new-utils.js.js
@@ -1,0 +1,41 @@
+"use strict";
+const { assert } = require("chai");
+const { bigintToLong, longToBigint } = require("../../lib/new-utils");
+const Long = require("long");
+
+const values = [
+    "0",
+    "1",
+    "-1",
+    "12",
+    "-12",
+    "20040400020",
+    "120000000000",
+    "9223372036854775807",
+    "9223372036854775806",
+    "-9223372036854775808",
+    "-9223372036854775805",
+    "-20040400020",
+];
+
+describe("Numeric types conversions", function () {
+    // We assume BigInt and Long are fully correct
+    describe("BigInt to Long", function () {
+        it("should convert correctly", function () {
+            values.forEach((value) => {
+                let bigInt = BigInt(value);
+                let long = bigintToLong(bigInt);
+                assert.strictEqual(value, long.toString());
+            });
+        });
+    });
+    describe("Long to BigInt", function () {
+        it("should convert correctly", function () {
+            values.forEach((value) => {
+                let long = Long.fromString(value);
+                let bigInt = longToBigint(long);
+                assert.strictEqual(value, bigInt.toString());
+            });
+        });
+    });
+});


### PR DESCRIPTION
Add utility functions for converting between nodeJS bigint, type for arbitrary length integers (used also in NAPI when passing certain types between rust and node layers) and Long type used internally and in exposed API by datastax driver.
