### PR TITLE
Reformat client docs

### DIFF
--- a/lib/client-options.js
+++ b/lib/client-options.js
@@ -10,35 +10,39 @@ const auth = require("./auth");
 
 /**
  * Client options.
- * <p>While the driver provides lots of extensibility points and configurability, few client options are required.</p>
- * <p>Default values for all settings are designed to be suitable for the majority of use cases, you should avoid
- * fine tuning it when not needed.</p>
- * <p>See [Client constructor]{@link Client} documentation for recommended options.</p>
+ *
+ * While the driver provides lots of extensibility points and configurability, few client options are required.
+ *
+ * Default values for all settings are designed to be suitable for the majority of use cases, you should avoid
+ * fine tuning it when not needed.
+ *
+ * See [Client constructor]{@link Client} documentation for recommended options.
+ *
  * @typedef {Object} ClientOptions
  * @property {Array.<string>} contactPoints
  * Array of addresses or host names of the nodes to add as contact points.
- * <p>
- *  Contact points are addresses of Cassandra nodes that the driver uses to discover the cluster topology.
- * </p>
- * <p>
- *  Only one contact point is required (the driver will retrieve the address of the other nodes automatically),
- *  but it is usually a good idea to provide more than one contact point, because if that single contact point is
- *  unavailable, the driver will not be able to initialize correctly.
- * </p>
+ *
+ * Contact points are addresses of Cassandra nodes that the driver uses to discover the cluster topology.
+ *
+ * Only one contact point is required (the driver will retrieve the address of the other nodes automatically),
+ * but it is usually a good idea to provide more than one contact point, because if that single contact point is
+ * unavailable, the driver will not be able to initialize correctly.
+ *
  * @property {String} [localDataCenter] The local data center to use.
- * <p>
- *   If using DCAwareRoundRobinPolicy (default), this option is required and only hosts from this data center are
- *   connected to and used in query plans.
- * </p>
+ *
+ * If using DCAwareRoundRobinPolicy (default), this option is required and only hosts from this data center are
+ * connected to and used in query plans.
+ *
+ * [TODO: Add support for this field]
  * @property {String} [keyspace] The logged keyspace for all the connections created within the {@link Client} instance.
  * [TODO: Add support for this field]
  * @property {Object} [credentials] An object containing the username and password for plain-text authentication.
  * It configures the authentication provider to be used against Apache Cassandra's PasswordAuthenticator or DSE's
  * DseAuthenticator, when default auth scheme is plain-text.
- * <p>
- *   Note that you should configure either <code>credentials</code> or <code>authProvider</code> to connect to an
- *   auth-enabled cluster, but not both.
- * </p>
+ *
+ * Note that you should configure either ``credentials`` or ``authProvider`` to connect to an
+ * auth-enabled cluster, but not both.
+ *
  * [TODO: Add support for this field]
  * @property {String} [credentials.username] The username to use for plain-text authentication.
  * [TODO: Add support for this field]
@@ -50,17 +54,21 @@ const auth = require("./auth");
  * [TODO: Add support for this field]
  * @property {String} [applicationName] An optional setting identifying the name of the application using
  * the {@link Client} instance.
- * <p>This value is passed to DSE and is useful as metadata for describing a client connection on the server side.</p>
+ *
+ * This value is passed to DSE and is useful as metadata for describing a client connection on the server side.
+ *
  * [TODO: Add support for this field]
  * @property {String} [applicationVersion] An optional setting identifying the version of the application using
  * the {@link Client} instance.
- * <p>This value is passed to DSE and is useful as metadata for describing a client connection on the server side.</p>
+ *
+ * This value is passed to DSE and is useful as metadata for describing a client connection on the server side.
+ *
  * [TODO: Add support for this field]
  * @property {Object} [monitorReporting] Options for reporting mechanism from the client to the DSE server, for
  * versions that support it.
  * [TODO: Add support for this field]
  * @property {Boolean} [monitorReporting.enabled=true] Determines whether the reporting mechanism is enabled.
- * Defaults to <code>true</code>.
+ * Defaults to ``true``.
  * [TODO: Add support for this field]
  * @property {Object} [cloud] The options to connect to a cloud instance.
  * [TODO: Add support for this field Remove?]
@@ -71,23 +79,25 @@ const auth = require("./auth");
  * [TODO: Add support for this field]
  * @property {Boolean} [isMetadataSyncEnabled] Determines whether client-side schema metadata retrieval and update is
  * enabled.
- * <p>Setting this value to <code>false</code> will cause keyspace information not to be automatically loaded, affecting
+ *
+ * Setting this value to ``false`` will cause keyspace information not to be automatically loaded, affecting
  * replica calculation per token in the different keyspaces. When disabling metadata synchronization, use
  * [Metadata.refreshKeyspaces()]{@link module:metadata~Metadata#refreshKeyspaces} to keep keyspace information up to
- * date or token-awareness will not work correctly.</p>
- * Default: <code>true</code>.
+ * date or token-awareness will not work correctly.
+ *
+ * Default: ``true``.
  * [TODO: Add support for this field]
  * @property {Boolean} [prepareOnAllHosts] Determines if the driver should prepare queries on all hosts in the cluster.
- * Default: <code>true</code>.
+ * Default: ``true``.
  * [TODO: Add support for this field]
  * @property {Boolean} [rePrepareOnUp] Determines if the driver should re-prepare all cached prepared queries on a
  * host when it marks it back up.
- * Default: <code>true</code>.
+ * Default: ``true``.
  * [TODO: Add support for this field]
  * @property {Number} [maxPrepared] Determines the maximum amount of different prepared queries before evicting items
  * from the internal cache. Reaching a high threshold hints that the queries are not being reused, like when
  * hard-coding parameter values inside the queries.
- * Default: <code>500</code>.
+ * Default: ``500``.
  * [TODO: Add support for this field]
  * @property {Object} [policies]
  * [TODO: Add support for this field]
@@ -100,21 +110,21 @@ const auth = require("./auth");
  * [TODO: Add support for this field]
  * @property {AddressTranslator} [policies.addressResolution] The address resolution policy.
  * [TODO: Add support for this field]
- * @property {SpeculativeExecutionPolicy} [policies.speculativeExecution] The <code>SpeculativeExecutionPolicy</code>
+ * @property {SpeculativeExecutionPolicy} [policies.speculativeExecution] The ``SpeculativeExecutionPolicy``
  * instance to be used to determine if the client should send speculative queries when the selected host takes more
  * time than expected.
- * <p>
- *   Default: <code>[NoSpeculativeExecutionPolicy]{@link
- *   module:policies/speculativeExecution~NoSpeculativeExecutionPolicy}</code>
- * </p>
+ *
+ * Default: ``[NoSpeculativeExecutionPolicy]{@link
+ * module:policies/speculativeExecution~NoSpeculativeExecutionPolicy}``
+ *
  * [TODO: Add support for this field]
  * @property {TimestampGenerator} [policies.timestampGeneration] The client-side
  * [query timestamp generator]{@link module:policies/timestampGeneration~TimestampGenerator}.
- * <p>
- *   Default: <code>[MonotonicTimestampGenerator]{@link module:policies/timestampGeneration~MonotonicTimestampGenerator}
- *   </code>
- * </p>
- * <p>Use <code>null</code> to disable client-side timestamp generation.</p>
+ *
+ * Default: ``[MonotonicTimestampGenerator]{@link module:policies/timestampGeneration~MonotonicTimestampGenerator}``
+ *
+ * Use ``null`` to disable client-side timestamp generation.
+ *
  * [TODO: Add support for this field]
  * @property {QueryOptions} [queryOptions] Default options for all queries.
  * [TODO: Add support for this field]
@@ -128,10 +138,9 @@ const auth = require("./auth");
  * [TODO: Add support for this field]
  * @property {Number} [pooling.maxRequestsPerConnection] The maximum number of requests per connection. The default
  * value is:
- * <ul>
- *   <li>For modern protocol versions (v3 and above): 2048</li>
- *   <li>For older protocol versions (v1 and v2): 128</li>
- * </ul>
+ * - For modern protocol versions (v3 and above): 2048
+ * - For older protocol versions (v1 and v2): 128
+ *
  * [TODO: Add support for this field]
  * @property {Boolean} [pooling.warmup] Determines if all connections to hosts in the local datacenter must be opened on
  * connect. Default: true.
@@ -149,15 +158,14 @@ const auth = require("./auth");
  * Useful for using the driver against a cluster that contains nodes with different major/minor versions of Cassandra.
  * [TODO: Add support for this field]
  * @property {Boolean} [protocolOptions.noCompact] When set to true, enables the NO_COMPACT startup option.
- * <p>
- * When this option is supplied <code>SELECT</code>, <code>UPDATE</code>, <code>DELETE</code>, and <code>BATCH</code>
- * statements on <code>COMPACT STORAGE</code> tables function in "compatibility" mode which allows seeing these tables
+ *
+ * When this option is supplied ``SELECT``, ``UPDATE``, ``DELETE``, and ``BATCH``
+ * statements on ``COMPACT STORAGE`` tables function in "compatibility" mode which allows seeing these tables
  * as if they were "regular" CQL tables.
- * </p>
- * <p>
- * This option only effects interactions with interactions with tables using <code>COMPACT STORAGE</code> and is only
+ *
+ * This option only effects interactions with interactions with tables using ``COMPACT STORAGE`` and is only
  * supported by C* 3.0.16+, 3.11.2+, 4.0+ and DSE 6.0+.
- * </p>
+ *
  * [TODO: Add support for this field]
  * @property {Object} [socketOptions]
  * [TODO: Add support for this field]
@@ -171,23 +179,20 @@ const auth = require("./auth");
  * @property {Number} [socketOptions.keepAliveDelay] TCP keep-alive delay in milliseconds. Default: 0.
  * [TODO: Add support for this field]
  * @property {Number} [socketOptions.readTimeout] Per-host read timeout in milliseconds.
- * <p>
- *   Please note that this is not the maximum time a call to {@link Client#execute} may have to wait;
- *   this is the maximum time that call will wait for one particular Cassandra host, but other hosts will be tried if
- *   one of them timeout. In other words, a {@link Client#execute} call may theoretically wait up to
- *   <code>readTimeout * number_of_cassandra_hosts</code> (though the total number of hosts tried for a given query also
- *   depends on the LoadBalancingPolicy in use).
- * <p>When setting this value, keep in mind the following:</p>
- * <ul>
- *   <li>the timeout settings used on the Cassandra side (*_request_timeout_in_ms in cassandra.yaml) should be taken
- *   into account when picking a value for this read timeout. You should pick a value a couple of seconds greater than
- *   the Cassandra timeout settings.
- *   </li>
- *   <li>
- *     the read timeout is only approximate and only control the timeout to one Cassandra host, not the full query.
- *   </li>
- * </ul>
- * Setting a value of 0 disables read timeouts. Default: <code>12000</code>.
+ *
+ * Please note that this is not the maximum time a call to {@link Client#execute} may have to wait;
+ * this is the maximum time that call will wait for one particular Cassandra host, but other hosts will be tried if
+ * one of them timeout. In other words, a {@link Client#execute} call may theoretically wait up to
+ * ``readTimeout * number_of_cassandra_hosts`` (though the total number of hosts tried for a given query also
+ * depends on the LoadBalancingPolicy in use).
+ *
+ * When setting this value, keep in mind the following:
+ * - the timeout settings used on the Cassandra side (*_request_timeout_in_ms in cassandra.yaml) should be taken
+ * into account when picking a value for this read timeout. You should pick a value a couple of seconds greater than
+ * the Cassandra timeout settings.
+ * - the read timeout is only approximate and only control the timeout to one Cassandra host, not the full query.
+ *
+ * Setting a value of 0 disables read timeouts. Default: ``12000``.
  * [TODO: Add support for this field]
  * @property {Boolean} [socketOptions.tcpNoDelay] When set to true, it disables the Nagle algorithm. Default: true.
  * [TODO: Add support for this field]
@@ -200,12 +205,12 @@ const auth = require("./auth");
  * with this instance.
  * [TODO: Add support for this field]
  * @property {Object} [sslOptions] Client-to-node ssl options. When set the driver will use the secure layer.
- * You can specify cert, ca, ... options named after the Node.js <code>tls.connect()</code> options.
- * <p>
- *   It uses the same default values as Node.js <code>tls.connect()</code> except for <code>rejectUnauthorized</code>
- *   which is set to <code>false</code> by default (for historical reasons). This setting is likely to change
- *   in upcoming versions to enable validation by default.
- * </p>
+ * You can specify cert, ca, ... options named after the Node.js ``tls.connect()`` options.
+ *
+ * It uses the same default values as Node.js ``tls.connect()`` except for ``rejectUnauthorized``
+ * which is set to ``false`` by default (for historical reasons). This setting is likely to change
+ * in upcoming versions to enable validation by default.
+ *
  * [TODO: Add support for this field]
  * @property {Object} [encoding] Encoding options.
  * [TODO: Add support for this field]
@@ -217,30 +222,28 @@ const auth = require("./auth");
  * [TODO: Add support for this field]
  * @property {Boolean} [encoding.copyBuffer] Determines if the network buffer should be copied for buffer based data
  * types (blob, uuid, timeuuid and inet).
- * <p>
- *   Setting it to true will cause that the network buffer is copied for each row value of those types,
- *   causing additional allocations but freeing the network buffer to be reused.
- *   Setting it to true is a good choice for cases where the Row and ResultSet returned by the queries are long-lived
- *   objects.
- * </p>
- * <p>
- *  Setting it to false will cause less overhead and the reference of the network buffer to be maintained until the row
- *  / result set are de-referenced.
- *  Default: true.
- * </p>
+ *
+ * Setting it to true will cause that the network buffer is copied for each row value of those types,
+ * causing additional allocations but freeing the network buffer to be reused.
+ * Setting it to true is a good choice for cases where the Row and ResultSet returned by the queries are long-lived
+ * objects.
+ *
+ * Setting it to false will cause less overhead and the reference of the network buffer to be maintained until the row
+ * / result set are de-referenced.
+ * Default: true.
+ *
  * [TODO: Add support for this field]
  * @property {Boolean} [encoding.useUndefinedAsUnset] Valid for Cassandra 2.2 and above. Determines that, if a parameter
  * is set to
- * <code>undefined</code> it should be encoded as <code>unset</code>.
- * <p>
- *  By default, ECMAScript <code>undefined</code> is encoded as <code>null</code> in the driver. Cassandra 2.2
- *  introduced the concept of unset.
- *  At driver level, you can set a parameter to unset using the field <code>types.unset</code>. Setting this flag to
- *  true allows you to use ECMAScript undefined as Cassandra <code>unset</code>.
- * </p>
- * <p>
- *   Default: true.
- * </p>
+ * ``undefined`` it should be encoded as ``unset``.
+ *
+ * By default, ECMAScript ``undefined`` is encoded as ``null`` in the driver. Cassandra 2.2
+ * introduced the concept of unset.
+ * At driver level, you can set a parameter to unset using the field ``types.unset``. Setting this flag to
+ * true allows you to use ECMAScript undefined as Cassandra ``unset``.
+ *
+ * Default: true.
+ *
  * [TODO: Add support for this field]
  * @property {Boolean} [encoding.useBigIntAsLong] Use [BigInt ECMAScript type](https://tc39.github.io/proposal-bigint/)
  * to represent CQL bigint and counter data types.
@@ -250,16 +253,15 @@ const auth = require("./auth");
  * [TODO: Add support for this field]
  * @property {Array.<ExecutionProfile>} [profiles] The array of [execution profiles]{@link ExecutionProfile}.
  * [TODO: Add support for this field]
- * @property {Function} [promiseFactory] Function to be used to create a <code>Promise</code> from a
+ * @property {Function} [promiseFactory] Function to be used to create a ``Promise`` from a
  * callback-style function.
- * <p>
- *   Promise libraries often provide different methods to create a promise. For example, you can use Bluebird's
- *   <code>Promise.fromCallback()</code> method.
- * </p>
- * <p>
- *   By default, the driver will use the
- *   [Promise constructor]{@link https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/Promise}.
- * </p>
+ *
+ * Promise libraries often provide different methods to create a promise. For example, you can use Bluebird's
+ * ``Promise.fromCallback()`` method.
+ *
+ * By default, the driver will use the
+ * [Promise constructor]{@link https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/Promise}.
+ *
  * [TODO: Add support for this field]
  */
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -34,32 +34,35 @@ const warmupLimit = 32;
  * @typedef {Object} QueryOptions
  * [TODO: Add support for this field]
  * @property {Boolean} [autoPage] Determines if the driver must retrieve the following result pages automatically.
