### PR TITLE
Add support for client options

### DIFF
--- a/lib/auth/plain-text-auth-provider.js
+++ b/lib/auth/plain-text-auth-provider.js
@@ -1,67 +1,63 @@
 "use strict";
-const util = require("util");
-
 const provider = require("./provider.js");
 const utils = require("../utils");
 const AuthProvider = provider.AuthProvider;
 const Authenticator = provider.Authenticator;
+
 /**
- * Creates a new instance of the Authenticator provider
- * @classdesc Provides plain text [Authenticator]{@link module:auth~Authenticator} instances to be used when
+ * Provides plain text [Authenticator]{@link module:auth~Authenticator} instances to be used when
  * connecting to a host.
  * @extends module:auth~AuthProvider
  * @example
  * var authProvider = new cassandra.auth.PlainTextAuthProvider('my_user', 'p@ssword1!');
  * //Set the auth provider in the clientOptions when creating the Client instance
  * const client = new Client({ contactPoints: contactPoints, authProvider: authProvider });
- * @param {String} username User name in plain text
- * @param {String} password Password in plain text
  * @alias module:auth~PlainTextAuthProvider
- * @constructor
  */
-function PlainTextAuthProvider(username, password) {
-    this.username = username;
-    this.password = password;
+class PlainTextAuthProvider extends AuthProvider {
+    /**
+     * Creates a new instance of the Authenticator provider
+     * @param {String} username User name in plain text
+     * @param {String} password Password in plain text
+     */
+    constructor(username, password) {
+        super();
+        this.username = username;
+        this.password = password;
+    }
+    /**
+     * Returns a new [Authenticator]{@link module:auth~Authenticator} instance to be used for plain text authentication.
+     * @override
+     * @returns {Authenticator}
+     */
+    newAuthenticator() {
+        return new PlainTextAuthenticator(this.username, this.password);
+    }
 }
-
-util.inherits(PlainTextAuthProvider, AuthProvider);
-
-/**
- * Returns a new [Authenticator]{@link module:auth~Authenticator} instance to be used for plain text authentication.
- * @override
- * @returns {Authenticator}
- */
-PlainTextAuthProvider.prototype.newAuthenticator = function () {
-    return new PlainTextAuthenticator(this.username, this.password);
-};
 
 /**
  * @ignore
  */
-function PlainTextAuthenticator(username, password) {
-    this.username = username;
-    this.password = password;
+class PlainTextAuthenticator extends Authenticator {
+    constructor(username, password) {
+        super();
+        this.username = username;
+        this.password = password;
+    }
+    initialResponse(callback) {
+        const initialToken = Buffer.concat([
+            utils.allocBufferFromArray([0]),
+            utils.allocBufferFromString(this.username, "utf8"),
+            utils.allocBufferFromArray([0]),
+            utils.allocBufferFromString(this.password, "utf8"),
+        ]);
+        callback(null, initialToken);
+    }
+    evaluateChallenge(challenge, callback) {
+        // noop
+        callback();
+    }
 }
-
-util.inherits(PlainTextAuthenticator, Authenticator);
-
-PlainTextAuthenticator.prototype.initialResponse = function (callback) {
-    const initialToken = Buffer.concat([
-        utils.allocBufferFromArray([0]),
-        utils.allocBufferFromString(this.username, "utf8"),
-        utils.allocBufferFromArray([0]),
-        utils.allocBufferFromString(this.password, "utf8"),
-    ]);
-    callback(null, initialToken);
-};
-
-PlainTextAuthenticator.prototype.evaluateChallenge = function (
-    challenge,
-    callback,
-) {
-    // noop
-    callback();
-};
 
 module.exports = {
     PlainTextAuthenticator,

--- a/lib/client-options.js
+++ b/lib/client-options.js
@@ -45,11 +45,8 @@ const errors = require("./errors.js");
  * Note that you should configure either ``credentials`` or ``authProvider`` to connect to an
  * auth-enabled cluster, but not both.
  *
- * [TODO: Add support for this field]
  * @property {String} [credentials.username] The username to use for plain-text authentication.
- * [TODO: Add support for this field]
  * @property {String} [credentials.password] The password to use for plain-text authentication.
- * [TODO: Add support for this field]
  * @property {Uuid} [id] A unique identifier assigned to a {@link Client} object, that will be communicated to the
  * server (DSE 6.0+) to identify the client instance created with this options. When not defined, the driver will
  * generate a random identifier.
@@ -555,11 +552,6 @@ function validateAuthenticationOptions(options) {
                     "credentials username and password must be a string",
                 );
             }
-
-            options.authProvider = new auth.PlainTextAuthProvider(
-                credentials.username,
-                credentials.password,
-            );
         } else {
             options.authProvider = new auth.NoAuthProvider();
         }
@@ -676,6 +668,19 @@ function setRustOptions(options) {
     rustOptions.applicationName = options.applicationName;
     rustOptions.applicationVersion = options.applicationVersion;
     rustOptions.keyspace = options.keyspace;
+    if (options.credentials) {
+        rustOptions.credentialsUsername = options.credentials.username;
+        rustOptions.credentialsPassword = options.credentials.password;
+    } else if (options.authProvider)
+        if (options.authProvider instanceof auth.PlainTextAuthProvider) {
+            rustOptions.credentialsUsername = options.authProvider.username;
+            rustOptions.credentialsPassword = options.authProvider.password;
+        } else {
+            throw new errors.ArgumentError(
+                // TODO: Add support for other auth providers
+                "Unsupported auth provider: " + options.authProvider,
+            );
+        }
     return rustOptions;
 }
 

--- a/lib/client-options.js
+++ b/lib/client-options.js
@@ -8,6 +8,8 @@ const tracker = require("./tracker");
 const metrics = require("./metrics");
 const auth = require("./auth");
 const { throwNotSupported } = require("./new-utils");
+const rust = require("../index");
+const errors = require("./errors.js");
 
 /**
  * Client options.
@@ -36,7 +38,6 @@ const { throwNotSupported } = require("./new-utils");
  *
  * [TODO: Add support for this field]
  * @property {String} [keyspace] The logged keyspace for all the connections created within the {@link Client} instance.
- * [TODO: Add support for this field]
  * @property {Object} [credentials] An object containing the username and password for plain-text authentication.
  * It configures the authentication provider to be used against Apache Cassandra's PasswordAuthenticator or DSE's
  * DseAuthenticator, when default auth scheme is plain-text.
@@ -663,7 +664,23 @@ function setMetadataDependent(client) {
     );
 }
 
+/**
+ * Create rust options using js Client options
+ * @param {ClientOptions} options
+ * @returns {SessionOptions}
+ * @private
+ */
+function setRustOptions(options) {
+    let rustOptions = rust.SessionOptions.empty();
+    rustOptions.connectPoints = options.contactPoints;
+    rustOptions.applicationName = options.applicationName;
+    rustOptions.applicationVersion = options.applicationVersion;
+    rustOptions.keyspace = options.keyspace;
+    return rustOptions;
+}
+
 exports.extend = extend;
+exports.setRustOptions = setRustOptions;
 exports.defaultOptions = defaultOptions;
 exports.coreConnectionsPerHostV2 = coreConnectionsPerHostV2;
 exports.coreConnectionsPerHostV3 = coreConnectionsPerHostV3;

--- a/lib/client.js
+++ b/lib/client.js
@@ -48,11 +48,7 @@ class Client extends events.EventEmitter {
      */
     constructor(options) {
         super();
-        let rustOptions = rust.SessionOptions.empty();
-        rustOptions.connectPoints = options.contactPoints;
-        rustOptions.applicationName = options.applicationName;
-        rustOptions.applicationVersion = options.applicationVersion;
-        this.rustOptions = rustOptions;
+        this.rustOptions = clientOptions.setRustOptions(options);
 
         this.options = clientOptions.extend(
             { logEmitter: this.emit.bind(this), id: types.Uuid.random() },

--- a/src/session.rs
+++ b/src/session.rs
@@ -20,6 +20,8 @@ pub struct SessionOptions {
     pub keyspace: Option<String>,
     pub application_name: Option<String>,
     pub application_version: Option<String>,
+    pub credentials_username: Option<String>,
+    pub credentials_password: Option<String>,
 }
 
 #[napi]
@@ -42,6 +44,8 @@ impl SessionOptions {
             keyspace: None,
             application_name: None,
             application_version: None,
+            credentials_username: None,
+            credentials_password: None,
         }
     }
 }
@@ -166,6 +170,18 @@ fn configure_session_builder(options: &SessionOptions) -> SessionBuilder {
     builder = builder.known_nodes(&options.connect_points);
     if let Some(keyspace) = &options.keyspace {
         builder = builder.use_keyspace(keyspace, false);
+    }
+    match (
+        options.credentials_username.as_ref(),
+        options.credentials_password.as_ref(),
+    ) {
+        (Some(username), Some(password)) => {
+            builder = builder.user(username, password);
+        }
+        (None, None) => (),
+        (Some(_), None) | (None, Some(_)) => {
+            unreachable!("There is a check in JS Client constructor that should have prevented only one credential passed")
+        }
     }
     builder
 }


### PR DESCRIPTION
Add support for basic client options: ``contact points``, ``keyspace``, ``application_name``, ``application_version``, ``credentials``.