### PR TITLE
Duration type (second attempt)

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -83,6 +83,7 @@ export declare class CqlValueWrapper {
   getBlob(): Buffer
   getCounter(): bigint
   getDouble(): number
+  getDuration(): DurationWrapper
   getFloat(): number
   getInt(): number
   getText(): string
@@ -100,11 +101,11 @@ export declare class SessionWrapper {
   static createSession(options: SessionOptions): Promise<SessionWrapper>
   queryUnpagedNoValues(query: string): Promise<QueryResultWrapper>
 }
-export declare class Duration {
+export declare class DurationWrapper {
   months: number
   days: number
   nanoseconds: number
-  static new(months: number, days: number, nsBigint: bigint): Duration
+  static new(months: number, days: number, nsBigint: bigint): DurationWrapper
   getNanoseconds(): bigint
 }
 export declare class TimeUuidWrapper {

--- a/index.d.ts
+++ b/index.d.ts
@@ -101,9 +101,8 @@ export declare class SessionWrapper {
   queryUnpagedNoValues(query: string): Promise<QueryResultWrapper>
 }
 export declare class Duration {
-  static new(months: number, days: number, nanoseconds: number): Duration
-  toBuffer(): Buffer
-  toString(): string
+  static new(months: number, days: number, ns1: number, ns2: number, filler: number): Duration
+  getObject(): Array<number>
   static fromBuffer(buffer: Buffer): Duration
 }
 export declare class TimeUuidWrapper {

--- a/index.d.ts
+++ b/index.d.ts
@@ -100,6 +100,12 @@ export declare class SessionWrapper {
   static createSession(options: SessionOptions): Promise<SessionWrapper>
   queryUnpagedNoValues(query: string): Promise<QueryResultWrapper>
 }
+export declare class Duration {
+  static new(months: number, days: number, nanoseconds: number): Duration
+  toBuffer(): Buffer
+  toString(): string
+  static fromBuffer(buffer: Buffer): Duration
+}
 export declare class TimeUuidWrapper {
   getBuffer(): Buffer
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -101,9 +101,11 @@ export declare class SessionWrapper {
   queryUnpagedNoValues(query: string): Promise<QueryResultWrapper>
 }
 export declare class Duration {
-  static new(months: number, days: number, ns1: number, ns2: number, filler: number): Duration
-  getObject(): Array<number>
-  static fromBuffer(buffer: Buffer): Duration
+  months: number
+  days: number
+  nanoseconds: number
+  static new(months: number, days: number, nsBigint: bigint): Duration
+  getNanoseconds(): bigint
 }
 export declare class TimeUuidWrapper {
   getBuffer(): Buffer

--- a/index.d.ts
+++ b/index.d.ts
@@ -42,6 +42,8 @@ export declare function testsGetCqlWrapperBlob(): CqlValueWrapper
 export declare function testsGetCqlWrapperCounter(): CqlValueWrapper
 /** Test function returning sample CqlValueWrapper with Double type */
 export declare function testsGetCqlWrapperDouble(): CqlValueWrapper
+/** Test function returning sample CqlValueWrapper with Duration type */
+export declare function testsGetCqlWrapperDuration(): CqlValueWrapper
 /** Test function returning sample CqlValueWrapper with Float type */
 export declare function testsGetCqlWrapperFloat(): CqlValueWrapper
 /** Test function returning sample CqlValueWrapper with Int type */

--- a/index.js
+++ b/index.js
@@ -310,7 +310,7 @@ if (!nativeBinding) {
   throw new Error(`Failed to load native binding`)
 }
 
-const { testConnection, PlainTextAuthProvider, QueryResultWrapper, RowWrapper, CqlValueWrapper, CqlType, testsGetCqlWrapperAscii, testsGetCqlWrapperBoolean, testsGetCqlWrapperBlob, testsGetCqlWrapperCounter, testsGetCqlWrapperDouble, testsGetCqlWrapperFloat, testsGetCqlWrapperInt, testsGetCqlWrapperText, testsGetCqlWrapperSet, testsGetCqlWrapperSmallInt, testsGetCqlWrapperTinyInt, testsGetCqlWrapperUuid, testsGetCqlWrapperTimeUuid, SessionOptions, SessionWrapper, testsBigintToI64, Duration, TimeUuidWrapper, UuidWrapper } = nativeBinding
+const { testConnection, PlainTextAuthProvider, QueryResultWrapper, RowWrapper, CqlValueWrapper, CqlType, testsGetCqlWrapperAscii, testsGetCqlWrapperBoolean, testsGetCqlWrapperBlob, testsGetCqlWrapperCounter, testsGetCqlWrapperDouble, testsGetCqlWrapperFloat, testsGetCqlWrapperInt, testsGetCqlWrapperText, testsGetCqlWrapperSet, testsGetCqlWrapperSmallInt, testsGetCqlWrapperTinyInt, testsGetCqlWrapperUuid, testsGetCqlWrapperTimeUuid, SessionOptions, SessionWrapper, testsBigintToI64, DurationWrapper, TimeUuidWrapper, UuidWrapper } = nativeBinding
 
 module.exports.testConnection = testConnection
 module.exports.PlainTextAuthProvider = PlainTextAuthProvider
@@ -334,6 +334,6 @@ module.exports.testsGetCqlWrapperTimeUuid = testsGetCqlWrapperTimeUuid
 module.exports.SessionOptions = SessionOptions
 module.exports.SessionWrapper = SessionWrapper
 module.exports.testsBigintToI64 = testsBigintToI64
-module.exports.Duration = Duration
+module.exports.DurationWrapper = DurationWrapper
 module.exports.TimeUuidWrapper = TimeUuidWrapper
 module.exports.UuidWrapper = UuidWrapper

--- a/index.js
+++ b/index.js
@@ -310,7 +310,7 @@ if (!nativeBinding) {
   throw new Error(`Failed to load native binding`)
 }
 
-const { testConnection, PlainTextAuthProvider, QueryResultWrapper, RowWrapper, CqlValueWrapper, CqlType, testsGetCqlWrapperAscii, testsGetCqlWrapperBoolean, testsGetCqlWrapperBlob, testsGetCqlWrapperCounter, testsGetCqlWrapperDouble, testsGetCqlWrapperFloat, testsGetCqlWrapperInt, testsGetCqlWrapperText, testsGetCqlWrapperSet, testsGetCqlWrapperSmallInt, testsGetCqlWrapperTinyInt, testsGetCqlWrapperUuid, testsGetCqlWrapperTimeUuid, SessionOptions, SessionWrapper, testsBigintToI64, DurationWrapper, TimeUuidWrapper, UuidWrapper } = nativeBinding
+const { testConnection, PlainTextAuthProvider, QueryResultWrapper, RowWrapper, CqlValueWrapper, CqlType, testsGetCqlWrapperAscii, testsGetCqlWrapperBoolean, testsGetCqlWrapperBlob, testsGetCqlWrapperCounter, testsGetCqlWrapperDouble, testsGetCqlWrapperDuration, testsGetCqlWrapperFloat, testsGetCqlWrapperInt, testsGetCqlWrapperText, testsGetCqlWrapperSet, testsGetCqlWrapperSmallInt, testsGetCqlWrapperTinyInt, testsGetCqlWrapperUuid, testsGetCqlWrapperTimeUuid, SessionOptions, SessionWrapper, testsBigintToI64, DurationWrapper, TimeUuidWrapper, UuidWrapper } = nativeBinding
 
 module.exports.testConnection = testConnection
 module.exports.PlainTextAuthProvider = PlainTextAuthProvider
@@ -323,6 +323,7 @@ module.exports.testsGetCqlWrapperBoolean = testsGetCqlWrapperBoolean
 module.exports.testsGetCqlWrapperBlob = testsGetCqlWrapperBlob
 module.exports.testsGetCqlWrapperCounter = testsGetCqlWrapperCounter
 module.exports.testsGetCqlWrapperDouble = testsGetCqlWrapperDouble
+module.exports.testsGetCqlWrapperDuration = testsGetCqlWrapperDuration
 module.exports.testsGetCqlWrapperFloat = testsGetCqlWrapperFloat
 module.exports.testsGetCqlWrapperInt = testsGetCqlWrapperInt
 module.exports.testsGetCqlWrapperText = testsGetCqlWrapperText

--- a/index.js
+++ b/index.js
@@ -310,7 +310,7 @@ if (!nativeBinding) {
   throw new Error(`Failed to load native binding`)
 }
 
-const { testConnection, PlainTextAuthProvider, QueryResultWrapper, RowWrapper, CqlValueWrapper, CqlType, testsGetCqlWrapperAscii, testsGetCqlWrapperBoolean, testsGetCqlWrapperBlob, testsGetCqlWrapperCounter, testsGetCqlWrapperDouble, testsGetCqlWrapperFloat, testsGetCqlWrapperInt, testsGetCqlWrapperText, testsGetCqlWrapperSet, testsGetCqlWrapperSmallInt, testsGetCqlWrapperTinyInt, testsGetCqlWrapperUuid, testsGetCqlWrapperTimeUuid, SessionOptions, SessionWrapper, testsBigintToI64, TimeUuidWrapper, UuidWrapper } = nativeBinding
+const { testConnection, PlainTextAuthProvider, QueryResultWrapper, RowWrapper, CqlValueWrapper, CqlType, testsGetCqlWrapperAscii, testsGetCqlWrapperBoolean, testsGetCqlWrapperBlob, testsGetCqlWrapperCounter, testsGetCqlWrapperDouble, testsGetCqlWrapperFloat, testsGetCqlWrapperInt, testsGetCqlWrapperText, testsGetCqlWrapperSet, testsGetCqlWrapperSmallInt, testsGetCqlWrapperTinyInt, testsGetCqlWrapperUuid, testsGetCqlWrapperTimeUuid, SessionOptions, SessionWrapper, testsBigintToI64, Duration, TimeUuidWrapper, UuidWrapper } = nativeBinding
 
 module.exports.testConnection = testConnection
 module.exports.PlainTextAuthProvider = PlainTextAuthProvider
@@ -334,5 +334,6 @@ module.exports.testsGetCqlWrapperTimeUuid = testsGetCqlWrapperTimeUuid
 module.exports.SessionOptions = SessionOptions
 module.exports.SessionWrapper = SessionWrapper
 module.exports.testsBigintToI64 = testsBigintToI64
+module.exports.Duration = Duration
 module.exports.TimeUuidWrapper = TimeUuidWrapper
 module.exports.UuidWrapper = UuidWrapper

--- a/lib/types/duration.js
+++ b/lib/types/duration.js
@@ -1,16 +1,9 @@
 "use strict";
 const Long = require("long");
 const util = require("util");
-const utils = require("../utils");
+const rust = require("../../index");
 
 /** @module types */
-
-// Reuse the same buffers that should perform slightly better than built-in buffer pool
-const reusableBuffers = {
-    months: utils.allocBuffer(9),
-    days: utils.allocBuffer(9),
-    nanoseconds: utils.allocBuffer(9),
-};
 
 const maxInt32 = 0x7fffffff;
 const longOneThousand = Long.fromInt(1000);
@@ -39,35 +32,15 @@ const iso8601AlternateRegex =
  * @constructor
  */
 function Duration(months, days, nanoseconds) {
-    /**
-     * Gets the number of months.
-     * @type {Number}
-     */
-    this.months = months;
-    /**
-     * Gets the number of days.
-     * @type {Number}
-     */
-    this.days = days;
-    /**
-     * Gets the number of nanoseconds represented as a <code>int64</code>.
-     * @type {Long}
-     */
-    this.nanoseconds =
-        typeof nanoseconds === "number"
-            ? Long.fromNumber(nanoseconds)
-            : nanoseconds;
+    // ToDo: Check types
+    this.internal = rust.Duration.new(months, days, nanoseconds);
 }
 
 Duration.prototype.equals = function (other) {
     if (!(other instanceof Duration)) {
         return false;
     }
-    return (
-        this.months === other.months &&
-        this.days === other.days &&
-        this.nanoseconds.equals(other.nanoseconds)
-    );
+    return this == other;
 };
 
 /**
@@ -75,27 +48,7 @@ Duration.prototype.equals = function (other) {
  * @returns {Buffer}
  */
 Duration.prototype.toBuffer = function () {
-    const lengthMonths = VIntCoding.writeVInt(
-        Long.fromNumber(this.months),
-        reusableBuffers.months,
-    );
-    const lengthDays = VIntCoding.writeVInt(
-        Long.fromNumber(this.days),
-        reusableBuffers.days,
-    );
-    const lengthNanoseconds = VIntCoding.writeVInt(
-        this.nanoseconds,
-        reusableBuffers.nanoseconds,
-    );
-    const buffer = utils.allocBufferUnsafe(
-        lengthMonths + lengthDays + lengthNanoseconds,
-    );
-    reusableBuffers.months.copy(buffer, 0, 0, lengthMonths);
-    let offset = lengthMonths;
-    reusableBuffers.days.copy(buffer, offset, 0, lengthDays);
-    offset += lengthDays;
-    reusableBuffers.nanoseconds.copy(buffer, offset, 0, lengthNanoseconds);
-    return buffer;
+    return this.internal.toBuffer();
 };
 
 /**
@@ -103,42 +56,7 @@ Duration.prototype.toBuffer = function () {
  * @return {string}
  */
 Duration.prototype.toString = function () {
-    let value = "";
-    function append(dividend, divisor, unit) {
-        if (dividend === 0 || dividend < divisor) {
-            return dividend;
-        }
-        // string concatenation is supposed to be fasted than join()
-        value += (dividend / divisor).toFixed(0) + unit;
-        return dividend % divisor;
-    }
-    function append64(dividend, divisor, unit) {
-        if (dividend.equals(Long.ZERO) || dividend.lessThan(divisor)) {
-            return dividend;
-        }
-        // string concatenation is supposed to be fasted than join()
-        value += dividend.divide(divisor).toString() + unit;
-        return dividend.modulo(divisor);
-    }
-    if (this.months < 0 || this.days < 0 || this.nanoseconds.isNegative()) {
-        value = "-";
-    }
-    let remainder = append(Math.abs(this.months), monthsPerYear, "y");
-    append(remainder, 1, "mo");
-    append(Math.abs(this.days), 1, "d");
-
-    if (!this.nanoseconds.equals(Long.ZERO)) {
-        const nanos = this.nanoseconds.isNegative()
-            ? this.nanoseconds.negate()
-            : this.nanoseconds;
-        remainder = append64(nanos, nanosPerHour, "h");
-        remainder = append64(remainder, nanosPerMinute, "m");
-        remainder = append64(remainder, nanosPerSecond, "s");
-        remainder = append64(remainder, nanosPerMilli, "ms");
-        remainder = append64(remainder, nanosPerMicro, "us");
-        append64(remainder, Long.ONE, "ns");
-    }
-    return value;
+    return this.toString();
 };
 
 /**
@@ -147,11 +65,8 @@ Duration.prototype.toString = function () {
  * @returns {Duration}
  */
 Duration.fromBuffer = function (buffer) {
-    const offset = { value: 0 };
-    const months = VIntCoding.readVInt(buffer, offset).toNumber();
-    const days = VIntCoding.readVInt(buffer, offset).toNumber();
-    const nanoseconds = VIntCoding.readVInt(buffer, offset);
-    return new Duration(months, days, nanoseconds);
+    // ToDo: Check types
+    return rust.Duration.fromBuffer(buffer);
 };
 
 /**
@@ -181,6 +96,7 @@ Duration.fromBuffer = function (buffer) {
  * @returns {Duration}
  */
 Duration.fromString = function (input) {
+    // This does a lot of stuff. Is it nesesery to implement it in rust, or should we just keep it as is?
     const isNegative = input.charAt(0) === "-";
     const source = isNegative ? input.substr(1) : input;
     if (source.charAt(0) === "P") {

--- a/lib/types/duration.js
+++ b/lib/types/duration.js
@@ -230,32 +230,32 @@ class Duration {
 
     /**
      * Creates a new {@link Duration} instance from the string representation of the value.
-     * <p>
-     *   Accepted formats:
-     * </p>
-     * <ul>
-     * <li>multiple digits followed by a time unit like: 12h30m where the time unit can be:
-     *   <ul>
-     *     <li>{@code y}: years</li>
-     *     <li>{@code m}: months</li>
-     *     <li>{@code w}: weeks</li>
-     *     <li>{@code d}: days</li>
-     *     <li>{@code h}: hours</li>
-     *     <li>{@code m}: minutes</li>
-     *     <li>{@code s}: seconds</li>
-     *     <li>{@code ms}: milliseconds</li>
-     *     <li>{@code us} or {@code µs}: microseconds</li>
-     *     <li>{@code ns}: nanoseconds</li>
-     *   </ul>
-     * </li>
-     * <li>ISO 8601 format:  <code>P[n]Y[n]M[n]DT[n]H[n]M[n]S or P[n]W</code></li>
-     * <li>ISO 8601 alternative format: <code>P[YYYY]-[MM]-[DD]T[hh]:[mm]:[ss]</code></li>
-     * </ul>
      * @param {String} input
+     *
+     * Accepted formats:
+     *
+     * - multiple digits followed by a time unit like: 12h30m where the time unit can be:
+     *     - ``y``: years
+     *     - ``mo``: months
+     *     - ``w``: weeks
+     *     - ``d``: days
+     *     - ``h``: hours
+     *     - ``m``: minutes
+     *     - ``s``: seconds
+     *     - ``ms``: milliseconds
+     *     - ``us`` or ``µs``: microseconds
+     *     - ``ns``: nanoseconds
+     * - ISO 8601 format:  <code>P[n]Y[n]M[n]DT[n]H[n]M[n]S or P[n]W</code>
+     * - ISO 8601 alternative format: <code>P[YYYY]-[MM]-[DD]T[hh]:[mm]:[ss]</code>
+     *
+     * Duration can be made negative by adding ``-`` at the beginning of the input
      * @returns {Duration}
+     * @example <caption>From formatted string</caption>
+     * let date = fromString("4mo7d20ns");  // 1 month, 7 days, 20 nanoseconds
+     * @example <caption>From ISO 8601</caption>
+     * let date = fromString("P2DT5M");     // 2 days, 5 minutes
      */
     static fromString(input) {
-        // This does a lot of stuff. Is it necessary to implement it in rust, or should we just keep it as is?
         const isNegative = input.charAt(0) === "-";
         const source = isNegative ? input.substring(1) : input;
         if (source.charAt(0) === "P") {

--- a/lib/types/duration.js
+++ b/lib/types/duration.js
@@ -31,177 +31,186 @@ const iso8601AlternateRegex =
     /P(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})/;
 
 /**
- * Creates a new instance of {@link Duration}.
- * @classdesc
  * Represents a duration. A duration stores separately months, days, and seconds due to the fact that the number of
  * days in a month varies, and a day can have 23 or 25 hours if a daylight saving is involved.
- * @param {Number} months The number of months.
- * @param {Number} days The number of days.
- * @param {Number|Long} nanoseconds The number of nanoseconds.
- * @constructor
  */
-function Duration(months, days, nanoseconds) {
-    if (nanoseconds instanceof Long)
-        this.internal = rust.DurationWrapper.new(
-            months,
-            days,
-            longToBigint(nanoseconds),
+class Duration {
+    /**
+     * Creates a new instance of {@link Duration}.
+     * @param {Number} months The number of months.
+     * @param {Number} days The number of days.
+     * @param {Number|Long|BigInt} nanoseconds The number of nanoseconds.
+     * @constructor
+     */
+    constructor(months, days, nanoseconds) {
+        if (typeof nanoseconds === "bigint") {
+            this.internal = rust.DurationWrapper.new(months, days, nanoseconds);
+        } else if (nanoseconds instanceof Long) {
+            this.internal = rust.DurationWrapper.new(
+                months,
+                days,
+                longToBigint(nanoseconds),
+            );
+        } else if (typeof nanoseconds === "number") {
+            this.internal = rust.DurationWrapper.new(
+                months,
+                days,
+                BigInt(nanoseconds),
+            );
+        } else {
+            throw new TypeError(
+                `Invalid nanosecond argument type: ${typeof nanoseconds}`,
+            );
+        }
+    }
+
+    equals(other) {
+        if (!(other instanceof Duration)) {
+            return false;
+        }
+        return (
+            this.internal.months === other.internal.months &&
+            this.internal.days === other.internal.days &&
+            this.internal.getNanoseconds() === other.internal.getNanoseconds()
         );
-    else if (typeof nanoseconds === "number")
-        this.internal = rust.DurationWrapper.new(
-            months,
-            days,
-            BigInt(nanoseconds),
+    }
+
+    /**
+     * Serializes the duration and returns the representation of the value in bytes.
+     * @returns {Buffer}
+     */
+    toBuffer() {
+        let nanoseconds = bigintToLong(this.internal.getNanoseconds());
+        const lengthMonths = VIntCoding.writeVInt(
+            Long.fromNumber(this.internal.months),
+            reusableBuffers.months,
         );
-    else
-        throw new TypeError(
-            `Invalid nanosecond argument type: ${typeof nanoseconds}`,
+        const lengthDays = VIntCoding.writeVInt(
+            Long.fromNumber(this.internal.days),
+            reusableBuffers.days,
         );
+        const lengthNanoseconds = VIntCoding.writeVInt(
+            nanoseconds,
+            reusableBuffers.nanoseconds,
+        );
+        const buffer = utils.allocBufferUnsafe(
+            lengthMonths + lengthDays + lengthNanoseconds,
+        );
+        reusableBuffers.months.copy(buffer, 0, 0, lengthMonths);
+        let offset = lengthMonths;
+        reusableBuffers.days.copy(buffer, offset, 0, lengthDays);
+        offset += lengthDays;
+        reusableBuffers.nanoseconds.copy(buffer, offset, 0, lengthNanoseconds);
+        return buffer;
+    }
+
+    /**
+     * Returns the string representation of the value.
+     * @return {string}
+     */
+    toString() {
+        let nanoseconds = bigintToLong(this.internal.getNanoseconds());
+        let value = "";
+        function append(dividend, divisor, unit) {
+            if (dividend === 0 || dividend < divisor) {
+                return dividend;
+            }
+            // string concatenation is supposed to be faster than join()
+            value += (dividend / divisor).toFixed(0) + unit;
+            return dividend % divisor;
+        }
+        function append64(dividend, divisor, unit) {
+            if (dividend.equals(Long.ZERO) || dividend.lessThan(divisor)) {
+                return dividend;
+            }
+            // string concatenation is supposed to be faster than join()
+            value += dividend.divide(divisor).toString() + unit;
+            return dividend.modulo(divisor);
+        }
+        if (
+            this.internal.months < 0 ||
+            this.internal.days < 0 ||
+            nanoseconds.isNegative()
+        ) {
+            value = "-";
+        }
+        let remainder = append(
+            Math.abs(this.internal.months),
+            monthsPerYear,
+            "y",
+        );
+        append(remainder, 1, "mo");
+        append(Math.abs(this.internal.days), 1, "d");
+
+        if (!nanoseconds.equals(Long.ZERO)) {
+            const nanos = nanoseconds.isNegative()
+                ? nanoseconds.negate()
+                : nanoseconds;
+            remainder = append64(nanos, nanosPerHour, "h");
+            remainder = append64(remainder, nanosPerMinute, "m");
+            remainder = append64(remainder, nanosPerSecond, "s");
+            remainder = append64(remainder, nanosPerMilli, "ms");
+            remainder = append64(remainder, nanosPerMicro, "us");
+            append64(remainder, Long.ONE, "ns");
+        }
+        return value;
+    }
+
+    /**
+     * Creates a new {@link Duration} instance from the binary representation of the value.
+     * @param {Buffer} buffer
+     * @returns {Duration}
+     */
+    static fromBuffer(buffer) {
+        const offset = { value: 0 };
+        const months = VIntCoding.readVInt(buffer, offset).toNumber();
+        const days = VIntCoding.readVInt(buffer, offset).toNumber();
+        const nanoseconds = VIntCoding.readVInt(buffer, offset);
+        return new Duration(months, days, nanoseconds);
+    }
+
+    /**
+     * Creates a new {@link Duration} instance from the string representation of the value.
+     * <p>
+     *   Accepted formats:
+     * </p>
+     * <ul>
+     * <li>multiple digits followed by a time unit like: 12h30m where the time unit can be:
+     *   <ul>
+     *     <li>{@code y}: years</li>
+     *     <li>{@code m}: months</li>
+     *     <li>{@code w}: weeks</li>
+     *     <li>{@code d}: days</li>
+     *     <li>{@code h}: hours</li>
+     *     <li>{@code m}: minutes</li>
+     *     <li>{@code s}: seconds</li>
+     *     <li>{@code ms}: milliseconds</li>
+     *     <li>{@code us} or {@code µs}: microseconds</li>
+     *     <li>{@code ns}: nanoseconds</li>
+     *   </ul>
+     * </li>
+     * <li>ISO 8601 format:  <code>P[n]Y[n]M[n]DT[n]H[n]M[n]S or P[n]W</code></li>
+     * <li>ISO 8601 alternative format: <code>P[YYYY]-[MM]-[DD]T[hh]:[mm]:[ss]</code></li>
+     * </ul>
+     * @param {String} input
+     * @returns {Duration}
+     */
+    static fromString(input) {
+        // This does a lot of stuff. Is it necessary to implement it in rust, or should we just keep it as is?
+        const isNegative = input.charAt(0) === "-";
+        const source = isNegative ? input.substring(1) : input;
+        if (source.charAt(0) === "P") {
+            if (source.charAt(source.length - 1) === "W") {
+                return parseIso8601WeekFormat(isNegative, source);
+            }
+            if (source.indexOf("-") > 0) {
+                return parseIso8601AlternativeFormat(isNegative, source);
+            }
+            return parseIso8601Format(isNegative, source);
+        }
+        return parseStandardFormat(isNegative, source);
+    }
 }
-
-Duration.prototype.equals = function (other) {
-    if (!(other instanceof Duration)) {
-        return false;
-    }
-    return (
-        this.internal.months === other.internal.months &&
-        this.internal.days === other.internal.days &&
-        this.internal.getNanoseconds() === other.internal.getNanoseconds()
-    );
-};
-
-/**
- * Serializes the duration and returns the representation of the value in bytes.
- * @returns {Buffer}
- */
-Duration.prototype.toBuffer = function () {
-    let nanoseconds = bigintToLong(this.internal.getNanoseconds());
-    const lengthMonths = VIntCoding.writeVInt(
-        Long.fromNumber(this.internal.months),
-        reusableBuffers.months,
-    );
-    const lengthDays = VIntCoding.writeVInt(
-        Long.fromNumber(this.internal.days),
-        reusableBuffers.days,
-    );
-    const lengthNanoseconds = VIntCoding.writeVInt(
-        nanoseconds,
-        reusableBuffers.nanoseconds,
-    );
-    const buffer = utils.allocBufferUnsafe(
-        lengthMonths + lengthDays + lengthNanoseconds,
-    );
-    reusableBuffers.months.copy(buffer, 0, 0, lengthMonths);
-    let offset = lengthMonths;
-    reusableBuffers.days.copy(buffer, offset, 0, lengthDays);
-    offset += lengthDays;
-    reusableBuffers.nanoseconds.copy(buffer, offset, 0, lengthNanoseconds);
-    return buffer;
-};
-
-/**
- * Returns the string representation of the value.
- * @return {string}
- */
-Duration.prototype.toString = function () {
-    let nanoseconds = bigintToLong(this.internal.getNanoseconds());
-    let value = "";
-    function append(dividend, divisor, unit) {
-        if (dividend === 0 || dividend < divisor) {
-            return dividend;
-        }
-        // string concatenation is supposed to be fasted than join()
-        value += (dividend / divisor).toFixed(0) + unit;
-        return dividend % divisor;
-    }
-    function append64(dividend, divisor, unit) {
-        if (dividend.equals(Long.ZERO) || dividend.lessThan(divisor)) {
-            return dividend;
-        }
-        // string concatenation is supposed to be fasted than join()
-        value += dividend.divide(divisor).toString() + unit;
-        return dividend.modulo(divisor);
-    }
-    if (
-        this.internal.months < 0 ||
-        this.internal.days < 0 ||
-        nanoseconds.isNegative()
-    ) {
-        value = "-";
-    }
-    let remainder = append(Math.abs(this.internal.months), monthsPerYear, "y");
-    append(remainder, 1, "mo");
-    append(Math.abs(this.internal.days), 1, "d");
-
-    if (!nanoseconds.equals(Long.ZERO)) {
-        const nanos = nanoseconds.isNegative()
-            ? nanoseconds.negate()
-            : nanoseconds;
-        remainder = append64(nanos, nanosPerHour, "h");
-        remainder = append64(remainder, nanosPerMinute, "m");
-        remainder = append64(remainder, nanosPerSecond, "s");
-        remainder = append64(remainder, nanosPerMilli, "ms");
-        remainder = append64(remainder, nanosPerMicro, "us");
-        append64(remainder, Long.ONE, "ns");
-    }
-    return value;
-};
-
-/**
- * Creates a new {@link Duration} instance from the binary representation of the value.
- * @param {Buffer} buffer
- * @returns {Duration}
- */
-Duration.fromBuffer = function (buffer) {
-    const offset = { value: 0 };
-    const months = VIntCoding.readVInt(buffer, offset).toNumber();
-    const days = VIntCoding.readVInt(buffer, offset).toNumber();
-    const nanoseconds = VIntCoding.readVInt(buffer, offset);
-    return new Duration(months, days, nanoseconds);
-};
-
-/**
- * Creates a new {@link Duration} instance from the string representation of the value.
- * <p>
- *   Accepted formats:
- * </p>
- * <ul>
- * <li>multiple digits followed by a time unit like: 12h30m where the time unit can be:
- *   <ul>
- *     <li>{@code y}: years</li>
- *     <li>{@code m}: months</li>
- *     <li>{@code w}: weeks</li>
- *     <li>{@code d}: days</li>
- *     <li>{@code h}: hours</li>
- *     <li>{@code m}: minutes</li>
- *     <li>{@code s}: seconds</li>
- *     <li>{@code ms}: milliseconds</li>
- *     <li>{@code us} or {@code µs}: microseconds</li>
- *     <li>{@code ns}: nanoseconds</li>
- *   </ul>
- * </li>
- * <li>ISO 8601 format:  <code>P[n]Y[n]M[n]DT[n]H[n]M[n]S or P[n]W</code></li>
- * <li>ISO 8601 alternative format: <code>P[YYYY]-[MM]-[DD]T[hh]:[mm]:[ss]</code></li>
- * </ul>
- * @param {String} input
- * @returns {Duration}
- */
-Duration.fromString = function (input) {
-    // This does a lot of stuff. Is it nesesery to implement it in rust, or should we just keep it as is?
-    const isNegative = input.charAt(0) === "-";
-    const source = isNegative ? input.substr(1) : input;
-    if (source.charAt(0) === "P") {
-        if (source.charAt(source.length - 1) === "W") {
-            return parseIso8601WeekFormat(isNegative, source);
-        }
-        if (source.indexOf("-") > 0) {
-            return parseIso8601AlternativeFormat(isNegative, source);
-        }
-        return parseIso8601Format(isNegative, source);
-    }
-    return parseStandardFormat(isNegative, source);
-};
-
 /**
  * @param {Boolean} isNegative
  * @param {String} source

--- a/lib/types/duration.js
+++ b/lib/types/duration.js
@@ -76,6 +76,18 @@ class Duration {
     }
 
     /**
+     * Get duration from rust object. Not intended to be exposed in the API
+     * @package
+     * @param {rust.DurationWrapper} arg
+     * @returns {Duration}
+     */
+    static fromRust(arg) {
+        let res = new Duration(0, 0, 0);
+        res.internal = arg;
+        return res;
+    }
+
+    /**
      * Serializes the duration and returns the representation of the value in bytes.
      * @returns {Buffer}
      */

--- a/lib/types/duration.js
+++ b/lib/types/duration.js
@@ -1,9 +1,16 @@
 "use strict";
 const Long = require("long");
 const util = require("util");
+const utils = require("../utils");
 const rust = require("../../index");
 
 /** @module types */
+
+const reusableBuffers = {
+    months: utils.allocBuffer(9),
+    days: utils.allocBuffer(9),
+    nanoseconds: utils.allocBuffer(9),
+};
 
 const maxInt32 = 0x7fffffff;
 const longOneThousand = Long.fromInt(1000);
@@ -33,14 +40,27 @@ const iso8601AlternateRegex =
  */
 function Duration(months, days, nanoseconds) {
     // ToDo: Check types
-    this.internal = rust.Duration.new(months, days, nanoseconds);
+    let ns1 = nanoseconds.modulo(maxInt32);
+    let ns2 = nanoseconds.div(maxInt32);
+    this.internal = rust.Duration.new(
+        Math.trunc(months),
+        Math.trunc(days),
+        Math.trunc(ns1),
+        Math.trunc(ns2),
+        Math.trunc(maxInt32),
+    );
 }
 
 Duration.prototype.equals = function (other) {
     if (!(other instanceof Duration)) {
         return false;
     }
-    return this == other;
+    let me = this.internal.getObject();
+    let other_me = other.internal.getObject();
+    for (let i = 0; i < me.length; i++) {
+        if (me[i] != other_me[i]) return false;
+    }
+    return true;
 };
 
 /**
@@ -48,7 +68,29 @@ Duration.prototype.equals = function (other) {
  * @returns {Buffer}
  */
 Duration.prototype.toBuffer = function () {
-    return this.internal.toBuffer();
+    let data = this.internal.getObject();
+    let nanoseconds = Long.fromNumber(data[2]).multiply(data[4]).add(data[3]);
+    const lengthMonths = VIntCoding.writeVInt(
+        Long.fromNumber(data[0]),
+        reusableBuffers.months,
+    );
+    const lengthDays = VIntCoding.writeVInt(
+        Long.fromNumber(data[1]),
+        reusableBuffers.days,
+    );
+    const lengthNanoseconds = VIntCoding.writeVInt(
+        nanoseconds,
+        reusableBuffers.nanoseconds,
+    );
+    const buffer = utils.allocBufferUnsafe(
+        lengthMonths + lengthDays + lengthNanoseconds,
+    );
+    reusableBuffers.months.copy(buffer, 0, 0, lengthMonths);
+    let offset = lengthMonths;
+    reusableBuffers.days.copy(buffer, offset, 0, lengthDays);
+    offset += lengthDays;
+    reusableBuffers.nanoseconds.copy(buffer, offset, 0, lengthNanoseconds);
+    return buffer;
 };
 
 /**
@@ -56,7 +98,45 @@ Duration.prototype.toBuffer = function () {
  * @return {string}
  */
 Duration.prototype.toString = function () {
-    return this.toString();
+    let data = this.internal.getObject();
+    let value = "";
+    console.log(data);
+    let nanoseconds = Long.fromNumber(data[2]).multiply(data[4]).add(data[3]);
+    function append(dividend, divisor, unit) {
+        if (dividend === 0 || dividend < divisor) {
+            return dividend;
+        }
+        // string concatenation is supposed to be fasted than join()
+        value += (dividend / divisor).toFixed(0) + unit;
+        return dividend % divisor;
+    }
+    function append64(dividend, divisor, unit) {
+        if (dividend.equals(Long.ZERO) || dividend.lessThan(divisor)) {
+            return dividend;
+        }
+        // string concatenation is supposed to be fasted than join()
+        value += dividend.divide(divisor).toString() + unit;
+        return dividend.modulo(divisor);
+    }
+    if (data[0] < 0 || data[1] < 0 || nanoseconds.isNegative()) {
+        value = "-";
+    }
+    let remainder = append(Math.abs(data[0]), monthsPerYear, "y");
+    append(remainder, 1, "mo");
+    append(Math.abs(data[1]), 1, "d");
+
+    if (!nanoseconds.equals(Long.ZERO)) {
+        const nanos = nanoseconds.isNegative()
+            ? nanoseconds.negate()
+            : nanoseconds;
+        remainder = append64(nanos, nanosPerHour, "h");
+        remainder = append64(remainder, nanosPerMinute, "m");
+        remainder = append64(remainder, nanosPerSecond, "s");
+        remainder = append64(remainder, nanosPerMilli, "ms");
+        remainder = append64(remainder, nanosPerMicro, "us");
+        append64(remainder, Long.ONE, "ns");
+    }
+    return value;
 };
 
 /**
@@ -65,8 +145,13 @@ Duration.prototype.toString = function () {
  * @returns {Duration}
  */
 Duration.fromBuffer = function (buffer) {
-    // ToDo: Check types
-    return rust.Duration.fromBuffer(buffer);
+    if ((!buffer) instanceof Buffer)
+        throw new TypeError("Expected Buffer type");
+    const offset = { value: 0 };
+    const months = VIntCoding.readVInt(buffer, offset).toNumber();
+    const days = VIntCoding.readVInt(buffer, offset).toNumber();
+    const nanoseconds = VIntCoding.readVInt(buffer, offset);
+    return new Duration(months, days, nanoseconds);
 };
 
 /**

--- a/lib/types/duration.js
+++ b/lib/types/duration.js
@@ -7,6 +7,7 @@ const { bigintToLong, longToBigint } = require("../new-utils");
 
 /** @module types */
 
+// Reuse the same buffers that should perform slightly better than built-in buffer pool
 const reusableBuffers = {
     months: utils.allocBuffer(9),
     days: utils.allocBuffer(9),
@@ -41,13 +42,17 @@ const iso8601AlternateRegex =
  */
 function Duration(months, days, nanoseconds) {
     if (nanoseconds instanceof Long)
-        this.internal = rust.Duration.new(
+        this.internal = rust.DurationWrapper.new(
             months,
             days,
             longToBigint(nanoseconds),
         );
-    else if (isNumber(nanoseconds))
-        this.internal = rust.Duration.new(months, days, BigInt(nanoseconds));
+    else if (typeof nanoseconds === "number")
+        this.internal = rust.DurationWrapper.new(
+            months,
+            days,
+            BigInt(nanoseconds),
+        );
     else
         throw new TypeError(
             `Invalid nanosecond argument type: ${typeof nanoseconds}`,

--- a/lib/types/duration.js
+++ b/lib/types/duration.js
@@ -3,6 +3,7 @@ const Long = require("long");
 const util = require("util");
 const utils = require("../utils");
 const rust = require("../../index");
+const { bigintToLong, longToBigint } = require("../new-utils");
 
 /** @module types */
 
@@ -39,28 +40,29 @@ const iso8601AlternateRegex =
  * @constructor
  */
 function Duration(months, days, nanoseconds) {
-    // ToDo: Check types
-    let ns1 = nanoseconds.modulo(maxInt32);
-    let ns2 = nanoseconds.div(maxInt32);
-    this.internal = rust.Duration.new(
-        Math.trunc(months),
-        Math.trunc(days),
-        Math.trunc(ns1),
-        Math.trunc(ns2),
-        Math.trunc(maxInt32),
-    );
+    if (nanoseconds instanceof Long)
+        this.internal = rust.Duration.new(
+            months,
+            days,
+            longToBigint(nanoseconds),
+        );
+    else if (isNumber(nanoseconds))
+        this.internal = rust.Duration.new(months, days, BigInt(nanoseconds));
+    else
+        throw new TypeError(
+            `Invalid nanosecond argument type: ${typeof nanoseconds}`,
+        );
 }
 
 Duration.prototype.equals = function (other) {
     if (!(other instanceof Duration)) {
         return false;
     }
-    let me = this.internal.getObject();
-    let other_me = other.internal.getObject();
-    for (let i = 0; i < me.length; i++) {
-        if (me[i] != other_me[i]) return false;
-    }
-    return true;
+    return (
+        this.internal.months === other.internal.months &&
+        this.internal.days === other.internal.days &&
+        this.internal.getNanoseconds() === other.internal.getNanoseconds()
+    );
 };
 
 /**
@@ -68,14 +70,13 @@ Duration.prototype.equals = function (other) {
  * @returns {Buffer}
  */
 Duration.prototype.toBuffer = function () {
-    let data = this.internal.getObject();
-    let nanoseconds = Long.fromNumber(data[2]).multiply(data[4]).add(data[3]);
+    let nanoseconds = bigintToLong(this.internal.getNanoseconds());
     const lengthMonths = VIntCoding.writeVInt(
-        Long.fromNumber(data[0]),
+        Long.fromNumber(this.internal.months),
         reusableBuffers.months,
     );
     const lengthDays = VIntCoding.writeVInt(
-        Long.fromNumber(data[1]),
+        Long.fromNumber(this.internal.days),
         reusableBuffers.days,
     );
     const lengthNanoseconds = VIntCoding.writeVInt(
@@ -98,10 +99,8 @@ Duration.prototype.toBuffer = function () {
  * @return {string}
  */
 Duration.prototype.toString = function () {
-    let data = this.internal.getObject();
+    let nanoseconds = bigintToLong(this.internal.getNanoseconds());
     let value = "";
-    console.log(data);
-    let nanoseconds = Long.fromNumber(data[2]).multiply(data[4]).add(data[3]);
     function append(dividend, divisor, unit) {
         if (dividend === 0 || dividend < divisor) {
             return dividend;
@@ -118,12 +117,16 @@ Duration.prototype.toString = function () {
         value += dividend.divide(divisor).toString() + unit;
         return dividend.modulo(divisor);
     }
-    if (data[0] < 0 || data[1] < 0 || nanoseconds.isNegative()) {
+    if (
+        this.internal.months < 0 ||
+        this.internal.days < 0 ||
+        nanoseconds.isNegative()
+    ) {
         value = "-";
     }
-    let remainder = append(Math.abs(data[0]), monthsPerYear, "y");
+    let remainder = append(Math.abs(this.internal.months), monthsPerYear, "y");
     append(remainder, 1, "mo");
-    append(Math.abs(data[1]), 1, "d");
+    append(Math.abs(this.internal.days), 1, "d");
 
     if (!nanoseconds.equals(Long.ZERO)) {
         const nanos = nanoseconds.isNegative()

--- a/lib/types/duration.js
+++ b/lib/types/duration.js
@@ -153,8 +153,6 @@ Duration.prototype.toString = function () {
  * @returns {Duration}
  */
 Duration.fromBuffer = function (buffer) {
-    if ((!buffer) instanceof Buffer)
-        throw new TypeError("Expected Buffer type");
     const offset = { value: 0 };
     const months = VIntCoding.readVInt(buffer, offset).toNumber();
     const days = VIntCoding.readVInt(buffer, offset).toNumber();

--- a/lib/types/duration.js
+++ b/lib/types/duration.js
@@ -36,6 +36,11 @@ const iso8601AlternateRegex =
  */
 class Duration {
     /**
+     * @type {rust.DurationWrapper}
+     * @private
+     */
+    #internal;
+    /**
      * Creates a new instance of {@link Duration}.
      * @param {Number} months The number of months.
      * @param {Number} days The number of days.
@@ -44,15 +49,19 @@ class Duration {
      */
     constructor(months, days, nanoseconds) {
         if (typeof nanoseconds === "bigint") {
-            this.internal = rust.DurationWrapper.new(months, days, nanoseconds);
+            this.#internal = rust.DurationWrapper.new(
+                months,
+                days,
+                nanoseconds,
+            );
         } else if (nanoseconds instanceof Long) {
-            this.internal = rust.DurationWrapper.new(
+            this.#internal = rust.DurationWrapper.new(
                 months,
                 days,
                 longToBigint(nanoseconds),
             );
         } else if (typeof nanoseconds === "number") {
-            this.internal = rust.DurationWrapper.new(
+            this.#internal = rust.DurationWrapper.new(
                 months,
                 days,
                 BigInt(nanoseconds),
@@ -69,9 +78,9 @@ class Duration {
             return false;
         }
         return (
-            this.internal.months === other.internal.months &&
-            this.internal.days === other.internal.days &&
-            this.internal.getNanoseconds() === other.internal.getNanoseconds()
+            this.months === other.months &&
+            this.days === other.days &&
+            this.nanoseconds.compare(other.nanoseconds) === 0
         );
     }
 
@@ -82,9 +91,47 @@ class Duration {
      * @returns {Duration}
      */
     static fromRust(arg) {
-        let res = new Duration(0, 0, 0);
-        res.internal = arg;
+        let res = new Duration(arg.months, arg.days, arg.getNanoseconds());
         return res;
+    }
+
+    /**
+     * Gets the number of months
+     * @readonly
+     * @type {Number}
+     */
+    get months() {
+        return this.#internal.months;
+    }
+
+    set months(_) {
+        throw new SyntaxError("Duration months is read-only");
+    }
+
+    /**
+     * Gets the number of days
+     * @readonly
+     * @type {Number}
+     */
+    get days() {
+        return this.#internal.days;
+    }
+
+    set days(_) {
+        throw new SyntaxError("Duration days is read-only");
+    }
+
+    /**
+     * Gets the number of nanoseconds
+     * @readonly
+     * @type {Long}
+     */
+    get nanoseconds() {
+        return bigintToLong(this.#internal.getNanoseconds());
+    }
+
+    set nanoseconds(_) {
+        throw new SyntaxError("Duration nanoseconds is read-only");
     }
 
     /**
@@ -92,13 +139,13 @@ class Duration {
      * @returns {Buffer}
      */
     toBuffer() {
-        let nanoseconds = bigintToLong(this.internal.getNanoseconds());
+        let nanoseconds = bigintToLong(this.#internal.getNanoseconds());
         const lengthMonths = VIntCoding.writeVInt(
-            Long.fromNumber(this.internal.months),
+            Long.fromNumber(this.#internal.months),
             reusableBuffers.months,
         );
         const lengthDays = VIntCoding.writeVInt(
-            Long.fromNumber(this.internal.days),
+            Long.fromNumber(this.#internal.days),
             reusableBuffers.days,
         );
         const lengthNanoseconds = VIntCoding.writeVInt(
@@ -121,7 +168,7 @@ class Duration {
      * @return {string}
      */
     toString() {
-        let nanoseconds = bigintToLong(this.internal.getNanoseconds());
+        let nanoseconds = bigintToLong(this.#internal.getNanoseconds());
         let value = "";
         function append(dividend, divisor, unit) {
             if (dividend === 0 || dividend < divisor) {
@@ -140,19 +187,19 @@ class Duration {
             return dividend.modulo(divisor);
         }
         if (
-            this.internal.months < 0 ||
-            this.internal.days < 0 ||
+            this.#internal.months < 0 ||
+            this.#internal.days < 0 ||
             nanoseconds.isNegative()
         ) {
             value = "-";
         }
         let remainder = append(
-            Math.abs(this.internal.months),
+            Math.abs(this.#internal.months),
             monthsPerYear,
             "y",
         );
         append(remainder, 1, "mo");
-        append(Math.abs(this.internal.days), 1, "d");
+        append(Math.abs(this.#internal.days), 1, "d");
 
         if (!nanoseconds.equals(Long.ZERO)) {
             const nanos = nanoseconds.isNegative()

--- a/lib/types/results-wrapper.js
+++ b/lib/types/results-wrapper.js
@@ -3,6 +3,7 @@
 const rust = require("../../index");
 const Uuid = require("./uuid");
 const TimeUuid = require("./time-uuid");
+const Duration = require("./duration");
 
 /**
  * Checks the type of value wrapper object and gets it from the underlying value
@@ -22,6 +23,8 @@ function getCqlObject(field) {
             return field.getCounter();
         case rust.CqlType.Double:
             return field.getDouble();
+        case rust.CqlType.Duration:
+            return Duration.fromRust(field.getDuration());
         case rust.CqlType.Float:
             return field.getFloat();
         case rust.CqlType.Int:

--- a/src/result.rs
+++ b/src/result.rs
@@ -5,6 +5,7 @@ use napi::{
 };
 use scylla::{frame::response::result::CqlValue, QueryResult};
 
+use crate::types::duration::DurationWrapper;
 use crate::utils::js_error;
 
 #[napi]
@@ -121,7 +122,7 @@ impl CqlValueWrapper {
             CqlValue::Decimal(_) => CqlType::Decimal, // NOI
             CqlValue::Date(_) => CqlType::Date,       // NOI
             CqlValue::Double(_) => CqlType::Double,
-            CqlValue::Duration(_) => CqlType::Duration, // NOI
+            CqlValue::Duration(_) => CqlType::Duration,
             CqlValue::Empty => CqlType::Empty,
             CqlValue::Float(_) => CqlType::Float,
             CqlValue::Int(_) => CqlType::Int,
@@ -189,6 +190,13 @@ impl CqlValueWrapper {
         }
     }
 
+    #[napi]
+    pub fn get_duration(&self) -> napi::Result<DurationWrapper> {
+        match self.inner.as_cql_duration() {
+            Some(r) => Ok(DurationWrapper::from_cql_duration(r)),
+            None => Err(Self::generic_error("duration")),
+        }
+    }
     #[napi]
     pub fn get_float(&self) -> napi::Result<f32> {
         match self.inner.as_float() {

--- a/src/result_tests.rs
+++ b/src/result_tests.rs
@@ -2,7 +2,7 @@ use std::str::FromStr;
 
 use scylla::frame::{
     response::result::CqlValue,
-    value::{Counter, CqlTimeuuid},
+    value::{Counter, CqlDuration, CqlTimeuuid},
 };
 
 use crate::result::CqlValueWrapper;
@@ -40,6 +40,17 @@ pub fn tests_get_cql_wrapper_counter() -> CqlValueWrapper {
 /// Test function returning sample CqlValueWrapper with Double type
 pub fn tests_get_cql_wrapper_double() -> CqlValueWrapper {
     let element = CqlValue::Double(f64::MAX);
+    CqlValueWrapper { inner: element }
+}
+
+#[napi]
+/// Test function returning sample CqlValueWrapper with Duration type
+pub fn tests_get_cql_wrapper_duration() -> CqlValueWrapper {
+    let element = CqlValue::Duration(CqlDuration {
+        months: 1,
+        days: 2,
+        nanoseconds: 3,
+    });
     CqlValueWrapper { inner: element }
 }
 

--- a/src/types/duration.rs
+++ b/src/types/duration.rs
@@ -1,0 +1,105 @@
+use std::cmp::min;
+
+use napi::{bindgen_prelude::Buffer, Status};
+use scylla::frame::value::{CqlDuration, Value};
+
+#[napi]
+// Will PartialEq or Eq be exposed to napi?
+#[derive(Clone, Debug, Copy, PartialEq, Eq)]
+pub struct Duration {
+    internal: CqlDuration,
+}
+
+const LONG_ONE_THOUSAND: i64 = 1000;
+const NANOS_PER_MICRO: i64 = LONG_ONE_THOUSAND;
+const NANOS_PER_MILLI: i64 = LONG_ONE_THOUSAND * NANOS_PER_MICRO;
+const NANOS_PER_SECOND: i64 = LONG_ONE_THOUSAND * NANOS_PER_MILLI;
+const NANOS_PER_MINUTE: i64 = 60 * NANOS_PER_SECOND;
+const NANOS_PER_HOUR: i64 = 60 * NANOS_PER_MINUTE;
+const MONTHS_PER_YEAR: i32 = 12;
+
+#[napi]
+impl Duration {
+    #[napi]
+    pub fn new(months: i32, days: i32, nanoseconds: i64) -> Self {
+        Duration {
+            internal: CqlDuration {
+                months,
+                days,
+                nanoseconds,
+            },
+        }
+    }
+
+    #[napi]
+    pub fn to_buffer(&self) -> Buffer {
+        let months = self.internal.months.to_ne_bytes();
+        let months = months.as_slice();
+
+        let days = self.internal.days.to_ne_bytes();
+        let days = days.as_slice();
+
+        let nanoseconds = self.internal.nanoseconds.to_ne_bytes();
+        let nanoseconds = nanoseconds.as_slice();
+        [months, days, nanoseconds].concat().into()
+    }
+
+    #[napi]
+    #[allow(clippy::inherent_to_string)]
+    pub fn to_string(&self) -> String {
+        let reminder = self.internal.nanoseconds.abs();
+
+        let hours = reminder / NANOS_PER_HOUR;
+        let reminder = reminder % NANOS_PER_HOUR;
+
+        let minutes = reminder / NANOS_PER_MINUTE;
+        let reminder = reminder % NANOS_PER_MINUTE;
+
+        let seconds = reminder / NANOS_PER_SECOND;
+        let reminder = reminder % NANOS_PER_SECOND;
+
+        let milliseconds = reminder / NANOS_PER_MILLI;
+        let reminder = reminder % NANOS_PER_MILLI;
+
+        let microseconds = reminder / NANOS_PER_MICRO;
+        let reminder = reminder % NANOS_PER_MICRO;
+        let negative_part = if min(
+            self.internal.nanoseconds,
+            min(self.internal.days, self.internal.months).into(),
+        ) < 0
+        {
+            "-"
+        } else {
+            ""
+        };
+
+        let days_part: String = format!(
+            "{}y{}mo{}d",
+            self.internal.months.abs() / MONTHS_PER_YEAR,
+            self.internal.months.abs() % MONTHS_PER_YEAR,
+            self.internal.days.abs(),
+        );
+
+        let ns_part: String = if self.internal.nanoseconds > 0 {
+            format!(
+                "{}h{}m{}s{}ms{}us{}ns",
+                hours, minutes, seconds, milliseconds, microseconds, reminder
+            )
+        } else {
+            "".into()
+        };
+
+        format!("{}{}{}", negative_part, days_part, ns_part)
+    }
+
+    #[napi]
+    // Consider BufferRef
+    pub fn from_buffer(buffer: Buffer) -> napi::Result<Duration> {
+        let tmp = Duration::new(0, 0, 0);
+        let arg: Vec<u8> = buffer.into();
+        tmp.internal
+            .serialize(&mut arg.clone())
+            .map_err(|e| napi::Error::new(Status::GenericFailure, format!("{}", e)))?;
+        Ok(tmp)
+    }
+}

--- a/src/types/duration.rs
+++ b/src/types/duration.rs
@@ -1,34 +1,23 @@
 use napi::bindgen_prelude::BigInt;
+use scylla::frame::value::CqlDuration;
 
-use crate::utils::js_error;
+use crate::utils::bigint_to_i64;
 
 #[napi]
-// Will PartialEq or Eq be exposed to napi?
-#[derive(Clone, Debug, Copy, PartialEq, Eq)]
-pub struct Duration {
+pub struct DurationWrapper {
     pub months: i32,
     pub days: i32,
     pub nanoseconds: i64,
 }
 
 #[napi]
-impl Duration {
+impl DurationWrapper {
     #[napi]
     pub fn new(months: i32, days: i32, ns_bigint: BigInt) -> napi::Result<Self> {
-        let ns = ns_bigint.get_i64();
-        if !ns.1 {
-            return Err(js_error("Invalid use: Should not happen?"));
-        }
-        let nanoseconds: i64 = ns.0
-            * if ns_bigint.sign_bit && ns.0 > 0 {
-                -1
-            } else {
-                1
-            };
-        Ok(Duration {
+        Ok(DurationWrapper {
             months,
             days,
-            nanoseconds,
+            nanoseconds: bigint_to_i64(ns_bigint, "Nanoseconds must not overflow i64")?,
         })
     }
 
@@ -38,5 +27,22 @@ impl Duration {
         let mut res: BigInt = BigInt::from(tmp.abs());
         res.sign_bit = self.nanoseconds < 0;
         res
+    }
+}
+
+impl DurationWrapper {
+    pub fn from_cql_duration(duration: CqlDuration) -> Self {
+        DurationWrapper {
+            months: duration.months,
+            days: duration.days,
+            nanoseconds: duration.nanoseconds,
+        }
+    }
+    pub fn get_cql_duration(&self) -> CqlDuration {
+        CqlDuration {
+            months: self.months,
+            days: self.days,
+            nanoseconds: self.nanoseconds,
+        }
     }
 }

--- a/src/types/duration.rs
+++ b/src/types/duration.rs
@@ -1,5 +1,3 @@
-use std::cmp::min;
-
 use napi::{bindgen_prelude::Buffer, Status};
 use scylla::frame::value::{CqlDuration, Value};
 
@@ -10,18 +8,11 @@ pub struct Duration {
     internal: CqlDuration,
 }
 
-const LONG_ONE_THOUSAND: i64 = 1000;
-const NANOS_PER_MICRO: i64 = LONG_ONE_THOUSAND;
-const NANOS_PER_MILLI: i64 = LONG_ONE_THOUSAND * NANOS_PER_MICRO;
-const NANOS_PER_SECOND: i64 = LONG_ONE_THOUSAND * NANOS_PER_MILLI;
-const NANOS_PER_MINUTE: i64 = 60 * NANOS_PER_SECOND;
-const NANOS_PER_HOUR: i64 = 60 * NANOS_PER_MINUTE;
-const MONTHS_PER_YEAR: i32 = 12;
-
 #[napi]
 impl Duration {
     #[napi]
-    pub fn new(months: i32, days: i32, nanoseconds: i64) -> Self {
+    pub fn new(months: i32, days: i32, ns1: i64, ns2: i64, filler: i64) -> Self {
+        let nanoseconds = ns1 + ns2 * filler;
         Duration {
             internal: CqlDuration {
                 months,
@@ -32,70 +23,22 @@ impl Duration {
     }
 
     #[napi]
-    pub fn to_buffer(&self) -> Buffer {
-        let months = self.internal.months.to_ne_bytes();
-        let months = months.as_slice();
-
-        let days = self.internal.days.to_ne_bytes();
-        let days = days.as_slice();
-
-        let nanoseconds = self.internal.nanoseconds.to_ne_bytes();
-        let nanoseconds = nanoseconds.as_slice();
-        [months, days, nanoseconds].concat().into()
-    }
-
-    #[napi]
-    #[allow(clippy::inherent_to_string)]
-    pub fn to_string(&self) -> String {
-        let reminder = self.internal.nanoseconds.abs();
-
-        let hours = reminder / NANOS_PER_HOUR;
-        let reminder = reminder % NANOS_PER_HOUR;
-
-        let minutes = reminder / NANOS_PER_MINUTE;
-        let reminder = reminder % NANOS_PER_MINUTE;
-
-        let seconds = reminder / NANOS_PER_SECOND;
-        let reminder = reminder % NANOS_PER_SECOND;
-
-        let milliseconds = reminder / NANOS_PER_MILLI;
-        let reminder = reminder % NANOS_PER_MILLI;
-
-        let microseconds = reminder / NANOS_PER_MICRO;
-        let reminder = reminder % NANOS_PER_MICRO;
-        let negative_part = if min(
-            self.internal.nanoseconds,
-            min(self.internal.days, self.internal.months).into(),
-        ) < 0
-        {
-            "-"
-        } else {
-            ""
-        };
-
-        let days_part: String = format!(
-            "{}y{}mo{}d",
-            self.internal.months.abs() / MONTHS_PER_YEAR,
-            self.internal.months.abs() % MONTHS_PER_YEAR,
-            self.internal.days.abs(),
-        );
-
-        let ns_part: String = if self.internal.nanoseconds > 0 {
-            format!(
-                "{}h{}m{}s{}ms{}us{}ns",
-                hours, minutes, seconds, milliseconds, microseconds, reminder
-            )
-        } else {
-            "".into()
-        };
-
-        format!("{}{}{}", negative_part, days_part, ns_part)
+    pub fn get_object(&self) -> napi::Result<Vec<i64>> {
+        let re: i64 = i32::MAX.into();
+        // println!("ns in rust: {}", self.internal.nanoseconds);
+        Ok(vec![
+            self.internal.months.into(),
+            self.internal.days.into(),
+            (self.internal.nanoseconds / re),
+            (self.internal.nanoseconds % re),
+            re,
+        ])
     }
 
     #[napi]
     // Consider BufferRef
     pub fn from_buffer(buffer: Buffer) -> napi::Result<Duration> {
-        let tmp = Duration::new(0, 0, 0);
+        let tmp = Duration::new(2, 0, 0, 0, 0);
         let arg: Vec<u8> = buffer.into();
         tmp.internal
             .serialize(&mut arg.clone())

--- a/src/types/duration.rs
+++ b/src/types/duration.rs
@@ -1,48 +1,42 @@
-use napi::{bindgen_prelude::Buffer, Status};
-use scylla::frame::value::{CqlDuration, Value};
+use napi::bindgen_prelude::BigInt;
+
+use crate::utils::js_error;
 
 #[napi]
 // Will PartialEq or Eq be exposed to napi?
 #[derive(Clone, Debug, Copy, PartialEq, Eq)]
 pub struct Duration {
-    internal: CqlDuration,
+    pub months: i32,
+    pub days: i32,
+    pub nanoseconds: i64,
 }
 
 #[napi]
 impl Duration {
     #[napi]
-    pub fn new(months: i32, days: i32, ns1: i64, ns2: i64, filler: i64) -> Self {
-        let nanoseconds = ns1 + ns2 * filler;
-        Duration {
-            internal: CqlDuration {
-                months,
-                days,
-                nanoseconds,
-            },
+    pub fn new(months: i32, days: i32, ns_bigint: BigInt) -> napi::Result<Self> {
+        let ns = ns_bigint.get_i64();
+        if !ns.1 {
+            return Err(js_error("Invalid use: Should not happen?"));
         }
+        let nanoseconds: i64 = ns.0
+            * if ns_bigint.sign_bit && ns.0 > 0 {
+                -1
+            } else {
+                1
+            };
+        Ok(Duration {
+            months,
+            days,
+            nanoseconds,
+        })
     }
 
     #[napi]
-    pub fn get_object(&self) -> napi::Result<Vec<i64>> {
-        let re: i64 = i32::MAX.into();
-        // println!("ns in rust: {}", self.internal.nanoseconds);
-        Ok(vec![
-            self.internal.months.into(),
-            self.internal.days.into(),
-            (self.internal.nanoseconds / re),
-            (self.internal.nanoseconds % re),
-            re,
-        ])
-    }
-
-    #[napi]
-    // Consider BufferRef
-    pub fn from_buffer(buffer: Buffer) -> napi::Result<Duration> {
-        let tmp = Duration::new(2, 0, 0, 0, 0);
-        let arg: Vec<u8> = buffer.into();
-        tmp.internal
-            .serialize(&mut arg.clone())
-            .map_err(|e| napi::Error::new(Status::GenericFailure, format!("{}", e)))?;
-        Ok(tmp)
+    pub fn get_nanoseconds(&self) -> BigInt {
+        let tmp: i128 = self.nanoseconds.into();
+        let mut res: BigInt = BigInt::from(tmp.abs());
+        res.sign_bit = self.nanoseconds < 0;
+        res
     }
 }

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -1,2 +1,3 @@
+pub mod duration;
 pub mod time_uuid;
 pub mod uuid;

--- a/test/unit/cql-value-wrapper.js
+++ b/test/unit/cql-value-wrapper.js
@@ -4,6 +4,7 @@ const rust = require("../../index");
 const { getCqlObject } = require("../../lib/types/results-wrapper");
 const Uuid = require("../../lib/types/uuid");
 const TimeUuid = require("../../lib/types/time-uuid");
+const Duration = require("../../lib/types/duration");
 
 const maxI64 = BigInt("9223372036854775807");
 const maxI32 = Number(2147483647);
@@ -58,6 +59,22 @@ describe("Cql value wrapper", function () {
         /* Corresponding value: 
         let element = CqlValue::Double(f64::MAX); */
         assert.strictEqual(value, Number.MAX_VALUE);
+    });
+
+    it("should get duration type correctly from napi", function () {
+        let element = rust.testsGetCqlWrapperDuration();
+        let type = element.getType();
+        assert.strictEqual(type, rust.CqlType.Duration);
+        let value = getCqlObject(element);
+        assert.instanceOf(value, Duration);
+        /* Corresponding value: 
+        let element = CqlValue::Duration(CqlDuration {
+            months: 1,
+            days: 2,
+            nanoseconds: 3,
+        }); */
+        let expected_duration = new Duration(1, 2, 3);
+        assert.equal(expected_duration.equals(value), true);
     });
 
     it("should get float type correctly from napi", function () {

--- a/test/unit/duration-type-tests.js
+++ b/test/unit/duration-type-tests.js
@@ -43,6 +43,10 @@ const values = [
         new Duration(0, 0, Long.fromString("9223372036854775807")),
         "0000fffffffffffffffffe",
     ],
+    [
+        new Duration(0, 0, Long.fromString("-9223372036854775")),
+        "0000fe4189374bc6a7ed",
+    ],
 ];
 
 describe("Duration", function () {
@@ -121,6 +125,37 @@ describe("Duration", function () {
                     return;
                 }
                 assert.strictEqual(item[0].toString(), item[2]);
+            });
+        });
+    });
+    describe("constructor type validation", function () {
+        it("should create duration type correctly", function () {
+            let keys = [0, Long.ZERO, 123, BigInt(0)];
+            keys.forEach(function (item) {
+                new Duration(0, 0, item);
+            });
+            new Duration(0, 0, 0);
+        });
+    });
+    describe("constructor type validation (invalid types)", function () {
+        it("should throw error when creating from invalid types", function () {
+            let ns_keys = [
+                "0",
+                0xfffffffffffffffff,
+                { _: 1 },
+                [0],
+                BigInt("213769213769213769213769"),
+            ];
+            ns_keys.forEach(function (item) {
+                assert.throws(() => {
+                    new Duration(0, 0, item);
+                }, Error);
+            });
+            let days_keys = ["0", Long.ZERO, BigInt(0), { _: 1 }, [0]];
+            days_keys.forEach(function (item) {
+                assert.throws(() => {
+                    new Duration(0, item, 0);
+                }, Error);
             });
         });
     });

--- a/test/unit/duration-type-tests.js
+++ b/test/unit/duration-type-tests.js
@@ -159,6 +159,44 @@ describe("Duration", function () {
             });
         });
     });
+    describe("setter errors", function () {
+        it("should validate if months setter throws an error", function () {
+            assert.throws(
+                function () {
+                    let duration = new Duration(0, 0, 0);
+                    duration.months = 1;
+                },
+                {
+                    name: "SyntaxError",
+                    message: "Duration months is read-only",
+                },
+            );
+        });
+        it("should validate if days setter throws an error", function () {
+            assert.throws(
+                function () {
+                    let duration = new Duration(0, 0, 0);
+                    duration.days = 1;
+                },
+                {
+                    name: "SyntaxError",
+                    message: "Duration days is read-only",
+                },
+            );
+        });
+        it("should validate if nanoseconds setter throws an error", function () {
+            assert.throws(
+                function () {
+                    let duration = new Duration(0, 0, 0);
+                    duration.nanoseconds = 1;
+                },
+                {
+                    name: "SyntaxError",
+                    message: "Duration nanoseconds is read-only",
+                },
+            );
+        });
+    });
 });
 
 /**


### PR DESCRIPTION
Second attempt of merging #5. Now in correct way and with just duration type. (Other will be in separate PR)

This is an implementation of one of the datatype used by the database. The current approch keeps the internal data of the type in object created in rust, while all the processing of this object is done in JS part (it usses mostly unchanged datastax code). Appart from diffrent behaviour in case of providing unexpected type in the constructor, everything should work the same way as in old implementation. If not, treat it as a bug.

This is a example implementation. The goal is to have some kind of example how to implement datastax custom types.
Current approach keeps the data in the rust object, but leaves all the processing that is done in the js part unchanged.
As this type is analog to CqlDuration used by the rust driver, there should be a way to create Duration object from CqlDuration, which is implemented.