### PR TITLE
Basic query options

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -18,126 +18,7 @@ const promiseUtils = require("./promise-utils");
 const rust = require("../index");
 const ResultSet = require("./types/result-set.js");
 const { parseParams } = require("./types/cql-utils.js");
-
-/**
- * Query options
- * @typedef {Object} QueryOptions
- * [TODO: Add support for this field]
- * @property {boolean} [autoPage] Determines if the driver must retrieve the following result pages automatically.
- *
- * This setting is only considered by the [Client#eachRow()]{@link Client#eachRow} method. For more information,
- * check the
- * [paging results documentation]{@link https://docs.datastax.com/en/developer/nodejs-driver/latest/features/paging/}.
- *
- * [TODO: Add support for this field]
- * @property {boolean} [captureStackTrace] Determines if the stack trace before the query execution should be
- * maintained.
- *
- * Useful for debugging purposes, it should be set to ``false`` under production environment as it adds an
- * unnecessary overhead to each execution.
- *
- * Default: false.
- * [TODO: Add support for this field]
- * @property {number} [consistency] [Consistency level]{@link module:types~consistencies}.
- *
- * Defaults to ``localOne`` for Apache Cassandra and DSE deployments.
- * For DataStax Astra, it defaults to ``localQuorum``.
- *
- * [TODO: Add support for this field]
- * @property {Object} [customPayload] Key-value payload to be passed to the server. On the Cassandra side,
- * implementations of QueryHandler can use this data.
- * [TODO: Add support for this field]
- * @property {string|ExecutionProfile} [executionProfile] Name or instance of the [profile]{@link ExecutionProfile} to
- * be used for this execution. If not set, it will the use "default" execution profile.
- * [TODO: Add support for this field]
- * @property {number} [fetchSize] Amount of rows to retrieve per page.
- * [TODO: Add support for this field]
- * @property {Array|Array<Array>} [hints] Type hints for parameters given in the query, ordered as for the parameters.
- *
- * For batch queries, an array of such arrays, ordered as with the queries in the batch.
- * [TODO: Add support for this field]
- * @property {Host} [host] The host that should handle the query.
- *
- * Use of this option is **heavily discouraged** and should only be used in the following cases:
- *
- * 1. Querying node-local tables, such as tables in the ``system`` and ``system_views`` keyspaces.
- * 2. Applying a series of schema changes, where it may be advantageous to execute schema changes in sequence on the
- *    same node.
- *
- * Configuring a specific host causes the configured
- * [LoadBalancingPolicy]{@link module:policies/loadBalancing~LoadBalancingPolicy} to be completely bypassed.
- * However, if the load balancing policy dictates that the host is at a
- * [distance of ignored]{@link module:types~distance} or there is no active connectivity to the host, the request will
- * fail with a [NoHostAvailableError]{@link module:errors~NoHostAvailableError}.
- *
- * [TODO: Add support for this field]
- * @property {boolean} [isIdempotent] Defines whether the query can be applied multiple times without changing the result
- * beyond the initial application.
- *
- * The query execution idempotence can be used at [RetryPolicy]{@link module:policies/retry~RetryPolicy} level to
- * determine if an statement can be retried in case of request error or write timeout.
- *
- * Default: ``false``.
- *
- * [TODO: Add support for this field]
- * @property {string} [keyspace] Specifies the keyspace for the query. It is used for the following:
- *
- * 1. To indicate what keyspace the statement is applicable to (protocol V5+ only).  This is useful when the
- * query does not provide an explicit keyspace and you want to override the current {@link Client#keyspace}.
- * 2. For query routing when the query operates on a different keyspace than the current {@link Client#keyspace}.
- *
- * [TODO: Add support for this field]
- * @property {boolean} [logged] Determines if the batch should be written to the batchlog. Only valid for
- * [Client#batch()]{@link Client#batch}, it will be ignored by other methods. Default: true.
- * [TODO: Add support for this field]
- * @property {boolean} [counter] Determines if its a counter batch. Only valid for
- * [Client#batch()]{@link Client#batch}, it will be ignored by other methods. Default: false.
- * [TODO: Add support for this field]
- * @property {Buffer|string} [pageState] Buffer or string token representing the paging state.
- *
- * Useful for manual paging, if provided, the query will be executed starting from a given paging state.
- * [TODO: Add support for this field]
- * @property {boolean} [prepare] Determines if the query must be executed as a prepared statement.
- * [TODO: Add support for this field]
- * @property {number} [readTimeout] When defined, it overrides the default read timeout
- * (``socketOptions.readTimeout``) in milliseconds for this execution per coordinator.
- *
- * Suitable for statements for which the coordinator may allow a longer server-side timeout, for example aggregation
- * queries.
- *
- * A value of ``0`` disables client side read timeout for the execution. Default: ``undefined``.
- *
- * [TODO: Add support for this field]
- * @property {RetryPolicy} [retry] Retry policy for the query.
- *
- * This property can be used to specify a different [retry policy]{@link module:policies/retry} to the one specified
- * in the {@link ClientOptions}.policies.
- * [TODO: Add support for this field]
- * @property {Array} [routingIndexes] Index of the parameters that are part of the partition key to determine
- * the routing.
- * [TODO: Add support for this field]
- * @property {Buffer|Array} [routingKey] Partition key(s) to determine which coordinator should be used for the query.
- * [TODO: Add support for this field]
- * @property {Array} [routingNames] Array of the parameters names that are part of the partition key to determine the
- * routing. Only valid for non-prepared requests, it's recommended that you use the prepare flag instead.
- * [TODO: Add support for this field]
- * @property {number} [serialConsistency] Serial consistency is the consistency level for the serial phase of
- * conditional updates.
- * This option will be ignored for anything else that a conditional update/insert.
- * [TODO: Add support for this field]
- * @property {number|Long} [timestamp] The default timestamp for the query in microseconds from the unix epoch
- * (00:00:00, January 1st, 1970).
- *
- * If provided, this will replace the server side assigned timestamp as default timestamp.
- *
- * Use [generateTimestamp()]{@link module:types~generateTimestamp} utility method to generate a valid timestamp
- * based on a Date and microseconds parts.
- * [TODO: Add support for this field]
- * @property {boolean} [traceQuery] Enable query tracing for the execution. Use query tracing to diagnose performance
- * problems related to query executions. Default: false.
- *
- * To retrieve trace, you can call [Metadata.getTrace()]{@link module:metadata~Metadata#getTrace} method.
- */
+const queryOptions = require("./query-options.js");
 
 /**
  * Represents a database client that maintains multiple connections to the cluster nodes, providing methods to
@@ -330,7 +211,7 @@ class Client extends events.EventEmitter {
      * @param {string} query The query to execute.
      * @param {Array|Object} [params] Array of parameter values or an associative array (object) containing parameter names
      * as keys and its value.
-     * @param {QueryOptions} [options] The query options for the execution.
+     * @param {queryOptions.QueryOptions} [options] The query options for the execution.
      * @param {ResultCallback} [callback] Executes callback(err, result) when execution completed. When not defined, the
      * method will return a promise.
      * @example <caption>Promise-based API, using async/await</caption>
@@ -393,7 +274,7 @@ class Client extends events.EventEmitter {
      * @param {string} query The query to execute
      * @param {Array|Object} [params] Array of parameter values or an associative array (object) containing parameter names
      * as keys and its value.
-     * @param {QueryOptions} [options] The query options.
+     * @param {queryOptions.QueryOptions} [options] The query options.
      * @param {function} rowCallback Executes ``rowCallback(n, row)`` per each row received, where n is the row
      * index and row is the current Row.
      * @param {function} [callback] Executes ``callback(err, result)`` after all rows have been received.
@@ -486,7 +367,7 @@ class Client extends events.EventEmitter {
      * @param {string} query The query to prepare and execute.
      * @param {Array|Object} [params] Array of parameter values or an associative array (object) containing parameter names
      * as keys and its value
-     * @param {QueryOptions} [options] The query options.
+     * @param {queryOptions.QueryOptions} [options] The query options.
      * @param {function} [callback] executes callback(err) after all rows have been received or if there is an error
      * @returns {ResultStream}
      */
