### PR TITLE
Add error types

### DIFF
--- a/lib/errors.js
+++ b/lib/errors.js
@@ -9,163 +9,158 @@ const util = require("util");
  * Base Error
  * @private
  */
-function DriverError(message) {
-    Error.call(this, message);
-    Error.captureStackTrace(this, this.constructor);
-    this.name = this.constructor.name;
-    this.info = "Cassandra Driver Error";
-    // Explicitly set the message property as the Error.call() doesn't set the property on v8
-    this.message = message;
+class DriverError extends Error {
+    /**
+     * @param {string} [message]
+     */
+    constructor(message) {
+        super(message);
+        Error.captureStackTrace(this, this.constructor);
+        this.name = this.constructor.name;
+        this.info = "Cassandra Driver Error";
+        // Explicitly set the message property as the Error.call() doesn't set the property on v8.
+        this.message = message;
+    }
 }
-
-util.inherits(DriverError, Error);
 
 /**
  * Represents an error when a query cannot be performed because no host is available or could be reached by the driver.
- * @param {Object} innerErrors An object map containing the error per host tried
- * @param {String} [message]
- * @constructor
  */
-function NoHostAvailableError(innerErrors, message) {
-    DriverError.call(this, message);
-    this.innerErrors = innerErrors;
-    this.info =
-        "Represents an error when a query cannot be performed because no host is available or could be reached by the driver.";
-    if (!message) {
-        this.message = "All host(s) tried for query failed.";
-        if (innerErrors) {
-            const hostList = Object.keys(innerErrors);
-            if (hostList.length > 0) {
-                const host = hostList[0];
-                this.message += util.format(
-                    " First host tried, %s: %s. See innerErrors.",
-                    host,
-                    innerErrors[host],
-                );
+class NoHostAvailableError extends DriverError {
+    /**
+     * @param {Object} innerErrors An object map containing the error per host tried.
+     * @param {string} [message]
+     */
+    constructor(innerErrors, message) {
+        super(message);
+        this.innerErrors = innerErrors;
+        this.info =
+            "Represents an error when a query cannot be performed because no host is available or could be reached by the driver.";
+        if (!message) {
+            this.message = "All host(s) tried for query failed.";
+            if (innerErrors) {
+                const hostList = Object.keys(innerErrors);
+                if (hostList.length > 0) {
+                    const host = hostList[0];
+                    this.message += ` First host tried, ${host}: ${innerErrors[host]}. See innerErrors.`;
+                }
             }
         }
     }
 }
 
-util.inherits(NoHostAvailableError, DriverError);
-
 /**
- * Represents an error message from the server
- * @param {Number} code Cassandra exception code
- * @param {String} message
- * @constructor
+ * Represents an error message from the server.
  */
-function ResponseError(code, message) {
-    DriverError.call(this, message);
+class ResponseError extends DriverError {
     /**
-     * The error code as defined in [responseErrorCodes]{@link module:types~responseErrorCodes}.
-     * @type {Number}
+     * @param {number} code Cassandra exception code as defined in [responseErrorCodes]{@link module:types~responseErrorCodes}.
+     * @param {string} message
      */
-    this.code = code;
-    this.info = "Represents an error message from the server";
+    constructor(code, message) {
+        super(message);
+        this.code = code;
+        this.info = "Represents an error message from the server.";
+    }
 }
-
-util.inherits(ResponseError, DriverError);
 
 /**
  * Represents a bug inside the driver or in a Cassandra host.
- * @param {String} message
- * @constructor
  */
-function DriverInternalError(message) {
-    DriverError.call(this, message);
-    this.info = "Represents a bug inside the driver or in a Cassandra host.";
-}
-
-util.inherits(DriverInternalError, DriverError);
-
-/**
- * Represents an error when trying to authenticate with auth-enabled host
- * @param {String} message
- * @constructor
- */
-function AuthenticationError(message) {
-    DriverError.call(this, message);
-    this.info =
-        "Represents an authentication error from the driver or from a Cassandra node.";
-}
-
-util.inherits(AuthenticationError, DriverError);
-
-/**
- * Represents an error that is raised when one of the arguments provided to a method is not valid
- * @param {String} message
- * @constructor
- */
-function ArgumentError(message) {
-    DriverError.call(this, message);
-    this.info =
-        "Represents an error that is raised when one of the arguments provided to a method is not valid.";
-}
-
-util.inherits(ArgumentError, DriverError);
-
-/**
- * Represents a client-side error that is raised when the client didn't hear back from the server within
- * {@link ClientOptions.socketOptions.readTimeout}.
- * @param {String} message The error message.
- * @param {String} [host] Address of the server host that caused the operation to time out.
- * @constructor
- */
-function OperationTimedOutError(message, host) {
-    DriverError.call(this, message, this.constructor);
-    this.info =
-        "Represents a client-side error that is raised when the client did not hear back from the server " +
-        "within socketOptions.readTimeout";
-
+class DriverInternalError extends DriverError {
     /**
-     * When defined, it gets the address of the host that caused the operation to time out.
-     * @type {String|undefined}
+     * @param {string} message
      */
-    this.host = host;
+    constructor(message) {
+        super(message);
+        this.info =
+            "Represents a bug inside the driver or in a Cassandra host.";
+    }
 }
 
-util.inherits(OperationTimedOutError, DriverError);
+/**
+ * Represents an error when trying to authenticate with auth-enabled host.
+ */
+class AuthenticationError extends DriverError {
+    /**
+     * @param {string} message
+     */
+    constructor(message) {
+        super(message);
+        this.info =
+            "Represents an authentication error from the driver or from a Cassandra node.";
+    }
+}
+
+/**
+ * Represents an error that is raised when one of the arguments provided to a method is not valid.
+ */
+class ArgumentError extends DriverError {
+    /**
+     * @param {string} message
+     */
+    constructor(message) {
+        super(message);
+        this.info =
+            "Represents an error that is raised when one of the arguments provided to a method is not valid.";
+    }
+}
+
+/**
+ * Represents a client-side error that is raised when the client didn't hear back from the server within.
+ * {@link ClientOptions.socketOptions.readTimeout}.
+ */
+class OperationTimedOutError extends DriverError {
+    /**
+     * @param {string} message
+     * @param {string} [host] Address of the server host that caused the operation to time out.
+     */
+    constructor(message, host) {
+        super(message);
+        this.info =
+            "Represents a client-side error that is raised when the client did not hear back from the server " +
+            "within socketOptions.readTimeout";
+
+        /**
+         * When defined, it gets the address of the host that caused the operation to time out.
+         * @type {string|undefined}
+         */
+        this.host = host;
+    }
+}
 
 /**
  * Represents an error that is raised when a feature is not supported in the driver or in the current Cassandra version.
- * @param message
- * @constructor
  */
-function NotSupportedError(message) {
-    DriverError.call(this, message, this.constructor);
-    this.info =
-        "Represents a feature that is not supported in the driver or in the Cassandra version.";
+class NotSupportedError extends DriverError {
+    /**
+     * @param {string} message
+     */
+    constructor(message) {
+        super(message);
+        this.info =
+            "Represents a feature that is not supported in the driver or in the Cassandra version.";
+    }
 }
-
-util.inherits(NotSupportedError, DriverError);
 
 /**
  * Represents a client-side error indicating that all connections to a certain host have reached
  * the maximum amount of in-flight requests supported.
- * @param {String} address
- * @param {Number} maxRequestsPerConnection
- * @param {Number} connectionLength
- * @constructor
  */
-function BusyConnectionError(
-    address,
-    maxRequestsPerConnection,
-    connectionLength,
-) {
-    const message = util.format(
-        "All connections to host %s are busy, %d requests are in-flight on %s",
-        address,
-        maxRequestsPerConnection,
-        connectionLength === 1 ? "a single connection" : "each connection",
-    );
-    DriverError.call(this, message, this.constructor);
-    this.info =
-        "Represents a client-side error indicating that all connections to a certain host have reached " +
-        "the maximum amount of in-flight requests supported (pooling.maxRequestsPerConnection)";
+class BusyConnectionError extends DriverError {
+    /**
+     * @param {string} address
+     * @param {number} maxRequestsPerConnection
+     * @param {number} connectionLength
+     */
+    constructor(address, maxRequestsPerConnection, connectionLength) {
+        const message = `All connections to host ${address} are busy, ${maxRequestsPerConnection} requests are in-flight on ${connectionLength === 1 ? "a single connection" : "each connection"}`;
+        super(message);
+        this.info =
+            "Represents a client-side error indicating that all connections to a certain host have reached " +
+            "the maximum amount of in-flight requests supported (pooling.maxRequestsPerConnection).";
+    }
 }
-
-util.inherits(BusyConnectionError, DriverError);
 
 exports.ArgumentError = ArgumentError;
 exports.AuthenticationError = AuthenticationError;

--- a/lib/new-utils.js
+++ b/lib/new-utils.js
@@ -1,4 +1,5 @@
 "use strict";
+const customErrors = require("./errors");
 
 /**
  * @param {String} entity
@@ -8,4 +9,47 @@ function throwNotSupported(name) {
     throw new ReferenceError(`${name} is not supported by our driver`);
 }
 
+const errorTypeMap = {
+    ...customErrors,
+    Error,
+    RangeError,
+    ReferenceError,
+    SyntaxError,
+    TypeError,
+};
+
+const concatenationMark = "#";
+
+/**
+ * A wrapper function to map napi errors to Node.js errors or custom errors.
+ * Because NAPI-RS does not support throwing errors different that Error, for example
+ * TypeError, RangeError, etc. or custom, driver-specific errors, this function is used
+ * to catch the original error and throw a new one with the appropriate type.
+ * This should be used to wrap all NAPI-RS functions that may throw errors.
+ *
+ * @param {Function} fn The original function to be wrapped.
+ * @returns {Function} A wrapped function with error handling logic.
+ */
+function napiErrorHandler(fn) {
+    return function (...args) {
+        try {
+            return fn.apply(this, args);
+        } catch (error) {
+            // Check if message is of format errorType#errorMessage, if so map it to
+            // appropriate error, otherwise throw the original error.
+            const [errorType, ...messageParts] =
+                error.message.split(concatenationMark);
+            const message = messageParts.join(concatenationMark);
+
+            if (errorTypeMap[errorType]) {
+                const newError = new errorTypeMap[errorType](message);
+                newError.stack = error.stack;
+                throw newError;
+            }
+            throw error;
+        }
+    };
+}
+
 exports.throwNotSupported = throwNotSupported;
+exports.napiErrorHandler = napiErrorHandler;

--- a/src/tests/error_throwing_tests.rs
+++ b/src/tests/error_throwing_tests.rs
@@ -1,0 +1,23 @@
+use crate::utils::{js_typed_error, ErrorType};
+
+#[napi]
+/// Test function that throws specified error with a custom message.
+pub fn throw_test_error(error_type: String, custom_message: Option<String>) -> napi::Result<()> {
+    let message = custom_message.unwrap_or_else(|| "Test error".to_string());
+    match error_type.as_str() {
+        "ArgumentError" => Err(js_typed_error(&message, ErrorType::ArgumentError)),
+        "AuthenticationError" => Err(js_typed_error(&message, ErrorType::AuthenticationError)),
+        "BusyConnectionError" => Err(js_typed_error(&message, ErrorType::BusyConnectionError)),
+        "DriverError" => Err(js_typed_error(&message, ErrorType::DriverError)),
+        "DriverInternalError" => Err(js_typed_error(&message, ErrorType::DriverInternalError)),
+        "NoHostAvailableError" => Err(js_typed_error(&message, ErrorType::NoHostAvailableError)),
+        "NotSupportedError" => Err(js_typed_error(&message, ErrorType::NotSupportedError)),
+        "ResponseError" => Err(js_typed_error(&message, ErrorType::ResponseError)),
+        "Error" => Err(js_typed_error(&message, ErrorType::Error)),
+        "RangeError" => Err(js_typed_error(&message, ErrorType::RangeError)),
+        "ReferenceError" => Err(js_typed_error(&message, ErrorType::ReferenceError)),
+        "SyntaxError" => Err(js_typed_error(&message, ErrorType::SyntaxError)),
+        "TypeError" => Err(js_typed_error(&message, ErrorType::TypeError)),
+        _ => Ok(()),
+    }
+}

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -1,1 +1,2 @@
+pub mod error_throwing_tests;
 pub mod utils_tests;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -12,13 +12,13 @@ use napi::{bindgen_prelude::BigInt, Status};
 pub enum ErrorType {
     ArgumentError,
     AuthenticationError,
-    BusyConnectionError,
+    BusyConnectionError, // TODO: Add suport for fields of this error
     DriverError,
     DriverInternalError,
-    NoHostAvailableError,
+    NoHostAvailableError, // TODO: Add suport for fields of this error
     NotSupportedError,
-    OperationTimedOutError,
-    ResponseError,
+    OperationTimedOutError, // TODO: Add suport for fields of this error
+    ResponseError,          // TODO: Add suport for fields of this error
     Error,
     RangeError,
     ReferenceError,

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,6 +1,51 @@
-use std::{error::Error, fmt::Display};
+use std::{
+    error::Error,
+    fmt::{self, Display},
+};
 
 use napi::{bindgen_prelude::BigInt, Status};
+
+/// Enum representing possible JavaScript error types.
+/// Error, RangeError, ReferenceError, SyntaxError, TypeError
+/// are native JavaScript error types and the rest are custom
+/// Datastax driver error types.
+pub enum ErrorType {
+    ArgumentError,
+    AuthenticationError,
+    BusyConnectionError,
+    DriverError,
+    DriverInternalError,
+    NoHostAvailableError,
+    NotSupportedError,
+    OperationTimedOutError,
+    ResponseError,
+    Error,
+    RangeError,
+    ReferenceError,
+    SyntaxError,
+    TypeError,
+}
+
+impl Display for ErrorType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(match self {
+            ErrorType::ArgumentError => "ArgumentError",
+            ErrorType::AuthenticationError => "AuthenticationError",
+            ErrorType::BusyConnectionError => "BusyConnectionError",
+            ErrorType::DriverError => "DriverError",
+            ErrorType::DriverInternalError => "DriverInternalError",
+            ErrorType::NoHostAvailableError => "NoHostAvailableError",
+            ErrorType::NotSupportedError => "NotSupportedError",
+            ErrorType::OperationTimedOutError => "OperationTimedOutError",
+            ErrorType::ResponseError => "ResponseError",
+            ErrorType::Error => "Error",
+            ErrorType::RangeError => "RangeError",
+            ErrorType::ReferenceError => "ReferenceError",
+            ErrorType::SyntaxError => "SyntaxError",
+            ErrorType::TypeError => "TypeError",
+        })
+    }
+}
 
 /// Convert rust error to napi::Error
 pub(crate) fn err_to_napi<T: Error>(e: T) -> napi::Error {
@@ -9,7 +54,12 @@ pub(crate) fn err_to_napi<T: Error>(e: T) -> napi::Error {
 
 /// Create napi::Error from a message
 pub(crate) fn js_error<T: Display>(e: T) -> napi::Error {
-    napi::Error::new(Status::GenericFailure, e.to_string())
+    js_typed_error(e, ErrorType::Error)
+}
+
+/// Create napi::Error from a message and error type
+pub(crate) fn js_typed_error<T: Display>(e: T, error_type: ErrorType) -> napi::Error {
+    napi::Error::new(Status::GenericFailure, format!("{}#{}", error_type, e))
 }
 
 /// Convert bigint to i64. Returns napi::Error if value doesn't fit in i64.

--- a/test/unit/errors-tests.js
+++ b/test/unit/errors-tests.js
@@ -1,0 +1,169 @@
+"use strict";
+const { assert } = require("chai");
+const { napiErrorHandler } = require("../../lib/new-utils");
+const { throwTestError } = require("../../index");
+const {
+    ArgumentError,
+    AuthenticationError,
+    BusyConnectionError,
+    DriverError,
+    DriverInternalError,
+    NoHostAvailableError,
+    NotSupportedError,
+    OperationTimedOutError,
+    ResponseError,
+} = require("../../lib/errors");
+
+class SomeJsClass {
+    // throws an error with the given type and "Test error" as the message
+    throwError = napiErrorHandler(function (errorType) {
+        return throwTestError(errorType);
+    });
+    // throws JS Error with the given message
+    throwMessage = napiErrorHandler(function (message) {
+        return throwTestError("Error", message);
+    });
+    // throws an error not through napi
+    throwSimple = napiErrorHandler(function () {
+        throw new Error("Simple error");
+    });
+}
+describe("napiErrorHandler", function () {
+    const classInstance = new SomeJsClass();
+
+    it("should throw ArgumentError", function () {
+        assert.throws(
+            () => classInstance.throwError("ArgumentError"),
+            ArgumentError,
+            "Test error",
+        );
+    });
+
+    it("should throw AuthenticationError", function () {
+        assert.throws(
+            () => classInstance.throwError("AuthenticationError"),
+            AuthenticationError,
+            "Test error",
+        );
+    });
+
+    // TODO: Fix after adding support for fields in errors
+    // it("should throw BusyConnectionError", function () {
+    //     assert.throws(
+    //         () => classInstance.throwError("BusyConnectionError"),
+    //         BusyConnectionError,
+    //         "Test error",
+    //     );
+    // });
+
+    it("should throw DriverError", function () {
+        assert.throws(
+            () => classInstance.throwError("DriverError"),
+            DriverError,
+            "Test error",
+        );
+    });
+
+    it("should throw DriverInternalError", function () {
+        assert.throws(
+            () => classInstance.throwError("DriverInternalError"),
+            DriverInternalError,
+            "Test error",
+        );
+    });
+
+    // TODO: Fix after adding support for fields in errors
+    // it("should throw NoHostAvailableError", function () {
+    //     assert.throws(
+    //         () => classInstance.throwError("NoHostAvailableError"),
+    //         NoHostAvailableError,
+    //         "Test error",
+    //     );
+    // });
+
+    it("should throw NotSupportedError", function () {
+        assert.throws(
+            () => classInstance.throwError("NotSupportedError"),
+            NotSupportedError,
+            "Test error",
+        );
+    });
+
+    // TODO: Fix after adding support for fields in errors
+    // it("should throw OperationTimedOutError", function () {
+    //     assert.throws(
+    //         () => classInstance.throwError("OperationTimedOutError"),
+    //         OperationTimedOutError,
+    //         "Test error",
+    //     );
+    // });
+
+    // TODO: Fix after adding support for fields in errors
+    // it("should throw ResponseError", function () {
+    //     assert.throws(
+    //         () => classInstance.throwError("ResponseError"),
+    //         ResponseError,
+    //         "Test error",
+    //     );
+    // });
+
+    it("should throw Error", function () {
+        assert.throws(
+            () => classInstance.throwError("Error"),
+            Error,
+            "Test error",
+        );
+    });
+
+    it("should throw RangeError", function () {
+        assert.throws(
+            () => classInstance.throwError("RangeError"),
+            RangeError,
+            "Test error",
+        );
+    });
+
+    it("should throw ReferenceError", function () {
+        assert.throws(
+            () => classInstance.throwError("ReferenceError"),
+            ReferenceError,
+            "Test error",
+        );
+    });
+
+    it("should throw SyntaxError", function () {
+        assert.throws(
+            () => classInstance.throwError("SyntaxError"),
+            SyntaxError,
+            "Test error",
+        );
+    });
+
+    it("should throw TypeError", function () {
+        assert.throws(
+            () => classInstance.throwError("TypeError"),
+            TypeError,
+            "Test error",
+        );
+    });
+
+    it("should throw Error with custom message", function () {
+        assert.throws(
+            () => classInstance.throwMessage("Example message"),
+            Error,
+            "Example message",
+        );
+    });
+
+    it("should throw Error with special characters", function () {
+        assert.throws(
+            () => classInstance.throwMessage("##Example # message # ##"),
+            Error,
+            "##Example # message # ##",
+        );
+    });
+
+    it("should rethrow simple error", function () {
+        assert.throws(() => classInstance.throwSimple(), Error, "Simple error");
+    });
+});


### PR DESCRIPTION
napi-rs does not support throwing specific errors, either custom or node.js specific. This PR adds support for it by adding a wrapper function that catches the error and rethrows a correct one based on the message. Tests were added for this functionality. Some errors need special parameters passed when creating, they are not supported for now (#119 ) as I don't think it is a crucial feature for Iteration 1. 