### PR TITLE
Disable eslint on integration tests

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -6,7 +6,7 @@ import pluginJs from "@eslint/js";
 export default [
   pluginJs.configs.recommended,
   {
-    ignores: ["test/integration/not-supported/**"],
+    ignores: ["test/integration/**"],
   }, 
   {
     files: ["lib/**/*.js", "test/**/*.js", "examples/**/*.js"], 
@@ -32,6 +32,7 @@ export default [
       "spaced-comment": "error",
 
       // This will be deleted after everything is switched from prototypes to classes
+      // TODO: FIX
       "no-prototype-builtins": "off",
 
       // Check if variable names are in camelCase


### PR DESCRIPTION
Integration tests do not pass eslint rules, so it will be switched off for now. Issue to resolve that was created #106.