### PR TITLE
UUID type

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ scylla = { git = "https://github.com/scylladb/scylla-rust-driver.git", rev = "v0
 ] }
 tokio = { version = "1.34", features = ["full"] }
 futures = "0.3"
+uuid = "1"
 
 
 [build-dependencies]

--- a/index.d.ts
+++ b/index.d.ts
@@ -54,6 +54,10 @@ export declare function testsGetCqlWrapperSet(): CqlValueWrapper
 export declare function testsGetCqlWrapperSmallInt(): CqlValueWrapper
 /** Test function returning sample CqlValueWrapper with TinyInt type */
 export declare function testsGetCqlWrapperTinyInt(): CqlValueWrapper
+/** Test function returning sample CqlValueWrapper with Uuid type */
+export declare function testsGetCqlWrapperUuid(): CqlValueWrapper
+/** Test function returning sample CqlValueWrapper with Timeuuid type */
+export declare function testsGetCqlWrapperTimeUuid(): CqlValueWrapper
 export declare class PlainTextAuthProvider {
   id: number
   static new(): PlainTextAuthProvider
@@ -84,6 +88,8 @@ export declare class CqlValueWrapper {
   getSet(): Array<CqlValueWrapper>
   getSmallInt(): number
   getTinyInt(): number
+  getUuid(): UuidWrapper
+  getTimeUuid(): TimeUuidWrapper
 }
 export declare class SessionOptions {
   connectPoints: Array<string>
@@ -92,4 +98,11 @@ export declare class SessionOptions {
 export declare class SessionWrapper {
   static createSession(options: SessionOptions): Promise<SessionWrapper>
   queryUnpagedNoValues(query: string): Promise<QueryResultWrapper>
+}
+export declare class TimeUuidWrapper {
+  getBuffer(): Buffer
+}
+export declare class UuidWrapper {
+  static new(buffer: Buffer): UuidWrapper
+  getBuffer(): Buffer
 }

--- a/index.js
+++ b/index.js
@@ -310,7 +310,7 @@ if (!nativeBinding) {
   throw new Error(`Failed to load native binding`)
 }
 
-const { testConnection, PlainTextAuthProvider, QueryResultWrapper, RowWrapper, CqlValueWrapper, CqlType, testsGetCqlWrapperAscii, testsGetCqlWrapperBoolean, testsGetCqlWrapperBlob, testsGetCqlWrapperCounter, testsGetCqlWrapperDouble, testsGetCqlWrapperFloat, testsGetCqlWrapperInt, testsGetCqlWrapperText, testsGetCqlWrapperSet, testsGetCqlWrapperSmallInt, testsGetCqlWrapperTinyInt, SessionOptions, SessionWrapper } = nativeBinding
+const { testConnection, PlainTextAuthProvider, QueryResultWrapper, RowWrapper, CqlValueWrapper, CqlType, testsGetCqlWrapperAscii, testsGetCqlWrapperBoolean, testsGetCqlWrapperBlob, testsGetCqlWrapperCounter, testsGetCqlWrapperDouble, testsGetCqlWrapperFloat, testsGetCqlWrapperInt, testsGetCqlWrapperText, testsGetCqlWrapperSet, testsGetCqlWrapperSmallInt, testsGetCqlWrapperTinyInt, testsGetCqlWrapperUuid, testsGetCqlWrapperTimeUuid, SessionOptions, SessionWrapper, TimeUuidWrapper, UuidWrapper } = nativeBinding
 
 module.exports.testConnection = testConnection
 module.exports.PlainTextAuthProvider = PlainTextAuthProvider
@@ -329,5 +329,9 @@ module.exports.testsGetCqlWrapperText = testsGetCqlWrapperText
 module.exports.testsGetCqlWrapperSet = testsGetCqlWrapperSet
 module.exports.testsGetCqlWrapperSmallInt = testsGetCqlWrapperSmallInt
 module.exports.testsGetCqlWrapperTinyInt = testsGetCqlWrapperTinyInt
+module.exports.testsGetCqlWrapperUuid = testsGetCqlWrapperUuid
+module.exports.testsGetCqlWrapperTimeUuid = testsGetCqlWrapperTimeUuid
 module.exports.SessionOptions = SessionOptions
 module.exports.SessionWrapper = SessionWrapper
+module.exports.TimeUuidWrapper = TimeUuidWrapper
+module.exports.UuidWrapper = UuidWrapper

--- a/lib/types/results-wrapper.js
+++ b/lib/types/results-wrapper.js
@@ -2,6 +2,7 @@
 
 const rust = require("../../index");
 const Uuid = require("./uuid");
+const TimeUuid = require("./time-uuid");
 
 /**
  * Checks the type of value wrapper object and gets it from the underlying value
@@ -39,6 +40,8 @@ function getCqlObject(field) {
             return field.getTinyInt();
         case rust.CqlType.Uuid:
             return Uuid.fromRust(field.getUuid());
+        case rust.CqlType.Timeuuid:
+            return TimeUuid.fromRust(field.getTimeUuid());
 
         default:
             // Temporarily returning string representation of the field

--- a/lib/types/results-wrapper.js
+++ b/lib/types/results-wrapper.js
@@ -1,6 +1,7 @@
 "use strict";
 
 const rust = require("../../index");
+const Uuid = require("./uuid");
 
 /**
  * Checks the type of value wrapper object and gets it from the underlying value
@@ -36,6 +37,8 @@ function getCqlObject(field) {
             return field.getSmallInt();
         case rust.CqlType.TinyInt:
             return field.getTinyInt();
+        case rust.CqlType.Uuid:
+            return Uuid.fromRust(field.getUuid());
 
         default:
             // Temporarily returning string representation of the field

--- a/lib/types/time-uuid.js
+++ b/lib/types/time-uuid.js
@@ -45,9 +45,7 @@ let _ticksForCurrentTime = 0;
 let _lastTimestamp = 0;
 
 /**
- * @class
- * @classdesc Represents an immutable version 1 universally unique identifier (UUID). A UUID represents a 128-bit value.
- * <p>Usage: <code>TimeUuid.now()</code></p>
+ * Represents an immutable version 1 universally unique identifier (UUID). A UUID represents a 128-bit value.
  * @extends module:types~Uuid
  */
 class TimeUuid extends Uuid {
@@ -55,28 +53,27 @@ class TimeUuid extends Uuid {
      * Creates a new instance of Uuid based on the parameters provided according to rfc4122.
      * If any of the arguments is not provided, it will be randomly generated, except for the date that will use the current
      * date.
-     * <p>
-     *   Note that when nodeId and/or clockId portions are not provided, the constructor will generate them using
-     *   <code>crypto.randomBytes()</code>. As it's possible that <code>crypto.randomBytes()</code> might block, it's
-     *   recommended that you use the callback-based version of the static methods <code>fromDate()</code> or
-     *   <code>now()</code> in that case.
-     * </p>
-     * @param {Date} [value] The datetime for the instance, if not provided, it will use the current Date.
+     *
+     * If nodeId and/or clockId portions are not provided, the constructor will generate them using
+     * ``crypto.randomBytes()``. As it's possible that ``crypto.randomBytes()`` might block, it's
+     * recommended that you use the callback-based version of the static methods ``fromDate()`` or
+     * ``now()``in that case.
+     *
+     * @param {Date} [date] The date for the instance. If not provided, current Date will be used.
      * @param {Number} [ticks] A number from 0 to 10000 representing the 100-nanoseconds units for this instance to fill in the information not available in the Date,
      * as Ecmascript Dates have only milliseconds precision.
      * @param {String|Buffer} [nodeId] A 6-length Buffer or string of 6 ascii characters representing the node identifier, ie: 'host01'.
      * @param {String|Buffer} [clockId] A 2-length Buffer or string of 6 ascii characters representing the clock identifier.
-     * @constructor
      */
-    constructor(value, ticks, nodeId, clockId) {
+    constructor(date, ticks, nodeId, clockId) {
         let buffer;
-        if (value instanceof Buffer) {
-            if (value.length !== 16) {
+        if (date instanceof Buffer) {
+            if (date.length !== 16) {
                 throw new Error("Buffer for v1 uuid not valid");
             }
-            buffer = value;
+            buffer = date;
         } else {
-            buffer = generateBuffer(value, ticks, nodeId, clockId);
+            buffer = generateBuffer(date, ticks, nodeId, clockId);
         }
         super(buffer);
     }
@@ -91,13 +88,13 @@ class TimeUuid extends Uuid {
      * @param {String|Buffer} [clockId] A 2-length Buffer or string of 6 ascii characters representing the clock identifier.
      * If not provided a random clockId will be generated.
      * @param {Function} [callback] An optional callback to be invoked with the error as first parameter and the created
-     * <code>TimeUuid</code> as second parameter. When a callback is provided, the random portions of the
-     * <code>TimeUuid</code> instance are created asynchronously.
-     * <p>
-     *   When nodeId and/or clockId portions are not provided, this method will generate them using
-     *   <code>crypto.randomBytes()</code>. As it's possible that <code>crypto.randomBytes()</code> might block, it's
-     *   recommended that you use the callback-based version of this method in that case.
-     * </p>
+     * ``TimeUuid`` as second parameter. When a callback is provided, the random portions of the
+     * ``TimeUuid`` instance are created asynchronously.
+     *
+     *  When nodeId and/or clockId portions are not provided, this method will generate them using
+     *  ``crypto.randomBytes()``. As it's possible that ``crypto.randomBytes()`` might block, it's
+     *  recommended that you use the callback-based version of this method in that case.
+     *
      * @example <caption>Generate a TimeUuid from a ECMAScript Date</caption>
      * const timeuuid = TimeUuid.fromDate(new Date());
      * @example <caption>Generate a TimeUuid from a Date with ticks portion</caption>
@@ -155,7 +152,7 @@ class TimeUuid extends Uuid {
 
     /**
      * Parses a string representation of a TimeUuid
-     * @param {String} value
+     * @param {String} value should be in 00000000-0000-0000-0000-000000000000 format
      * @returns {TimeUuid}
      */
     static fromString(value) {
@@ -163,7 +160,10 @@ class TimeUuid extends Uuid {
     }
 
     /**
-     * Returns the smaller possible type 1 uuid with the provided Date.
+     * Returns the smallest possible type 1 uuid with the provided Date.
+     * @param {Date} date
+     * @param {Number} ticks
+     * @returns {TimeUuid}
      */
     static min(date, ticks) {
         return new TimeUuid(date, ticks, minNodeId, minClockId);
@@ -171,6 +171,9 @@ class TimeUuid extends Uuid {
 
     /**
      * Returns the biggest possible type 1 uuid with the provided Date.
+     * @param {Date} date
+     * @param {Number} ticks
+     * @returns {TimeUuid}
      */
     static max(date, ticks) {
         return new TimeUuid(date, ticks, maxNodeId, maxClockId);
@@ -183,13 +186,13 @@ class TimeUuid extends Uuid {
      * @param {String|Buffer} [clockId] A 2-length Buffer or string of 6 ascii characters representing the clock identifier.
      * If not provided a random clockId will be generated.
      * @param {Function} [callback] An optional callback to be invoked with the error as first parameter and the created
-     * <code>TimeUuid</code> as second parameter. When a callback is provided, the random portions of the
-     * <code>TimeUuid</code> instance are created asynchronously.
-     * <p>
-     *   When nodeId and/or clockId portions are not provided, this method will generate them using
-     *   <code>crypto.randomBytes()</code>. As it's possible that <code>crypto.randomBytes()</code> might block, it's
-     *   recommended that you use the callback-based version of this method in that case.
-     * </p>
+     * ``TimeUuid`` as second parameter. When a callback is provided, the random portions of the
+     * ``TimeUuid`` instance are created asynchronously.
+     *
+     * When nodeId and/or clockId portions are not provided, this method will generate them using
+     * ``crypto.randomBytes()``. As it's possible that ``crypto.randomBytes()`` might block, it's
+     * recommended that you use the callback-based version of this method in that case.
+     *
      * @example <caption>Generate a TimeUuid from a Date without any random portion</caption>
      * const timeuuid = TimeUuid.now('host01', '02');
      * @example <caption>Generate a TimeUuid with random node and clock identifiers</caption>
@@ -256,10 +259,19 @@ class TimeUuid extends Uuid {
     getNodeIdString() {
         return this.buffer.slice(10).toString("ascii");
     }
+
+    /**
+     * @package
+     * @param {rust.TimeUuidWrapper} buffer
+     */
+    static fromRust(buffer) {
+        const uuid = new Uuid(buffer.getBuffer());
+        return TimeUuid.fromString(uuid.toString());
+    }
 }
 
 function writeTime(buffer, time, ticks) {
-    //value time expressed in ticks precision
+    // value time expressed in ticks precision
     const val = Long.fromNumber(time + _unixToGregorian)
         .multiply(Long.fromNumber(10000))
         .add(Long.fromNumber(ticks));
@@ -281,7 +293,7 @@ function getClockId(clockId) {
         buffer = utils.allocBufferFromString(clockId, "ascii");
     }
     if (!(buffer instanceof Buffer)) {
-        //Generate
+        // Generate
         buffer = getRandomBytes(2);
     } else if (buffer.length !== 2) {
         throw new Error("Clock identifier must have 2 bytes");
@@ -301,7 +313,7 @@ function getNodeId(nodeId) {
         buffer = utils.allocBufferFromString(nodeId, "ascii");
     }
     if (!(buffer instanceof Buffer)) {
-        //Generate
+        // Generate
         buffer = getRandomBytes(6);
     } else if (buffer.length !== 6) {
         throw new Error("Node identifier must have 6 bytes");
@@ -375,24 +387,24 @@ function generateBuffer(date, ticks, nodeId, clockId) {
     nodeId = getNodeId(nodeId);
     clockId = getClockId(clockId);
     const buffer = utils.allocBufferUnsafe(16);
-    //Positions 0-7 Timestamp
+    // Positions 0-7 Timestamp
     writeTime(buffer, timeWithTicks.time, timeWithTicks.ticks);
-    //Position 8-9 Clock
+    // Position 8-9 Clock
     clockId.copy(buffer, 8, 0);
-    //Positions 10-15 Node
+    // Positions 10-15 Node
     nodeId.copy(buffer, 10, 0);
-    //Version Byte: Time based
-    //0001xxxx
-    //turn off first 4 bits
+    // Version Byte: Time based
+    // 0001xxxx
+    // turn off first 4 bits
     buffer[6] = buffer[6] & 0x0f;
     //turn on fifth bit
     buffer[6] = buffer[6] | 0x10;
 
-    //IETF Variant Byte: 1.0.x
-    //10xxxxxx
-    //turn off first 2 bits
+    // IETF Variant Byte: 1.0.x
+    // 10xxxxxx
+    // turn off first 2 bits
     buffer[8] = buffer[8] & 0x3f;
-    //turn on first bit
+    // turn on first bit
     buffer[8] = buffer[8] | 0x80;
     return buffer;
 }

--- a/lib/types/time-uuid.js
+++ b/lib/types/time-uuid.js
@@ -45,216 +45,218 @@ let _ticksForCurrentTime = 0;
 let _lastTimestamp = 0;
 
 /**
- * Creates a new instance of Uuid based on the parameters provided according to rfc4122.
- * If any of the arguments is not provided, it will be randomly generated, except for the date that will use the current
- * date.
- * <p>
- *   Note that when nodeId and/or clockId portions are not provided, the constructor will generate them using
- *   <code>crypto.randomBytes()</code>. As it's possible that <code>crypto.randomBytes()</code> might block, it's
- *   recommended that you use the callback-based version of the static methods <code>fromDate()</code> or
- *   <code>now()</code> in that case.
- * </p>
  * @class
  * @classdesc Represents an immutable version 1 universally unique identifier (UUID). A UUID represents a 128-bit value.
  * <p>Usage: <code>TimeUuid.now()</code></p>
  * @extends module:types~Uuid
- * @param {Date} [value] The datetime for the instance, if not provided, it will use the current Date.
- * @param {Number} [ticks] A number from 0 to 10000 representing the 100-nanoseconds units for this instance to fill in the information not available in the Date,
- * as Ecmascript Dates have only milliseconds precision.
- * @param {String|Buffer} [nodeId] A 6-length Buffer or string of 6 ascii characters representing the node identifier, ie: 'host01'.
- * @param {String|Buffer} [clockId] A 2-length Buffer or string of 6 ascii characters representing the clock identifier.
- * @constructor
  */
-function TimeUuid(value, ticks, nodeId, clockId) {
-    let buffer;
-    if (value instanceof Buffer) {
-        if (value.length !== 16) {
-            throw new Error("Buffer for v1 uuid not valid");
+class TimeUuid extends Uuid {
+    /**
+     * Creates a new instance of Uuid based on the parameters provided according to rfc4122.
+     * If any of the arguments is not provided, it will be randomly generated, except for the date that will use the current
+     * date.
+     * <p>
+     *   Note that when nodeId and/or clockId portions are not provided, the constructor will generate them using
+     *   <code>crypto.randomBytes()</code>. As it's possible that <code>crypto.randomBytes()</code> might block, it's
+     *   recommended that you use the callback-based version of the static methods <code>fromDate()</code> or
+     *   <code>now()</code> in that case.
+     * </p>
+     * @param {Date} [value] The datetime for the instance, if not provided, it will use the current Date.
+     * @param {Number} [ticks] A number from 0 to 10000 representing the 100-nanoseconds units for this instance to fill in the information not available in the Date,
+     * as Ecmascript Dates have only milliseconds precision.
+     * @param {String|Buffer} [nodeId] A 6-length Buffer or string of 6 ascii characters representing the node identifier, ie: 'host01'.
+     * @param {String|Buffer} [clockId] A 2-length Buffer or string of 6 ascii characters representing the clock identifier.
+     * @constructor
+     */
+    constructor(value, ticks, nodeId, clockId) {
+        let buffer;
+        if (value instanceof Buffer) {
+            if (value.length !== 16) {
+                throw new Error("Buffer for v1 uuid not valid");
+            }
+            buffer = value;
+        } else {
+            buffer = generateBuffer(value, ticks, nodeId, clockId);
         }
-        buffer = value;
-    } else {
-        buffer = generateBuffer(value, ticks, nodeId, clockId);
+        super(buffer);
     }
-    Uuid.call(this, buffer);
+
+    /**
+     * Generates a TimeUuid instance based on the Date provided using random node and clock values.
+     * @param {Date} date Date to generate the v1 uuid.
+     * @param {Number} [ticks] A number from 0 to 10000 representing the 100-nanoseconds units for this instance to fill in the information not available in the Date,
+     * as Ecmascript Dates have only milliseconds precision.
+     * @param {String|Buffer} [nodeId] A 6-length Buffer or string of 6 ascii characters representing the node identifier, ie: 'host01'.
+     * If not provided, a random nodeId will be generated.
+     * @param {String|Buffer} [clockId] A 2-length Buffer or string of 6 ascii characters representing the clock identifier.
+     * If not provided a random clockId will be generated.
+     * @param {Function} [callback] An optional callback to be invoked with the error as first parameter and the created
+     * <code>TimeUuid</code> as second parameter. When a callback is provided, the random portions of the
+     * <code>TimeUuid</code> instance are created asynchronously.
+     * <p>
+     *   When nodeId and/or clockId portions are not provided, this method will generate them using
+     *   <code>crypto.randomBytes()</code>. As it's possible that <code>crypto.randomBytes()</code> might block, it's
+     *   recommended that you use the callback-based version of this method in that case.
+     * </p>
+     * @example <caption>Generate a TimeUuid from a ECMAScript Date</caption>
+     * const timeuuid = TimeUuid.fromDate(new Date());
+     * @example <caption>Generate a TimeUuid from a Date with ticks portion</caption>
+     * const timeuuid = TimeUuid.fromDate(new Date(), 1203);
+     * @example <caption>Generate a TimeUuid from a Date without any random portion</caption>
+     * const timeuuid = TimeUuid.fromDate(new Date(), 1203, 'host01', '02');
+     * @example <caption>Generate a TimeUuid from a Date with random node and clock identifiers</caption>
+     * TimeUuid.fromDate(new Date(), 1203, function (err, timeuuid) {
+     *   // do something with the generated timeuuid
+     * });
+     */
+    static fromDate(date, ticks, nodeId, clockId, callback) {
+        if (typeof ticks === "function") {
+            callback = ticks;
+            ticks = nodeId = clockId = null;
+        } else if (typeof nodeId === "function") {
+            callback = nodeId;
+            nodeId = clockId = null;
+        } else if (typeof clockId === "function") {
+            callback = clockId;
+            clockId = null;
+        }
+
+        if (!callback) {
+            return new TimeUuid(date, ticks, nodeId, clockId);
+        }
+
+        utils.parallel(
+            [
+                (next) =>
+                    getOrGenerateRandom(nodeId, 6, (err, buffer) =>
+                        next(err, (nodeId = buffer)),
+                    ),
+                (next) =>
+                    getOrGenerateRandom(clockId, 2, (err, buffer) =>
+                        next(err, (clockId = buffer)),
+                    ),
+            ],
+            (err) => {
+                if (err) {
+                    return callback(err);
+                }
+
+                let timeUuid;
+                try {
+                    timeUuid = new TimeUuid(date, ticks, nodeId, clockId);
+                } catch (e) {
+                    return callback(e);
+                }
+
+                callback(null, timeUuid);
+            },
+        );
+    }
+
+    /**
+     * Parses a string representation of a TimeUuid
+     * @param {String} value
+     * @returns {TimeUuid}
+     */
+    static fromString(value) {
+        return new TimeUuid(Uuid.fromString(value).getBuffer());
+    }
+
+    /**
+     * Returns the smaller possible type 1 uuid with the provided Date.
+     */
+    static min(date, ticks) {
+        return new TimeUuid(date, ticks, minNodeId, minClockId);
+    }
+
+    /**
+     * Returns the biggest possible type 1 uuid with the provided Date.
+     */
+    static max(date, ticks) {
+        return new TimeUuid(date, ticks, maxNodeId, maxClockId);
+    }
+
+    /**
+     * Generates a TimeUuid instance based on the current date using random node and clock values.
+     * @param {String|Buffer} [nodeId] A 6-length Buffer or string of 6 ascii characters representing the node identifier, ie: 'host01'.
+     * If not provided, a random nodeId will be generated.
+     * @param {String|Buffer} [clockId] A 2-length Buffer or string of 6 ascii characters representing the clock identifier.
+     * If not provided a random clockId will be generated.
+     * @param {Function} [callback] An optional callback to be invoked with the error as first parameter and the created
+     * <code>TimeUuid</code> as second parameter. When a callback is provided, the random portions of the
+     * <code>TimeUuid</code> instance are created asynchronously.
+     * <p>
+     *   When nodeId and/or clockId portions are not provided, this method will generate them using
+     *   <code>crypto.randomBytes()</code>. As it's possible that <code>crypto.randomBytes()</code> might block, it's
+     *   recommended that you use the callback-based version of this method in that case.
+     * </p>
+     * @example <caption>Generate a TimeUuid from a Date without any random portion</caption>
+     * const timeuuid = TimeUuid.now('host01', '02');
+     * @example <caption>Generate a TimeUuid with random node and clock identifiers</caption>
+     * TimeUuid.now(function (err, timeuuid) {
+     *   // do something with the generated timeuuid
+     * });
+     * @example <caption>Generate a TimeUuid based on the current date (might block)</caption>
+     * const timeuuid = TimeUuid.now();
+     */
+    static now(nodeId, clockId, callback) {
+        return TimeUuid.fromDate(null, null, nodeId, clockId, callback);
+    }
+
+    /**
+     * Gets the Date and 100-nanoseconds units representation of this instance.
+     * @returns {{date: Date, ticks: Number}}
+     */
+    getDatePrecision() {
+        const timeLow = this.buffer.readUInt32BE(0);
+
+        let timeHigh = 0;
+        timeHigh |= (this.buffer[4] & 0xff) << 8;
+        timeHigh |= this.buffer[5] & 0xff;
+        timeHigh |= (this.buffer[6] & 0x0f) << 24;
+        timeHigh |= (this.buffer[7] & 0xff) << 16;
+
+        const val = Long.fromBits(timeLow, timeHigh);
+        const ticksInMsLong = Long.fromNumber(_ticksInMs);
+        const ticks = val.modulo(ticksInMsLong);
+        const time = val
+            .div(ticksInMsLong)
+            .subtract(Long.fromNumber(_unixToGregorian));
+        return { date: new Date(time.toNumber()), ticks: ticks.toNumber() };
+    }
+
+    /**
+     * Gets the Date representation of this instance.
+     * @returns {Date}
+     */
+    getDate() {
+        return this.getDatePrecision().date;
+    }
+
+    /**
+     * Returns the node id this instance
+     * @returns {Buffer}
+     */
+    getNodeId() {
+        return this.buffer.slice(10);
+    }
+
+    /**
+     * Returns the clock id this instance, with the variant applied (first 2 msb being 1 and 0).
+     * @returns {Buffer}
+     */
+    getClockId() {
+        return this.buffer.slice(8, 10);
+    }
+
+    /**
+     * Returns the node id this instance as an ascii string
+     * @returns {String}
+     */
+    getNodeIdString() {
+        return this.buffer.slice(10).toString("ascii");
+    }
 }
-
-util.inherits(TimeUuid, Uuid);
-
-/**
- * Generates a TimeUuid instance based on the Date provided using random node and clock values.
- * @param {Date} date Date to generate the v1 uuid.
- * @param {Number} [ticks] A number from 0 to 10000 representing the 100-nanoseconds units for this instance to fill in the information not available in the Date,
- * as Ecmascript Dates have only milliseconds precision.
- * @param {String|Buffer} [nodeId] A 6-length Buffer or string of 6 ascii characters representing the node identifier, ie: 'host01'.
- * If not provided, a random nodeId will be generated.
- * @param {String|Buffer} [clockId] A 2-length Buffer or string of 6 ascii characters representing the clock identifier.
- * If not provided a random clockId will be generated.
- * @param {Function} [callback] An optional callback to be invoked with the error as first parameter and the created
- * <code>TimeUuid</code> as second parameter. When a callback is provided, the random portions of the
- * <code>TimeUuid</code> instance are created asynchronously.
- * <p>
- *   When nodeId and/or clockId portions are not provided, this method will generate them using
- *   <code>crypto.randomBytes()</code>. As it's possible that <code>crypto.randomBytes()</code> might block, it's
- *   recommended that you use the callback-based version of this method in that case.
- * </p>
- * @example <caption>Generate a TimeUuid from a ECMAScript Date</caption>
- * const timeuuid = TimeUuid.fromDate(new Date());
- * @example <caption>Generate a TimeUuid from a Date with ticks portion</caption>
- * const timeuuid = TimeUuid.fromDate(new Date(), 1203);
- * @example <caption>Generate a TimeUuid from a Date without any random portion</caption>
- * const timeuuid = TimeUuid.fromDate(new Date(), 1203, 'host01', '02');
- * @example <caption>Generate a TimeUuid from a Date with random node and clock identifiers</caption>
- * TimeUuid.fromDate(new Date(), 1203, function (err, timeuuid) {
- *   // do something with the generated timeuuid
- * });
- */
-TimeUuid.fromDate = function (date, ticks, nodeId, clockId, callback) {
-    if (typeof ticks === "function") {
-        callback = ticks;
-        ticks = nodeId = clockId = null;
-    } else if (typeof nodeId === "function") {
-        callback = nodeId;
-        nodeId = clockId = null;
-    } else if (typeof clockId === "function") {
-        callback = clockId;
-        clockId = null;
-    }
-
-    if (!callback) {
-        return new TimeUuid(date, ticks, nodeId, clockId);
-    }
-
-    utils.parallel(
-        [
-            (next) =>
-                getOrGenerateRandom(nodeId, 6, (err, buffer) =>
-                    next(err, (nodeId = buffer)),
-                ),
-            (next) =>
-                getOrGenerateRandom(clockId, 2, (err, buffer) =>
-                    next(err, (clockId = buffer)),
-                ),
-        ],
-        (err) => {
-            if (err) {
-                return callback(err);
-            }
-
-            let timeUuid;
-            try {
-                timeUuid = new TimeUuid(date, ticks, nodeId, clockId);
-            } catch (e) {
-                return callback(e);
-            }
-
-            callback(null, timeUuid);
-        },
-    );
-};
-
-/**
- * Parses a string representation of a TimeUuid
- * @param {String} value
- * @returns {TimeUuid}
- */
-TimeUuid.fromString = function (value) {
-    return new TimeUuid(Uuid.fromString(value).getBuffer());
-};
-
-/**
- * Returns the smaller possible type 1 uuid with the provided Date.
- */
-TimeUuid.min = function (date, ticks) {
-    return new TimeUuid(date, ticks, minNodeId, minClockId);
-};
-
-/**
- * Returns the biggest possible type 1 uuid with the provided Date.
- */
-TimeUuid.max = function (date, ticks) {
-    return new TimeUuid(date, ticks, maxNodeId, maxClockId);
-};
-
-/**
- * Generates a TimeUuid instance based on the current date using random node and clock values.
- * @param {String|Buffer} [nodeId] A 6-length Buffer or string of 6 ascii characters representing the node identifier, ie: 'host01'.
- * If not provided, a random nodeId will be generated.
- * @param {String|Buffer} [clockId] A 2-length Buffer or string of 6 ascii characters representing the clock identifier.
- * If not provided a random clockId will be generated.
- * @param {Function} [callback] An optional callback to be invoked with the error as first parameter and the created
- * <code>TimeUuid</code> as second parameter. When a callback is provided, the random portions of the
- * <code>TimeUuid</code> instance are created asynchronously.
- * <p>
- *   When nodeId and/or clockId portions are not provided, this method will generate them using
- *   <code>crypto.randomBytes()</code>. As it's possible that <code>crypto.randomBytes()</code> might block, it's
- *   recommended that you use the callback-based version of this method in that case.
- * </p>
- * @example <caption>Generate a TimeUuid from a Date without any random portion</caption>
- * const timeuuid = TimeUuid.now('host01', '02');
- * @example <caption>Generate a TimeUuid with random node and clock identifiers</caption>
- * TimeUuid.now(function (err, timeuuid) {
- *   // do something with the generated timeuuid
- * });
- * @example <caption>Generate a TimeUuid based on the current date (might block)</caption>
- * const timeuuid = TimeUuid.now();
- */
-TimeUuid.now = function (nodeId, clockId, callback) {
-    return TimeUuid.fromDate(null, null, nodeId, clockId, callback);
-};
-
-/**
- * Gets the Date and 100-nanoseconds units representation of this instance.
- * @returns {{date: Date, ticks: Number}}
- */
-TimeUuid.prototype.getDatePrecision = function () {
-    const timeLow = this.buffer.readUInt32BE(0);
-
-    let timeHigh = 0;
-    timeHigh |= (this.buffer[4] & 0xff) << 8;
-    timeHigh |= this.buffer[5] & 0xff;
-    timeHigh |= (this.buffer[6] & 0x0f) << 24;
-    timeHigh |= (this.buffer[7] & 0xff) << 16;
-
-    const val = Long.fromBits(timeLow, timeHigh);
-    const ticksInMsLong = Long.fromNumber(_ticksInMs);
-    const ticks = val.modulo(ticksInMsLong);
-    const time = val
-        .div(ticksInMsLong)
-        .subtract(Long.fromNumber(_unixToGregorian));
-    return { date: new Date(time.toNumber()), ticks: ticks.toNumber() };
-};
-
-/**
- * Gets the Date representation of this instance.
- * @returns {Date}
- */
-TimeUuid.prototype.getDate = function () {
-    return this.getDatePrecision().date;
-};
-
-/**
- * Returns the node id this instance
- * @returns {Buffer}
- */
-TimeUuid.prototype.getNodeId = function () {
-    return this.buffer.slice(10);
-};
-
-/**
- * Returns the clock id this instance, with the variant applied (first 2 msb being 1 and 0).
- * @returns {Buffer}
- */
-TimeUuid.prototype.getClockId = function () {
-    return this.buffer.slice(8, 10);
-};
-
-/**
- * Returns the node id this instance as an ascii string
- * @returns {String}
- */
-TimeUuid.prototype.getNodeIdString = function () {
-    return this.buffer.slice(10).toString("ascii");
-};
 
 function writeTime(buffer, time, ticks) {
     //value time expressed in ticks precision

--- a/lib/types/uuid.js
+++ b/lib/types/uuid.js
@@ -2,22 +2,48 @@
 
 const crypto = require("crypto");
 const utils = require("../utils");
+const rust = require("../../index");
 
 /** @module types */
+
+/**
+ * Used to check if the UUID is in a correct format
+ * Source: https://stackoverflow.com/a/6640851
+ * Verified also with documentation of UUID library in Rust: https://docs.rs/uuid/latest/uuid/
+ */
+const uuidRegex =
+    /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
 /**
  * Represents an immutable universally unique identifier (UUID). A UUID represents a 128-bit value.
  */
 class Uuid {
+    #internal;
+
     /**
      * Creates a new instance of Uuid based on a Buffer
      * @param {Buffer} buffer The 16-length buffer.
      */
     constructor(buffer) {
         if (!buffer || buffer.length !== 16) {
-            throw new Error("You must provide a buffer containing 16 bytes");
+            throw new TypeError(
+                "You must provide a buffer containing 16 bytes",
+            );
         }
-        this.buffer = buffer;
+        this.#internal = rust.UuidWrapper.new(buffer);
+    }
+
+    /**
+     * Returns the underlying buffer
+     * @readonly
+     * @type Buffer
+     */
+    get buffer() {
+        return this.#internal.getBuffer();
+    }
+
+    set buffer(value) {
+        throw new SyntaxError("UUID buffer is read-only");
     }
 
     /**
@@ -26,10 +52,9 @@ class Uuid {
      * @returns {Uuid}
      */
     static fromString(value) {
-        // 36 chars: 32 + 4 hyphens
-        if (typeof value !== "string" || value.length !== 36) {
+        if (typeof value !== "string" || !uuidRegex.test(value)) {
             throw new Error(
-                "Invalid string representation of Uuid, it should be in the 00000000-0000-0000-0000-000000000000",
+                "Invalid string representation of Uuid, it should be in the 00000000-0000-0000-0000-000000000000 format",
             );
         }
         return new Uuid(
@@ -39,11 +64,14 @@ class Uuid {
 
     /**
      * Creates a new random (version 4) Uuid.
-     * @param {function} [callback] Optional callback to be invoked with the error as first parameter and the created Uuid as
-     * second parameter.
+     * @param {function} [callback] Optional callback to be invoked with the error as
+     * first parameter and the created Uuid as second parameter.
      * @returns {Uuid}
      */
     static random(callback) {
+        function getRandomBytes(cb) {
+            return crypto.randomBytes(16, cb);
+        }
         if (callback) {
             getRandomBytes(function (err, buffer) {
                 if (err) {
@@ -62,7 +90,7 @@ class Uuid {
      * @returns {Buffer}
      */
     getBuffer() {
-        return this.buffer;
+        return this.#internal.getBuffer();
     }
 
     /**
@@ -71,7 +99,10 @@ class Uuid {
      * @param {Uuid} other The other value to test for equality.
      */
     equals(other) {
-        return other instanceof Uuid && this.buffer.equals(other.buffer);
+        if (!(other instanceof Uuid)) {
+            return false;
+        }
+        return this.buffer.compare(other.getBuffer()) == 0;
     }
 
     /**
@@ -81,26 +112,16 @@ class Uuid {
      */
     toString() {
         // 32 hex representation of the Buffer
-        const hexValue = getHex(this);
-        return (
-            hexValue.substr(0, 8) +
-            "-" +
-            hexValue.substr(8, 4) +
-            "-" +
-            hexValue.substr(12, 4) +
-            "-" +
-            hexValue.substr(16, 4) +
-            "-" +
-            hexValue.substr(20, 12)
-        );
+        const hexValue = this.buffer.toString("hex");
+        return `${hexValue.slice(0, 8)}-${hexValue.slice(8, 12)}-${hexValue.slice(12, 16)}-${hexValue.slice(16, 20)}-${hexValue.slice(20)}`;
     }
 
     /**
      * Provide the name of the constructor and the string representation
-     * @returns {string}
+     * @returns {String}
      */
     inspect() {
-        return this.constructor.name + ": " + this.toString();
+        return `${this.constructor.name}: ${this.toString()}`;
     }
 
     /**
@@ -109,6 +130,14 @@ class Uuid {
      */
     toJSON() {
         return this.toString();
+    }
+
+    /**
+     * @package
+     * @param {rust.UuidWrapper} buffer
+     */
+    static fromRust(buffer) {
+        return new Uuid(buffer.getBuffer());
     }
 }
 
@@ -127,23 +156,6 @@ function createUuidFromBuffer(buffer) {
     // set the IETF variant
     buffer[8] |= 0x80;
     return new Uuid(buffer);
-}
-
-/**
- * @private
- * @returns {String} 32 hex representation of the instance, without separators
- */
-function getHex(uuid) {
-    return uuid.buffer.toString("hex");
-}
-
-/**
- * Gets a crypto generated 16 bytes
- * @private
- * @returns {Buffer}
- */
-function getRandomBytes(cb) {
-    return crypto.randomBytes(16, cb);
 }
 
 module.exports = Uuid;

--- a/lib/types/uuid.js
+++ b/lib/types/uuid.js
@@ -6,108 +6,111 @@ const utils = require("../utils");
 /** @module types */
 
 /**
- * Creates a new instance of Uuid based on a Buffer
- * @class
- * @classdesc Represents an immutable universally unique identifier (UUID). A UUID represents a 128-bit value.
- * @param {Buffer} buffer The 16-length buffer.
- * @constructor
+ * Represents an immutable universally unique identifier (UUID). A UUID represents a 128-bit value.
  */
-function Uuid(buffer) {
-    if (!buffer || buffer.length !== 16) {
-        throw new Error("You must provide a buffer containing 16 bytes");
+class Uuid {
+    /**
+     * Creates a new instance of Uuid based on a Buffer
+     * @param {Buffer} buffer The 16-length buffer.
+     */
+    constructor(buffer) {
+        if (!buffer || buffer.length !== 16) {
+            throw new Error("You must provide a buffer containing 16 bytes");
+        }
+        this.buffer = buffer;
     }
-    this.buffer = buffer;
-}
 
-/**
- * Parses a string representation of a Uuid
- * @param {String} value
- * @returns {Uuid}
- */
-Uuid.fromString = function (value) {
-    //36 chars: 32 + 4 hyphens
-    if (typeof value !== "string" || value.length !== 36) {
-        throw new Error(
-            "Invalid string representation of Uuid, it should be in the 00000000-0000-0000-0000-000000000000",
+    /**
+     * Parses a string representation of a Uuid
+     * @param {String} value
+     * @returns {Uuid}
+     */
+    static fromString(value) {
+        // 36 chars: 32 + 4 hyphens
+        if (typeof value !== "string" || value.length !== 36) {
+            throw new Error(
+                "Invalid string representation of Uuid, it should be in the 00000000-0000-0000-0000-000000000000",
+            );
+        }
+        return new Uuid(
+            utils.allocBufferFromString(value.replace(/-/g, ""), "hex"),
         );
     }
-    return new Uuid(
-        utils.allocBufferFromString(value.replace(/-/g, ""), "hex"),
-    );
-};
 
-/**
- * Creates a new random (version 4) Uuid.
- * @param {function} [callback] Optional callback to be invoked with the error as first parameter and the created Uuid as
- * second parameter.
- * @returns {Uuid}
- */
-Uuid.random = function (callback) {
-    if (callback) {
-        getRandomBytes(function (err, buffer) {
-            if (err) {
-                return callback(err);
-            }
-            return callback(null, createUuidFromBuffer(buffer));
-        });
-    } else {
-        const buffer = getRandomBytes();
-        return createUuidFromBuffer(buffer);
+    /**
+     * Creates a new random (version 4) Uuid.
+     * @param {function} [callback] Optional callback to be invoked with the error as first parameter and the created Uuid as
+     * second parameter.
+     * @returns {Uuid}
+     */
+    static random(callback) {
+        if (callback) {
+            getRandomBytes(function (err, buffer) {
+                if (err) {
+                    return callback(err);
+                }
+                return callback(null, createUuidFromBuffer(buffer));
+            });
+        } else {
+            const buffer = getRandomBytes();
+            return createUuidFromBuffer(buffer);
+        }
     }
-};
 
-/**
- * Gets the bytes representation of a Uuid
- * @returns {Buffer}
- */
-Uuid.prototype.getBuffer = function () {
-    return this.buffer;
-};
-/**
- * Compares this object to the specified object.
- * The result is true if and only if the argument is not null, is a UUID object, and contains the same value, bit for bit, as this UUID.
- * @param {Uuid} other The other value to test for equality.
- */
-Uuid.prototype.equals = function (other) {
-    return other instanceof Uuid && this.buffer.equals(other.buffer);
-};
+    /**
+     * Gets the bytes representation of a Uuid
+     * @returns {Buffer}
+     */
+    getBuffer() {
+        return this.buffer;
+    }
 
-/**
- * Returns a string representation of the value of this Uuid instance.
- * 32 hex separated by hyphens, in the form of 00000000-0000-0000-0000-000000000000.
- * @returns {String}
- */
-Uuid.prototype.toString = function () {
-    //32 hex representation of the Buffer
-    const hexValue = getHex(this);
-    return (
-        hexValue.substr(0, 8) +
-        "-" +
-        hexValue.substr(8, 4) +
-        "-" +
-        hexValue.substr(12, 4) +
-        "-" +
-        hexValue.substr(16, 4) +
-        "-" +
-        hexValue.substr(20, 12)
-    );
-};
+    /**
+     * Compares this object to the specified object.
+     * The result is true if and only if the argument is not null, is a UUID object, and contains the same value, bit for bit, as this UUID.
+     * @param {Uuid} other The other value to test for equality.
+     */
+    equals(other) {
+        return other instanceof Uuid && this.buffer.equals(other.buffer);
+    }
 
-/**
- * Provide the name of the constructor and the string representation
- * @returns {string}
- */
-Uuid.prototype.inspect = function () {
-    return this.constructor.name + ": " + this.toString();
-};
+    /**
+     * Returns a string representation of the value of this Uuid instance.
+     * 32 hex separated by hyphens, in the form of 00000000-0000-0000-0000-000000000000.
+     * @returns {String}
+     */
+    toString() {
+        // 32 hex representation of the Buffer
+        const hexValue = getHex(this);
+        return (
+            hexValue.substr(0, 8) +
+            "-" +
+            hexValue.substr(8, 4) +
+            "-" +
+            hexValue.substr(12, 4) +
+            "-" +
+            hexValue.substr(16, 4) +
+            "-" +
+            hexValue.substr(20, 12)
+        );
+    }
 
-/**
- * Returns the string representation.
- * Method used by the native JSON.stringify() to serialize this instance.
- */
-Uuid.prototype.toJSON = function () {
-    return this.toString();
-};
+    /**
+     * Provide the name of the constructor and the string representation
+     * @returns {string}
+     */
+    inspect() {
+        return this.constructor.name + ": " + this.toString();
+    }
+
+    /**
+     * Returns the string representation.
+     * Method used by the native JSON.stringify() to serialize this instance.
+     */
+    toJSON() {
+        return this.toString();
+    }
+}
 
 /**
  * Returns new Uuid
@@ -115,13 +118,13 @@ Uuid.prototype.toJSON = function () {
  * @returns {Uuid}
  */
 function createUuidFromBuffer(buffer) {
-    //clear the version
+    // clear the version
     buffer[6] &= 0x0f;
-    //set the version 4
+    // set the version 4
     buffer[6] |= 0x40;
-    //clear the variant
+    // clear the variant
     buffer[8] &= 0x3f;
-    //set the IETF variant
+    // set the IETF variant
     buffer[8] |= 0x80;
     return new Uuid(buffer);
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,3 +23,4 @@ pub mod auth;
 pub mod result;
 pub mod result_tests;
 pub mod session;
+pub mod types;

--- a/src/result.rs
+++ b/src/result.rs
@@ -1,3 +1,4 @@
+use crate::types::uuid::UuidWrapper;
 use napi::{
     bindgen_prelude::{BigInt, Buffer},
     Error, Status,
@@ -134,8 +135,8 @@ impl CqlValueWrapper {
             CqlValue::Time(_) => CqlType::Time,         // NOI
             CqlValue::Timeuuid(_) => CqlType::Timeuuid, // NOI
             CqlValue::Tuple(_) => CqlType::Tuple,       // NOI
-            CqlValue::Uuid(_) => CqlType::Uuid,         // NOI
-            CqlValue::Varint(_) => CqlType::Varint,     // NOI
+            CqlValue::Uuid(_) => CqlType::Uuid,
+            CqlValue::Varint(_) => CqlType::Varint, // NOI
         }
     }
 
@@ -237,6 +238,14 @@ impl CqlValueWrapper {
         match self.inner.as_tinyint() {
             Some(r) => Ok(r),
             None => Err(Self::generic_error("tiny_int")),
+        }
+    }
+
+    #[napi]
+    pub fn get_uuid(&self) -> napi::Result<UuidWrapper> {
+        match self.inner.as_uuid() {
+            Some(r) => Ok(UuidWrapper::from_cql_uuid(r)),
+            None => Err(Self::generic_error("uuid")),
         }
     }
 }

--- a/src/result.rs
+++ b/src/result.rs
@@ -1,4 +1,4 @@
-use crate::types::uuid::UuidWrapper;
+use crate::types::{time_uuid::TimeUuidWrapper, uuid::UuidWrapper};
 use napi::{
     bindgen_prelude::{BigInt, Buffer},
     Error, Status,
@@ -132,9 +132,9 @@ impl CqlValueWrapper {
             CqlValue::UserDefinedType { .. } => CqlType::UserDefinedType, // NOI
             CqlValue::SmallInt(_) => CqlType::SmallInt,
             CqlValue::TinyInt(_) => CqlType::TinyInt,
-            CqlValue::Time(_) => CqlType::Time,         // NOI
-            CqlValue::Timeuuid(_) => CqlType::Timeuuid, // NOI
-            CqlValue::Tuple(_) => CqlType::Tuple,       // NOI
+            CqlValue::Time(_) => CqlType::Time, // NOI
+            CqlValue::Timeuuid(_) => CqlType::Timeuuid,
+            CqlValue::Tuple(_) => CqlType::Tuple, // NOI
             CqlValue::Uuid(_) => CqlType::Uuid,
             CqlValue::Varint(_) => CqlType::Varint, // NOI
         }
@@ -246,6 +246,14 @@ impl CqlValueWrapper {
         match self.inner.as_uuid() {
             Some(r) => Ok(UuidWrapper::from_cql_uuid(r)),
             None => Err(Self::generic_error("uuid")),
+        }
+    }
+
+    #[napi]
+    pub fn get_time_uuid(&self) -> napi::Result<TimeUuidWrapper> {
+        match self.inner.as_timeuuid() {
+            Some(r) => Ok(TimeUuidWrapper::from_cql_time_uuid(r)),
+            None => Err(Self::generic_error("time_uuid")),
         }
     }
 }

--- a/src/result_tests.rs
+++ b/src/result_tests.rs
@@ -1,6 +1,12 @@
-use scylla::frame::{response::result::CqlValue, value::Counter};
+use std::str::FromStr;
+
+use scylla::frame::{
+    response::result::CqlValue,
+    value::{Counter, CqlTimeuuid},
+};
 
 use crate::result::CqlValueWrapper;
+use uuid::uuid;
 
 #[napi]
 /// Test function returning sample CqlValueWrapper with Ascii type
@@ -79,5 +85,20 @@ pub fn tests_get_cql_wrapper_small_int() -> CqlValueWrapper {
 /// Test function returning sample CqlValueWrapper with TinyInt type
 pub fn tests_get_cql_wrapper_tiny_int() -> CqlValueWrapper {
     let element = CqlValue::TinyInt(3);
+    CqlValueWrapper { inner: element }
+}
+
+#[napi]
+/// Test function returning sample CqlValueWrapper with Uuid type
+pub fn tests_get_cql_wrapper_uuid() -> CqlValueWrapper {
+    let element = CqlValue::Uuid(uuid!("ffffffff-ffff-ffff-ffff-ffffffffffff"));
+    CqlValueWrapper { inner: element }
+}
+
+#[napi]
+/// Test function returning sample CqlValueWrapper with Timeuuid type
+pub fn tests_get_cql_wrapper_time_uuid() -> CqlValueWrapper {
+    let element =
+        CqlValue::Timeuuid(CqlTimeuuid::from_str("8e14e760-7fa8-11eb-bc66-000000000001").unwrap());
     CqlValueWrapper { inner: element }
 }

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -1,0 +1,1 @@
+pub mod uuid;

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -1,1 +1,2 @@
+pub mod time_uuid;
 pub mod uuid;

--- a/src/types/time_uuid.rs
+++ b/src/types/time_uuid.rs
@@ -1,0 +1,28 @@
+use napi::bindgen_prelude::Buffer;
+use scylla::frame::value::CqlTimeuuid;
+
+use super::uuid::UuidWrapper;
+
+#[napi]
+pub struct TimeUuidWrapper {
+    uuid: UuidWrapper,
+}
+
+#[napi]
+impl TimeUuidWrapper {
+    #[napi]
+    pub fn get_buffer(&self) -> Buffer {
+        Buffer::from(self.uuid.get_cql_uuid().into_bytes().to_vec())
+    }
+}
+
+impl TimeUuidWrapper {
+    pub fn from_cql_time_uuid(time_uuid: CqlTimeuuid) -> Self {
+        TimeUuidWrapper {
+            uuid: UuidWrapper::from_cql_uuid(*time_uuid.as_ref()),
+        }
+    }
+    pub fn get_cql_time_uuid(&self) -> CqlTimeuuid {
+        CqlTimeuuid::from_bytes(self.uuid.get_cql_uuid().into_bytes())
+    }
+}

--- a/src/types/uuid.rs
+++ b/src/types/uuid.rs
@@ -1,0 +1,32 @@
+use napi::{bindgen_prelude::Buffer, bindgen_prelude::BufferSlice, Error, Status};
+use uuid::Uuid;
+
+#[napi]
+pub struct UuidWrapper {
+    uuid: Uuid,
+}
+
+#[napi]
+impl UuidWrapper {
+    #[napi]
+    pub fn new(buffer: BufferSlice) -> napi::Result<Self> {
+        match Uuid::from_slice(buffer.as_ref()) {
+            Err(_) => Err(Error::new(Status::InvalidArg, "Invalid uuid buffer")),
+            Ok(uuid) => Ok(Self { uuid }),
+        }
+    }
+
+    #[napi]
+    pub fn get_buffer(&self) -> Buffer {
+        Buffer::from(self.uuid.as_bytes().to_vec())
+    }
+}
+
+impl UuidWrapper {
+    pub fn from_cql_uuid(uuid: Uuid) -> Self {
+        UuidWrapper { uuid }
+    }
+    pub fn get_cql_uuid(&self) -> Uuid {
+        self.uuid
+    }
+}

--- a/test/unit/cql-value-wrapper.js
+++ b/test/unit/cql-value-wrapper.js
@@ -2,6 +2,8 @@
 const { assert } = require("chai");
 const rust = require("../../index");
 const { getCqlObject } = require("../../lib/types/results-wrapper");
+const Uuid = require("../../lib/types/uuid");
+const TimeUuid = require("../../lib/types/time-uuid");
 
 const maxI64 = BigInt("9223372036854775807");
 const maxI32 = Number(2147483647);
@@ -119,5 +121,34 @@ describe("Cql value wrapper", function () {
         /* Corresponding value: 
         let element = CqlValue::TinyInt(3); */
         assert.strictEqual(value, Number(3));
+    });
+
+    it("should get uuid type correctly from napi", function () {
+        let element = rust.testsGetCqlWrapperUuid();
+        let type = element.getType();
+        assert.strictEqual(type, rust.CqlType.Uuid);
+        let value = getCqlObject(element);
+        assert.instanceOf(value, Uuid);
+        /* Corresponding value: 
+        let element = CqlValue::Uuid(uuid!("ffffffff-ffff-ffff-ffff-ffffffffffff")); */
+        let expectedUuid = Uuid.fromString(
+            "ffffffff-ffff-ffff-ffff-ffffffffffff",
+        );
+        assert.equal(value.equals(expectedUuid), true);
+    });
+
+    it("should get time uuid type correctly from napi", function () {
+        let element = rust.testsGetCqlWrapperTimeUuid();
+        let type = element.getType();
+        assert.strictEqual(type, rust.CqlType.Timeuuid);
+        let value = getCqlObject(element);
+        assert.instanceOf(value, TimeUuid);
+        /* Corresponding value: 
+        let element =
+        CqlValue::Timeuuid(CqlTimeuuid::from_str("8e14e760-7fa8-11eb-bc66-000000000001").unwrap()); */
+        let expectedUuid = TimeUuid.fromString(
+            "8e14e760-7fa8-11eb-bc66-000000000001",
+        );
+        assert.equal(value.equals(expectedUuid), true);
     });
 });

--- a/test/unit/uuid-type-tests.js
+++ b/test/unit/uuid-type-tests.js
@@ -3,6 +3,7 @@
 const assert = require("assert");
 const helper = require("../test-helper");
 const utils = require("../../lib/utils");
+const { fromString } = require("../../lib/types/uuid");
 const Uuid = require("../../lib/types").Uuid;
 const TimeUuid = require("../../lib/types").TimeUuid;
 
@@ -115,7 +116,7 @@ describe("Uuid", function () {
         });
     });
     describe("fromString()", function () {
-        it("should validate that the string", function () {
+        it("should validate the string", function () {
             assert.throws(function () {
                 Uuid.fromString("22");
             });
@@ -234,12 +235,29 @@ describe("Uuid", function () {
             );
         });
     });
+
+    describe("setter errors", function () {
+        it("should validate if setter throws an error", function () {
+            assert.throws(
+                function () {
+                    let uuid = Uuid.fromString(
+                        "ffffffff-ffff-ffff-ffff-ffffffffffff",
+                    );
+                    uuid.buffer = "00000000-0000-0000-0000-000000000000";
+                },
+                {
+                    name: "SyntaxError",
+                    message: "UUID buffer is read-only",
+                },
+            );
+        });
+    });
 });
 
 describe("TimeUuid", function () {
     describe("constructor()", function () {
         it("should generate based on the parameters", function () {
-            //Gregorian calendar epoch
+            // Gregorian calendar epoch
             let val = new TimeUuid(
                 new Date(-12219292800000),
                 0,
@@ -260,7 +278,7 @@ describe("TimeUuid", function () {
                 val.toString(),
                 "00989680-0000-1000-8000-000000000000",
             );
-            //unix  epoch
+            // unix  epoch
             val = new TimeUuid(
                 new Date(0),
                 0,
@@ -360,7 +378,7 @@ describe("TimeUuid", function () {
                 ] = true;
             }
             assert.strictEqual(Object.keys(values).length, length);
-            //next should collide
+            // next should collide
             assert.strictEqual(
                 values[
                     TimeUuid.fromDate(date, null, "host01", "AA").toString()


### PR DESCRIPTION
This is implementation of the ``Uuid`` and ``Timeuuid`` types used by the database. It introduces wrappers for the types in rust - ``TimeUuidWrapper`` and ``UuidWrapper``. Current implementation holds data in a Rust object and most processing is done in JS. While creating an uuid it is now checked using a regex instead of checking only if the length of the given buffer is correct. There is a ``get``ter and a ``set``ter introduced for the buffer attribute. As it is read-only using a ``set``ter throws a ``SyntaxError`` exception. 