@@ -546,7 +427,7 @@ class Client extends events.EventEmitter {
      *
      * @param {Array.<string>|Array.<{query, params}>} queries The queries to execute as an Array of strings or as an array
      * of object containing the query and params
-     * @param {QueryOptions} [options] The query options.
+     * @param {queryOptions.QueryOptions} [options] The query options.
      * @param {ResultCallback} [callback] Executes callback(err, result) when the batch was executed
      */
     batch(queries, options, callback) {
@@ -564,7 +445,7 @@ class Client extends events.EventEmitter {
     /**
      * Async-only version of {@link Client#batch()} .
      * @param {Array.<string>|Array.<{query, params}>}queries
-     * @param {QueryOptions} options
+     * @param {queryOptions.QueryOptions} options
      * @returns {Promise<ResultSet>}
      * @private
      */
@@ -778,7 +659,7 @@ class Client extends events.EventEmitter {
         }
 
         return new Promise((resolve, reject) => {
-            this.#executePromise(resolve, reject, query, params);
+            this.#executePromise(resolve, reject, query, params, execOptions);
         });
     }
 
@@ -789,9 +670,9 @@ class Client extends events.EventEmitter {
      * @param {string} query
      * @param {Array} params
      */
-    async #executePromise(resolve, reject, query, params) {
+    async #executePromise(resolve, reject, query, params, execOptions) {
         try {
-            let rustOptions = rust.QueryOptionsWrapper.emptyOptions();
+            let rustOptions = queryOptions.queryOptionsIntoWrapper(execOptions);
             let rusty;
             // Optimize: If we have no parameters we can skip preparation step
             if (!params) {

--- a/lib/client.js
+++ b/lib/client.js
@@ -47,13 +47,6 @@ const { parseParams } = require("./types/cql-utils.js");
  * @property {Object} [customPayload] Key-value payload to be passed to the server. On the Cassandra side,
  * implementations of QueryHandler can use this data.
  * [TODO: Add support for this field]
- * @property {string} [executeAs] The user or role name to act as when executing this statement.
- *
- * When set, it executes as a different user/role than the one currently authenticated (a.k.a. proxy execution).
- *
- * This feature is only available in DSE 5.1+.
- *
- * [TODO: Add support for this field Delete?]
  * @property {string|ExecutionProfile} [executionProfile] Name or instance of the [profile]{@link ExecutionProfile} to
  * be used for this execution. If not set, it will the use "default" execution profile.
  * [TODO: Add support for this field]
@@ -798,10 +791,14 @@ class Client extends events.EventEmitter {
      */
     async #executePromise(resolve, reject, query, params) {
         try {
+            let rustOptions = rust.QueryOptionsWrapper.emptyOptions();
             let rusty;
             // Optimize: If we have no parameters we can skip preparation step
             if (!params) {
-                rusty = await this.rustClient.queryUnpagedNoValues(query);
+                rusty = await this.rustClient.queryUnpagedNoValues(
+                    query,
+                    rustOptions,
+                );
             }
             // Otherwise prepare the statement to know the types
             else {
@@ -810,6 +807,7 @@ class Client extends events.EventEmitter {
                 rusty = await this.rustClient.executePreparedUnpaged(
                     statement,
                     parsedParams,
+                    rustOptions,
                 );
             }
             resolve(new ResultSet(rusty));

--- a/lib/query-options.js
+++ b/lib/query-options.js
@@ -1,0 +1,156 @@
+const Long = require("long");
+const rust = require("../index");
+const _execOptions = require("./execution-options");
+const { longToBigint } = require("./new-utils");
+
+/**
+ * Query options
+ * @typedef {Object} QueryOptions
+ * [TODO: Add support for this field]
+ * @property {boolean} [autoPage] Determines if the driver must retrieve the following result pages automatically.
+ *
+ * This setting is only considered by the [Client#eachRow()]{@link Client#eachRow} method. For more information,
+ * check the
+ * [paging results documentation]{@link https://docs.datastax.com/en/developer/nodejs-driver/latest/features/paging/}.
+ *
+ * [TODO: Add support for this field]
+ * @property {boolean} [captureStackTrace] Determines if the stack trace before the query execution should be
+ * maintained.
+ *
+ * Useful for debugging purposes, it should be set to ``false`` under production environment as it adds an
+ * unnecessary overhead to each execution.
+ *
+ * Default: false.
+ * [TODO: Add support for this field]
+ * @property {number} [consistency] [Consistency level]{@link module:types~consistencies}.
+ *
+ * Defaults to ``localOne`` for Apache Cassandra and ScyllaDB deployments.
+ *
+ * [TODO: Test this field]
+ * @property {Object} [customPayload] Key-value payload to be passed to the server. On the Cassandra side,
+ * implementations of QueryHandler can use this data.
+ * [TODO: Add support for this field]
+ * @property {string|ExecutionProfile} [executionProfile] Name or instance of the [profile]{@link ExecutionProfile} to
+ * be used for this execution. If not set, it will the use "default" execution profile.
+ * [TODO: Add support for this field]
+ * @property {number} [fetchSize] Amount of rows to retrieve per page.
+ * [TODO: Add support for this field]
+ * @property {Array|Array<Array>} [hints] Type hints for parameters given in the query, ordered as for the parameters.
+ *
+ * For batch queries, an array of such arrays, ordered as with the queries in the batch.
+ * [TODO: Add support for this field]
+ * @property {Host} [host] The host that should handle the query.
+ *
+ * Use of this option is **heavily discouraged** and should only be used in the following cases:
+ *
+ * 1. Querying node-local tables, such as tables in the ``system`` and ``system_views`` keyspaces.
+ * 2. Applying a series of schema changes, where it may be advantageous to execute schema changes in sequence on the
+ *    same node.
+ *
+ * Configuring a specific host causes the configured
+ * [LoadBalancingPolicy]{@link module:policies/loadBalancing~LoadBalancingPolicy} to be completely bypassed.
+ * However, if the load balancing policy dictates that the host is at a
+ * [distance of ignored]{@link module:types~distance} or there is no active connectivity to the host, the request will
+ * fail with a [NoHostAvailableError]{@link module:errors~NoHostAvailableError}.
+ *
+ * [TODO: Add support for this field]
+ * @property {boolean} [idempotent] Defines whether the query can be applied multiple times without changing the result
+ * beyond the initial application.
+ *
+ * The query execution idempotence can be used at [RetryPolicy]{@link module:policies/retry~RetryPolicy} level to
+ * determine if an statement can be retried in case of request error or write timeout.
+ *
+ * Default: ``false``.
+ *
+ * [TODO: Add support for this field]
+ * @property {string} [keyspace] Specifies the keyspace for the query. It is used for the following:
+ *
+ * 1. To indicate what keyspace the statement is applicable to (protocol V5+ only).  This is useful when the
+ * query does not provide an explicit keyspace and you want to override the current {@link Client#keyspace}.
+ * 2. For query routing when the query operates on a different keyspace than the current {@link Client#keyspace}.
+ *
+ * [TODO: Add support for this field]
+ * @property {boolean} [logged] Determines if the batch should be written to the batchlog. Only valid for
+ * [Client#batch()]{@link Client#batch}, it will be ignored by other methods. Default: true.
+ * [TODO: Add support for this field]
+ * @property {boolean} [counter] Determines if its a counter batch. Only valid for
+ * [Client#batch()]{@link Client#batch}, it will be ignored by other methods. Default: false.
+ * [TODO: Add support for this field]
+ * @property {Buffer|string} [pageState] Buffer or string token representing the paging state.
+ *
+ * Useful for manual paging, if provided, the query will be executed starting from a given paging state.
+ * [TODO: Add support for this field]
+ * @property {boolean} [prepare] Determines if the query must be executed as a prepared statement.
+ * [TODO: Add support for this field]
+ * @property {number} [readTimeout] When defined, it overrides the default read timeout
+ * (``socketOptions.readTimeout``) in milliseconds for this execution per coordinator.
+ *
+ * Suitable for statements for which the coordinator may allow a longer server-side timeout, for example aggregation
+ * queries.
+ *
+ * A value of ``0`` disables client side read timeout for the execution. Default: ``undefined``.
+ *
+ * [TODO: Add support for this field]
+ * @property {RetryPolicy} [retry] Retry policy for the query.
+ *
+ * This property can be used to specify a different [retry policy]{@link module:policies/retry} to the one specified
+ * in the {@link ClientOptions}.policies.
+ * [TODO: Add support for this field]
+ * @property {Array} [routingIndexes] Index of the parameters that are part of the partition key to determine
+ * the routing.
+ * [TODO: Add support for this field]
+ * @property {Buffer|Array} [routingKey] Partition key(s) to determine which coordinator should be used for the query.
+ * [TODO: Add support for this field]
+ * @property {Array} [routingNames] Array of the parameters names that are part of the partition key to determine the
+ * routing. Only valid for non-prepared requests, it's recommended that you use the prepare flag instead.
+ * [TODO: Add support for this field]
+ * @property {number} [serialConsistency] Serial consistency is the consistency level for the serial phase of
+ * conditional updates.
+ * This option will be ignored for anything else that a conditional update/insert.
+ * [TODO: Add support for this field]
+ * @property {number|Long} [timestamp] The default timestamp for the query in microseconds from the unix epoch
+ * (00:00:00, January 1st, 1970).
+ *
+ * If provided, this will replace the server side assigned timestamp as default timestamp.
+ *
+ * Use [generateTimestamp()]{@link module:types~generateTimestamp} utility method to generate a valid timestamp
+ * based on a Date and microseconds parts.
+ * [TODO: Test this field]
+ * @property {boolean} [traceQuery] Enable query tracing for the execution. Use query tracing to diagnose performance
+ * problems related to query executions. Default: false.
+ *
+ * To retrieve trace, you can call [Metadata.getTrace()]{@link module:metadata~Metadata#getTrace} method.
+ */
+
+/**
+ * Parses js query options into rust query options wrapper
+ * @param {_execOptions.ExecutionOptions} options
+ * @returns {rust.QueryOptionsWrapper}
+ * @package
+ */
+function queryOptionsIntoWrapper(options) {
+    let wrapper = rust.QueryOptionsWrapper.emptyOptions();
+
+    wrapper.autoPage = options.isAutoPage();
+    wrapper.captureStackTrace = options.getCaptureStackTrace();
+    wrapper.consistency = options.getConsistency();
+    wrapper.counter = options.counter;
+    wrapper.fetchSize = options.getFetchSize();
+    wrapper.isIdempotent = options.isIdempotent();
+    wrapper.keyspace = options.keyspace;
+    wrapper.logged = options.logged;
+    wrapper.prepare = options.prepare;
+    wrapper.readTimeout = options.getReadTimeout();
+    wrapper.routingIndexes = options.getRoutingIndexes();
+    wrapper.routingNames = options.getRoutingNames();
+    wrapper.serialConsistency = options.getSerialConsistency();
+    let timestamp = options.getTimestamp();
+    if (timestamp instanceof Long) timestamp = longToBigint(timestamp);
+    else if (timestamp) timestamp = BigInt(timestamp);
+    wrapper.timestamp = timestamp;
+    wrapper.traceQuery = options.traceQuery;
+
+    return wrapper;
+}
+
+module.exports.queryOptionsIntoWrapper = queryOptionsIntoWrapper;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,7 @@ extern crate napi_derive;
 // Link other files
 pub mod auth;
 pub mod options;
-pub mod request;
+pub mod requests;
 pub mod result;
 pub mod session;
 pub mod tests;

--- a/src/requests/mod.rs
+++ b/src/requests/mod.rs
@@ -1,0 +1,2 @@
+pub mod parameter_wrappers;
+pub mod request;

--- a/src/requests/parameter_wrappers.rs
+++ b/src/requests/parameter_wrappers.rs
@@ -1,17 +1,13 @@
 use napi::bindgen_prelude::{BigInt, Buffer};
-use scylla::{
-    frame::{
-        response::result::CqlValue,
-        value::{Counter, CqlTimestamp, CqlTimeuuid},
-    },
-    prepared_statement::PreparedStatement,
+use scylla::frame::{
+    response::result::CqlValue,
+    value::{Counter, CqlTimestamp, CqlTimeuuid},
 };
 
 use crate::{
-    result::map_column_type_to_complex_type,
     types::{
         duration::DurationWrapper, inet::InetAddressWrapper, local_date::LocalDateWrapper,
-        local_time::LocalTimeWrapper, type_wrappers::ComplexType, uuid::UuidWrapper,
+        local_time::LocalTimeWrapper, uuid::UuidWrapper,
     },
     utils::{bigint_to_i64, js_error},
 };
@@ -20,12 +16,6 @@ use crate::{
 #[napi]
 pub struct QueryParameterWrapper {
     pub(crate) parameter: CqlValue,
-}
-
-#[napi]
-/// Wrapper for struct representing Prepared statement to the database
-pub struct PreparedStatementWrapper {
-    pub(crate) prepared: PreparedStatement,
 }
 
 #[napi]
@@ -203,19 +193,6 @@ impl QueryParameterWrapper {
     ) -> Vec<Option<CqlValue>> {
         row.iter()
             .map(|e| e.as_ref().map(|v| v.parameter.clone()))
-            .collect()
-    }
-}
-
-#[napi]
-impl PreparedStatementWrapper {
-    #[napi]
-    /// Get array of expected types for this prepared statement.
-    pub fn get_expected_types(&self) -> Vec<ComplexType> {
-        self.prepared
-            .get_variable_col_specs()
-            .iter()
-            .map(|e| map_column_type_to_complex_type(e.typ()))
             .collect()
     }
 }

--- a/src/requests/request.rs
+++ b/src/requests/request.rs
@@ -1,0 +1,21 @@
+use scylla::prepared_statement::PreparedStatement;
+
+use crate::{result::map_column_type_to_complex_type, types::type_wrappers::ComplexType};
+
+#[napi]
+pub struct PreparedStatementWrapper {
+    pub(crate) prepared: PreparedStatement,
+}
+
+#[napi]
+impl PreparedStatementWrapper {
+    #[napi]
+    /// Get array of expected types for this prepared statement.
+    pub fn get_expected_types(&self) -> Vec<ComplexType> {
+        self.prepared
+            .get_variable_col_specs()
+            .iter()
+            .map(|e| map_column_type_to_complex_type(e.typ()))
+            .collect()
+    }
+}

--- a/src/requests/request.rs
+++ b/src/requests/request.rs
@@ -1,3 +1,4 @@
+use napi::bindgen_prelude::BigInt;
 use scylla::prepared_statement::PreparedStatement;
 
 use crate::{result::map_column_type_to_complex_type, types::type_wrappers::ComplexType};
@@ -5,6 +6,32 @@ use crate::{result::map_column_type_to_complex_type, types::type_wrappers::Compl
 #[napi]
 pub struct PreparedStatementWrapper {
     pub(crate) prepared: PreparedStatement,
+}
+
+#[napi]
+pub struct QueryOptionsWrapper {
+    pub auto_page: Option<bool>,
+    pub capture_stack_trace: Option<bool>,
+    pub consistency: Option<u16>,
+    pub counter: Option<bool>,
+    // customPayload?: any;
+    // executionProfile?: string | ExecutionProfile;
+    pub fetch_size: Option<i32>,
+    // hints?: string[] | string[][];
+    // host?: Host;
+    pub is_idempotent: Option<bool>,
+    pub keyspace: Option<String>,
+    pub logged: Option<bool>,
+    // pageState?: Buffer | string;
+    pub prepare: Option<bool>,
+    pub read_timeout: Option<i32>,
+    // retry?: policies.retry.RetryPolicy;
+    pub routing_indexes: Option<Vec<i32>>,
+    // routingKey?: Buffer | Buffer[];
+    pub routing_names: Option<Vec<String>>,
+    pub serial_consistency: Option<i16>,
+    pub timestamp: Option<BigInt>,
+    pub trace_query: Option<bool>,
 }
 
 #[napi]
@@ -17,5 +44,29 @@ impl PreparedStatementWrapper {
             .iter()
             .map(|e| map_column_type_to_complex_type(e.typ()))
             .collect()
+    }
+}
+
+#[napi]
+impl QueryOptionsWrapper {
+    #[napi]
+    pub fn empty_options() -> QueryOptionsWrapper {
+        QueryOptionsWrapper {
+            auto_page: None,
+            capture_stack_trace: None,
+            consistency: None,
+            counter: None,
+            fetch_size: None,
+            is_idempotent: None,
+            keyspace: None,
+            logged: None,
+            prepare: None,
+            read_timeout: None,
+            routing_indexes: None,
+            routing_names: None,
+            serial_consistency: None,
+            timestamp: None,
+            trace_query: None,
+        }
     }
 }

--- a/src/session.rs
+++ b/src/session.rs
@@ -4,6 +4,7 @@ use scylla::{
 };
 
 use crate::requests::parameter_wrappers::QueryParameterWrapper;
+use crate::requests::request::QueryOptionsWrapper;
 use crate::{
     options, requests::request::PreparedStatementWrapper, result::QueryResultWrapper,
     utils::err_to_napi,
@@ -60,7 +61,11 @@ impl SessionWrapper {
     }
 
     #[napi]
-    pub async fn query_unpaged_no_values(&self, query: String) -> napi::Result<QueryResultWrapper> {
+    pub async fn query_unpaged_no_values(
+        &self,
+        query: String,
+        _options: &QueryOptionsWrapper,
+    ) -> napi::Result<QueryResultWrapper> {
         let query_result = self
             .internal
             .query_unpaged(query, &[])
@@ -99,6 +104,7 @@ impl SessionWrapper {
         &self,
         query: &PreparedStatementWrapper,
         params: Vec<Option<&QueryParameterWrapper>>,
+        _options: &QueryOptionsWrapper,
     ) -> napi::Result<QueryResultWrapper> {
         let params_vec: Vec<Option<CqlValue>> = QueryParameterWrapper::extract_parameters(params);
         QueryResultWrapper::from_query(

--- a/src/session.rs
+++ b/src/session.rs
@@ -3,10 +3,9 @@ use scylla::{
     SessionBuilder,
 };
 
+use crate::requests::parameter_wrappers::QueryParameterWrapper;
 use crate::{
-    options,
-    request::{PreparedStatementWrapper, QueryParameterWrapper},
-    result::QueryResultWrapper,
+    options, requests::request::PreparedStatementWrapper, result::QueryResultWrapper,
     utils::err_to_napi,
 };
 

--- a/src/tests/request_values_tests.rs
+++ b/src/tests/request_values_tests.rs
@@ -9,7 +9,7 @@ use scylla::frame::{
 };
 
 use crate::{
-    request::QueryParameterWrapper,
+    requests::parameter_wrappers::QueryParameterWrapper,
     types::type_wrappers::{ComplexType, CqlType},
 };
 

--- a/test/integration/supported/client-execute-prepared-tests.js
+++ b/test/integration/supported/client-execute-prepared-tests.js
@@ -899,9 +899,7 @@ describe("Client @SERVER_API", function () {
         });
  */
 
-        // Protocol level timestamp implemented in #92
-        // TODO: fix this test
-        /* vit("2.1", "should support protocol level timestamp", function (done) {
+        vit("2.1", "should support protocol level timestamp", function (done) {
             const client = setupInfo.client;
             const id = Uuid.random();
             const timestamp = types.generateTimestamp(new Date(), 456);
@@ -951,7 +949,7 @@ describe("Client @SERVER_API", function () {
                 ],
                 done,
             );
-        }); */
+        });
 
         // No support for client keyspace option
         // TODO: fix this test

--- a/test/integration/supported/client-execute-tests.js
+++ b/test/integration/supported/client-execute-tests.js
@@ -543,10 +543,7 @@ describe("Client @SERVER_API", function () {
                 },
             );
         });
-
-        // No support for consistency
-        // TODO: Fix this test
-        /* it("should accept localOne and localQuorum consistencies", function (done) {
+        it("should accept localOne and localQuorum consistencies", function (done) {
             const client = setupInfo.client;
             utils.series(
                 [
@@ -569,9 +566,9 @@ describe("Client @SERVER_API", function () {
                 ],
                 done,
             );
-        }); */
+        });
 
-        // No support for consistency
+        // No support for ExecutionProfile
         // TODO: Fix this test
         /* it("should use consistency level from profile and override profile when provided in query options", function (done) {
             const client = newInstance({
@@ -824,7 +821,7 @@ describe("Client @SERVER_API", function () {
             );
         }); */
 
-        // No support for consistency levels
+        // No support for ExecutionProfile consistency levels
         // TODO: Fix this test
         /* vit(
             "2.0",
@@ -896,9 +893,7 @@ describe("Client @SERVER_API", function () {
             },
         ); */
 
-        // No support for protocol level timestamp
-        // TODO: Fix this test
-        /* vit("2.1", "should support protocol level timestamp", function (done) {
+        vit("2.1", "should support protocol level timestamp", function (done) {
             const client = setupInfo.client;
             const id = types.Uuid.random();
             const timestamp = types.generateTimestamp(new Date(), 777);
@@ -938,7 +933,7 @@ describe("Client @SERVER_API", function () {
                 ],
                 done,
             );
-        }); */
+        });
 
         // No support for queryTrace flag
         // TODO: Fix this test
@@ -1983,10 +1978,7 @@ describe("Client @SERVER_API", function () {
                 },
             );
         }); */
-
-        // No support for consistency
-        // TODO: Fix this test
-        /* describe("with no callback specified", function () {
+        describe("with no callback specified", function () {
             vit(
                 "2.0",
                 "should return a promise with the result as a value",
@@ -2024,7 +2016,8 @@ describe("Client @SERVER_API", function () {
                         });
                 },
             );
-            it("should reject the promise when there is a syntax error", function () {
+            // Would require correct error throwing
+            /* it("should reject the promise when there is a syntax error", function () {
                 const client = setupInfo.client;
                 return client
                     .connect()
@@ -2037,9 +2030,8 @@ describe("Client @SERVER_API", function () {
                     .catch(function (err) {
                         helper.assertInstanceOf(err, errors.ResponseError);
                     });
-            });
-        }); */
-
+            }); */
+        });
         vdescribe("2.0", "with lightweight transactions", function () {
             const client = setupInfo.client;
             const id = types.Uuid.random();


### PR DESCRIPTION
Add wrapper for query options. Passes those options from JS code to rust. Make use of some basic options: 

- consistency
- is_idempotent
- fetch_size
- timestamp (would require #93 to function properly)
- trace_query (doesn't take use of the trace)

Reorganize rust request structure, by moving code related to request logic into separate folder.