- * <p>
- *   This setting is only considered by the [Client#eachRow()]{@link Client#eachRow} method. For more information,
- *   check the
- *   [paging results documentation]{@link https://docs.datastax.com/en/developer/nodejs-driver/latest/features/paging/}.
- * </p>
+ *
+ * This setting is only considered by the [Client#eachRow()]{@link Client#eachRow} method. For more information,
+ * check the
+ * [paging results documentation]{@link https://docs.datastax.com/en/developer/nodejs-driver/latest/features/paging/}.
+ *
  * [TODO: Add support for this field]
  * @property {Boolean} [captureStackTrace] Determines if the stack trace before the query execution should be
  * maintained.
- * <p>
- *   Useful for debugging purposes, it should be set to <code>false</code> under production environment as it adds an
- *   unnecessary overhead to each execution.
- * </p>
+ *
+ * Useful for debugging purposes, it should be set to ``false`` under production environment as it adds an
+ * unnecessary overhead to each execution.
+ *
  * Default: false.
  * [TODO: Add support for this field]
  * @property {Number} [consistency] [Consistency level]{@link module:types~consistencies}.
- * <p>
- *   Defaults to <code>localOne</code> for Apache Cassandra and DSE deployments.
- *   For DataStax Astra, it defaults to <code>localQuorum</code>.
- * </p>
+ *
+ * Defaults to ``localOne`` for Apache Cassandra and DSE deployments.
+ * For DataStax Astra, it defaults to ``localQuorum``.
+ *
  * [TODO: Add support for this field]
  * @property {Object} [customPayload] Key-value payload to be passed to the server. On the Cassandra side,
  * implementations of QueryHandler can use this data.
  * [TODO: Add support for this field]
  * @property {String} [executeAs] The user or role name to act as when executing this statement.
- * <p>When set, it executes as a different user/role than the one currently authenticated (a.k.a. proxy execution).</p>
- * <p>This feature is only available in DSE 5.1+.</p>
+ *
+ * When set, it executes as a different user/role than the one currently authenticated (a.k.a. proxy execution).
+ *
+ * This feature is only available in DSE 5.1+.
+ *
  * [TODO: Add support for this field Delete?]
  * @property {String|ExecutionProfile} [executionProfile] Name or instance of the [profile]{@link ExecutionProfile} to
  * be used for this execution. If not set, it will the use "default" execution profile.
@@ -67,44 +70,39 @@ const warmupLimit = 32;
  * @property {Number} [fetchSize] Amount of rows to retrieve per page.
  * [TODO: Add support for this field]
  * @property {Array|Array<Array>} [hints] Type hints for parameters given in the query, ordered as for the parameters.
- * <p>For batch queries, an array of such arrays, ordered as with the queries in the batch.</p>
+ *
+ * For batch queries, an array of such arrays, ordered as with the queries in the batch.
  * [TODO: Add support for this field]
  * @property {Host} [host] The host that should handle the query.
- * <p>
- *   Use of this option is <em>heavily discouraged</em> and should only be used in the following cases:
- * </p>
- * <ol>
- *   <li>
- *     Querying node-local tables, such as tables in the <code>system</code> and <code>system_views</code>
- *     keyspaces.
- *   </li>
- *   <li>
- *     Applying a series of schema changes, where it may be advantageous to execute schema changes in sequence on the
- *     same node.
- *   </li>
- * </ol>
- * <p>
- *   Configuring a specific host causes the configured
- *   [LoadBalancingPolicy]{@link module:policies/loadBalancing~LoadBalancingPolicy} to be completely bypassed.
- *   However, if the load balancing policy dictates that the host is at a
- *   [distance of ignored]{@link module:types~distance} or there is no active connectivity to the host, the request will
- *   fail with a [NoHostAvailableError]{@link module:errors~NoHostAvailableError}.
- * </p>
+ *
+ * Use of this option is **heavily discouraged** and should only be used in the following cases:
+ *
+ * 1. Querying node-local tables, such as tables in the ``system`` and ``system_views`` keyspaces.
+ * 2. Applying a series of schema changes, where it may be advantageous to execute schema changes in sequence on the
+ *    same node.
+ *
+ * Configuring a specific host causes the configured
+ * [LoadBalancingPolicy]{@link module:policies/loadBalancing~LoadBalancingPolicy} to be completely bypassed.
+ * However, if the load balancing policy dictates that the host is at a
+ * [distance of ignored]{@link module:types~distance} or there is no active connectivity to the host, the request will
+ * fail with a [NoHostAvailableError]{@link module:errors~NoHostAvailableError}.
+ *
  * [TODO: Add support for this field]
  * @property {Boolean} [isIdempotent] Defines whether the query can be applied multiple times without changing the result
  * beyond the initial application.
- * <p>
- *   The query execution idempotence can be used at [RetryPolicy]{@link module:policies/retry~RetryPolicy} level to
- *   determine if an statement can be retried in case of request error or write timeout.
- * </p>
- * <p>Default: <code>false</code>.</p>
+ *
+ * The query execution idempotence can be used at [RetryPolicy]{@link module:policies/retry~RetryPolicy} level to
+ * determine if an statement can be retried in case of request error or write timeout.
+ *
+ * Default: ``false``.
+ *
  * [TODO: Add support for this field]
  * @property {String} [keyspace] Specifies the keyspace for the query. It is used for the following:
- * <ol>
- * <li>To indicate what keyspace the statement is applicable to (protocol V5+ only).  This is useful when the
- * query does not provide an explicit keyspace and you want to override the current {@link Client#keyspace}.</li>
- * <li>For query routing when the query operates on a different keyspace than the current {@link Client#keyspace}.</li>
- * </ol>
+ *
+ * 1. To indicate what keyspace the statement is applicable to (protocol V5+ only).  This is useful when the
+ * query does not provide an explicit keyspace and you want to override the current {@link Client#keyspace}.
+ * 2. For query routing when the query operates on a different keyspace than the current {@link Client#keyspace}.
+ *
  * [TODO: Add support for this field]
  * @property {Boolean} [logged] Determines if the batch should be written to the batchlog. Only valid for
  * [Client#batch()]{@link Client#batch}, it will be ignored by other methods. Default: true.
@@ -113,25 +111,24 @@ const warmupLimit = 32;
  * [Client#batch()]{@link Client#batch}, it will be ignored by other methods. Default: false.
  * [TODO: Add support for this field]
  * @property {Buffer|String} [pageState] Buffer or string token representing the paging state.
- * <p>Useful for manual paging, if provided, the query will be executed starting from a given paging state.</p>
+ *
+ * Useful for manual paging, if provided, the query will be executed starting from a given paging state.
  * [TODO: Add support for this field]
  * @property {Boolean} [prepare] Determines if the query must be executed as a prepared statement.
  * [TODO: Add support for this field]
  * @property {Number} [readTimeout] When defined, it overrides the default read timeout
- * (<code>socketOptions.readTimeout</code>) in milliseconds for this execution per coordinator.
- * <p>
- *   Suitable for statements for which the coordinator may allow a longer server-side timeout, for example aggregation
- *   queries.
- * </p>
- * <p>
- *   A value of <code>0</code> disables client side read timeout for the execution. Default: <code>undefined</code>.
- * </p>
+ * (``socketOptions.readTimeout``) in milliseconds for this execution per coordinator.
+ *
+ * Suitable for statements for which the coordinator may allow a longer server-side timeout, for example aggregation
+ * queries.
+ *
+ * A value of ``0`` disables client side read timeout for the execution. Default: ``undefined``.
+ *
  * [TODO: Add support for this field]
  * @property {RetryPolicy} [retry] Retry policy for the query.
- * <p>
- *   This property can be used to specify a different [retry policy]{@link module:policies/retry} to the one specified
- *   in the {@link ClientOptions}.policies.
- * </p>
+ *
+ * This property can be used to specify a different [retry policy]{@link module:policies/retry} to the one specified
+ * in the {@link ClientOptions}.policies.
  * [TODO: Add support for this field]
  * @property {Array} [routingIndexes] Index of the parameters that are part of the partition key to determine
  * the routing.
@@ -147,13 +144,16 @@ const warmupLimit = 32;
  * [TODO: Add support for this field]
  * @property {Number|Long} [timestamp] The default timestamp for the query in microseconds from the unix epoch
  * (00:00:00, January 1st, 1970).
- * <p>If provided, this will replace the server side assigned timestamp as default timestamp.</p>
- * <p>Use [generateTimestamp()]{@link module:types~generateTimestamp} utility method to generate a valid timestamp
- * based on a Date and microseconds parts.</p>
+ *
+ * If provided, this will replace the server side assigned timestamp as default timestamp.
+ *
+ * Use [generateTimestamp()]{@link module:types~generateTimestamp} utility method to generate a valid timestamp
+ * based on a Date and microseconds parts.
  * [TODO: Add support for this field]
  * @property {Boolean} [traceQuery] Enable query tracing for the execution. Use query tracing to diagnose performance
  * problems related to query executions. Default: false.
- * <p>To retrieve trace, you can call [Metadata.getTrace()]{@link module:metadata~Metadata#getTrace} method.</p>
+ *
+ * To retrieve trace, you can call [Metadata.getTrace()]{@link module:metadata~Metadata#getTrace} method.
  */
 
 /**
@@ -226,7 +226,8 @@ class Client extends events.EventEmitter {
         /**
          * The [ClientMetrics]{@link module:metrics~ClientMetrics} instance used to expose measurements of its internal
          * behavior and of the server as seen from the driver side.
-         * <p>By default, a [DefaultMetrics]{@link module:metrics~DefaultMetrics} instance is used.</p>
+         *
+         * By default, a [DefaultMetrics]{@link module:metrics~DefaultMetrics} instance is used.
          * @type {ClientMetrics}
          */
         this.metrics = this.options.metrics;
@@ -234,38 +235,32 @@ class Client extends events.EventEmitter {
 
     /**
      * Emitted when a new host is added to the cluster.
-     * <ul>
-     *   <li>{@link Host} The host being added.</li>
-     * </ul>
+     * - {@link Host} The host being added.
      * @event Client#hostAdd
      */
     /**
      * Emitted when a host is removed from the cluster
-     * <ul>
-     *   <li>{@link Host} The host being removed.</li>
-     * </ul>
+     * - {@link Host} The host being removed.
      * @event Client#hostRemove
      */
     /**
      * Emitted when a host in the cluster changed status from down to up.
-     * <ul>
-     *   <li>{@link Host host} The host that changed the status.</li>
-     * </ul>
+     * - {@link Host host} The host that changed the status.
      * @event Client#hostUp
      */
     /**
      * Emitted when a host in the cluster changed status from up to down.
-     * <ul>
-     *   <li>{@link Host host} The host that changed the status.</li>
-     * </ul>
+     * - {@link Host host} The host that changed the status.
      * @event Client#hostDown
      */
 
     /**
      * Attempts to connect to one of the [contactPoints]{@link ClientOptions} and discovers the rest the nodes of the
      * cluster.
-     * <p>When the {@link Client} is already connected, it resolves immediately.</p>
-     * <p>It returns a <code>Promise</code> when a <code>callback</code> is not provided.</p>
+     *
+     * When the {@link Client} is already connected, it resolves immediately.
+     *
+     * It returns a ``Promise`` when a ``callback`` is not provided.
      * @param {function} [callback] The optional callback that is invoked when the pool is connected or it failed to
      * connect.
      * @example <caption>Usage example</caption>
@@ -349,13 +344,15 @@ class Client extends events.EventEmitter {
 
     /**
      * Executes a query on an available connection.
-     * <p>The query can be prepared (recommended) or not depending on the [prepare]{@linkcode QueryOptions} flag.</p>
-     * <p>
-     *   Some execution failures can be handled transparently by the driver, according to the
-     *   [RetryPolicy]{@linkcode module:policies/retry~RetryPolicy} or the
-     *   [SpeculativeExecutionPolicy]{@linkcode module:policies/speculativeExecution} used.
-     * </p>
-     * <p>It returns a <code>Promise</code> when a <code>callback</code> is not provided.</p>
+     *
+     * The query can be prepared (recommended) or not depending on the [prepare]{@linkcode QueryOptions} flag.
+     *
+     * Some execution failures can be handled transparently by the driver, according to the
+     * [RetryPolicy]{@linkcode module:policies/retry~RetryPolicy} or the
+     * [SpeculativeExecutionPolicy]{@linkcode module:policies/speculativeExecution} used.
+     *
+     * It returns a ``Promise`` when a ``callback`` is not provided.
+     *
      * @param {String} query The query to execute.
      * @param {Array|Object} [params] Array of parameter values or an associative array (object) containing parameter names
      * as keys and its value.
@@ -414,23 +411,23 @@ class Client extends events.EventEmitter {
     }
 
     /**
-     * Executes the query and calls <code>rowCallback</code> for each row as soon as they are received. Calls the final
-     * <code>callback</code> after all rows have been sent, or when there is an error.
-     * <p>
-     *   The query can be prepared (recommended) or not depending on the [prepare]{@linkcode QueryOptions} flag.
-     * </p>
+     * Executes the query and calls ``rowCallback`` for each row as soon as they are received. Calls the final
+     * ``callback`` after all rows have been sent, or when there is an error.
+     *
+     * The query can be prepared (recommended) or not depending on the [prepare]{@linkcode QueryOptions} flag.
+     *
      * @param {String} query The query to execute
      * @param {Array|Object} [params] Array of parameter values or an associative array (object) containing parameter names
      * as keys and its value.
      * @param {QueryOptions} [options] The query options.
-     * @param {function} rowCallback Executes <code>rowCallback(n, row)</code> per each row received, where n is the row
+     * @param {function} rowCallback Executes ``rowCallback(n, row)`` per each row received, where n is the row
      * index and row is the current Row.
-     * @param {function} [callback] Executes <code>callback(err, result)</code> after all rows have been received.
-     * <p>
-     *   When dealing with paged results, [ResultSet#nextPage()]{@link module:types~ResultSet#nextPage} method can be used
-     *   to retrieve the following page. In that case, <code>rowCallback()</code> will be again called for each row and
-     *   the final callback will be invoked when all rows in the following page has been retrieved.
-     * </p>
+     * @param {function} [callback] Executes ``callback(err, result)`` after all rows have been received.
+     *
+     * When dealing with paged results, [ResultSet#nextPage()]{@link module:types~ResultSet#nextPage} method can be used
+     * to retrieve the following page. In that case, ``rowCallback()`` will be again called for each row and
+     * the final callback will be invoked when all rows in the following page has been retrieved.
+     *
      * @example <caption>Using per-row callback and arrow functions</caption>
      * client.eachRow(query, params, { prepare: true }, (n, row) => console.log(n, row), err => console.error(err));
      * @example <caption>Overloads</caption>
@@ -504,15 +501,14 @@ class Client extends events.EventEmitter {
 
     /**
      * Executes the query and pushes the rows to the result stream as soon as they received.
-     * <p>
+     *
      * The stream is a [ReadableStream]{@linkcode https://nodejs.org/api/stream.html#stream_class_stream_readable} object
-     *  that emits rows.
-     *  It can be piped downstream and provides automatic pause/resume logic (it buffers when not read).
-     * </p>
-     * <p>
-     *   The query can be prepared (recommended) or not depending on {@link QueryOptions}.prepare flag. Retries on multiple
-     *   hosts if needed.
-     * </p>
+     * that emits rows.
+     * It can be piped downstream and provides automatic pause/resume logic (it buffers when not read).
+     *
+     * The query can be prepared (recommended) or not depending on {@link QueryOptions}.prepare flag. Retries on multiple
+     * hosts if needed.
+     *
      * @param {String} query The query to prepare and execute.
      * @param {Array|Object} [params] Array of parameter values or an associative array (object) containing parameter names
      * as keys and its value
@@ -571,7 +567,9 @@ class Client extends events.EventEmitter {
 
     /**
      * Executes batch of queries on an available connection to a host.
-     * <p>It returns a <code>Promise</code> when a <code>callback</code> is not provided.</p>
+     *
+     * It returns a ``Promise`` when a ``callback`` is not provided.
+     *
      * @param {Array.<string>|Array.<{query, params}>} queries The queries to execute as an Array of strings or as an array
      * of object containing the query and params
      * @param {QueryOptions} [options] The query options.
@@ -661,10 +659,10 @@ class Client extends events.EventEmitter {
 
     /**
      * Gets a snapshot containing information on the connections pools held by this Client at the current time.
-     * <p>
-     *   The information provided in the returned object only represents the state at the moment this method was called and
-     *   it's not maintained in sync with the driver metadata.
-     * </p>
+     *
+     * The information provided in the returned object only represents the state at the moment this method was called and
+     * it's not maintained in sync with the driver metadata.
+     *
      * @returns {ClientState} A [ClientState]{@linkcode module:metadata~ClientState} instance.
      */
     getState() {
@@ -675,7 +673,9 @@ class Client extends events.EventEmitter {
 
     /**
      * Closes all connections to all hosts.
-     * <p>It returns a <code>Promise</code> when a <code>callback</code> is not provided.</p>
+     *
+     * It returns a ``Promise`` when a ``callback`` is not provided.
+     *
      * @param {Function} [callback] Optional callback to be invoked when finished closing all connections.
      */
     shutdown(callback) {


### PR DESCRIPTION
Remove html tags from documentation, replace with markdown. ``Client``, ``ClientOptions`` and ``QueryOptions`` were updated.