### PR TITLE
Add unit tests for converting value into QueryParameterWrapper

### DIFF
--- a/lib/types/cql-utils.js
+++ b/lib/types/cql-utils.js
@@ -6,6 +6,7 @@ const { ResponseError } = require("../errors");
 const TimeUuid = require("./time-uuid");
 const Uuid = require("./uuid");
 const Duration = require("./duration");
+const LocalTime = require("./local-time");
 
 /**
  * Ensures the value isn't one of many ways to express null value
@@ -135,6 +136,14 @@ function getWrapped(type, value) {
             return rust.QueryParameterWrapper.fromMap(encodedMap);
         case rust.CqlType.SmallInt:
             return rust.QueryParameterWrapper.fromSmallInt(value);
+        case rust.CqlType.Time:
+            if (!(value instanceof LocalTime))
+                throw new TypeError(
+                    "Expected LocalTime type to parse into Cql Time",
+                );
+            return rust.QueryParameterWrapper.fromLocalTime(
+                value.getInternal(),
+            );
         case rust.CqlType.TinyInt:
             return rust.QueryParameterWrapper.fromTinyInt(value);
         case rust.CqlType.Uuid:

--- a/lib/types/cql-utils.js
+++ b/lib/types/cql-utils.js
@@ -56,7 +56,7 @@ function encodeMap(value, parentType) {
             continue;
         }
         const val = value[key];
-        res.push([getWrapped(key, keySubtype), getWrapped(val, valueSubtype)]);
+        res.push([getWrapped(keySubtype, key), getWrapped(valueSubtype, val)]);
     }
     return res;
 }
@@ -112,7 +112,7 @@ function getWrapped(type, value) {
                 return this.encodeList(arr, subtype);
             } */
             let encodedSet = encodeListLike(value, type.getSupportType(1));
-            return rust.QueryParameterWrapper.fromList(encodedSet);
+            return rust.QueryParameterWrapper.fromSet(encodedSet);
         case rust.CqlType.Text:
             return rust.QueryParameterWrapper.fromText(value);
         case rust.CqlType.Timestamp:

--- a/lib/types/cql-utils.js
+++ b/lib/types/cql-utils.js
@@ -84,7 +84,7 @@ function getWrapped(type, value) {
         case rust.CqlType.Boolean:
             return rust.QueryParameterWrapper.fromBoolean(value);
         case rust.CqlType.Counter:
-            return rust.QueryParameterWrapper.fromCounter(value);
+            return rust.QueryParameterWrapper.fromCounter(BigInt(value));
         case rust.CqlType.Double:
             return rust.QueryParameterWrapper.fromDouble(value);
         case rust.CqlType.Duration:

--- a/lib/types/cql-utils.js
+++ b/lib/types/cql-utils.js
@@ -196,3 +196,6 @@ function parseParams(preparedStatement, params) {
 }
 
 module.exports.parseParams = parseParams;
+
+// For unit test usage
+module.exports.getWrapped = getWrapped;

--- a/lib/types/cql-utils.js
+++ b/lib/types/cql-utils.js
@@ -7,6 +7,7 @@ const TimeUuid = require("./time-uuid");
 const Uuid = require("./uuid");
 const Duration = require("./duration");
 const LocalTime = require("./local-time");
+const InetAddress = require("./inet-address");
 
 /**
  * Ensures the value isn't one of many ways to express null value
@@ -118,6 +119,12 @@ function getWrapped(type, value) {
             return rust.QueryParameterWrapper.fromText(value);
         case rust.CqlType.Timestamp:
             return rust.QueryParameterWrapper.fromTimestamp(BigInt(value));
+        case rust.CqlType.Inet:
+            if (!(value instanceof InetAddress))
+                throw new TypeError(
+                    "Expected InetAddress type to parse into Cql Inet",
+                );
+            return rust.QueryParameterWrapper.fromInet(value.getInternal());
         case rust.CqlType.List:
             let encodedList = encodeListLike(value, type.getSupportType(1));
             return rust.QueryParameterWrapper.fromList(encodedList);

--- a/lib/types/inet-address.js
+++ b/lib/types/inet-address.js
@@ -283,6 +283,15 @@ class InetAddress {
     static fromRust(rustInetAddress) {
         return new InetAddress(rustInetAddress.getBuffer());
     }
+
+    /**
+     * Get the rust object.
+     * @package
+     * @returns {rust.InetAddressWrapper}
+     */
+    getInternal() {
+        return this.#internal;
+    }
 }
 
 module.exports = InetAddress;

--- a/lib/types/local-time.js
+++ b/lib/types/local-time.js
@@ -271,5 +271,13 @@ class LocalTime {
     static fromRust(arg) {
         return new LocalTime(bigintToLong(arg.value));
     }
+
+    /**
+     * @package
+     * @returns {rust.LocalTimeWrapper}
+     */
+    getInternal() {
+        return this.#internal;
+    }
 }
 module.exports = LocalTime;

--- a/src/request.rs
+++ b/src/request.rs
@@ -10,8 +10,8 @@ use scylla::{
 use crate::{
     result::map_column_type_to_complex_type,
     types::{
-        duration::DurationWrapper, local_time::LocalTimeWrapper, type_wrappers::ComplexType,
-        uuid::UuidWrapper,
+        duration::DurationWrapper, inet::InetAddressWrapper, local_time::LocalTimeWrapper,
+        type_wrappers::ComplexType, uuid::UuidWrapper,
     },
     utils::{bigint_to_i64, js_error},
 };
@@ -111,6 +111,13 @@ impl QueryParameterWrapper {
                 "timestamp cannot overflow i64",
             )?)),
         })
+    }
+
+    #[napi]
+    pub fn from_inet(val: &InetAddressWrapper) -> QueryParameterWrapper {
+        QueryParameterWrapper {
+            parameter: CqlValue::Inet(val.get_ip_addr()),
+        }
     }
 
     #[napi]

--- a/src/request.rs
+++ b/src/request.rs
@@ -9,7 +9,10 @@ use scylla::{
 
 use crate::{
     result::map_column_type_to_complex_type,
-    types::{duration::DurationWrapper, type_wrappers::ComplexType, uuid::UuidWrapper},
+    types::{
+        duration::DurationWrapper, local_time::LocalTimeWrapper, type_wrappers::ComplexType,
+        uuid::UuidWrapper,
+    },
     utils::{bigint_to_i64, js_error},
 };
 
@@ -145,6 +148,13 @@ impl QueryParameterWrapper {
                     .map_err(|_| js_error("Value must fit in i16 type to be small int"))?,
             ),
         })
+    }
+
+    #[napi]
+    pub fn from_local_time(val: &LocalTimeWrapper) -> QueryParameterWrapper {
+        QueryParameterWrapper {
+            parameter: CqlValue::Time(val.get_cql_time()),
+        }
     }
 
     #[napi]

--- a/src/request.rs
+++ b/src/request.rs
@@ -96,7 +96,7 @@ impl QueryParameterWrapper {
     #[napi]
     pub fn from_text(val: String) -> QueryParameterWrapper {
         QueryParameterWrapper {
-            parameter: CqlValue::Ascii(val),
+            parameter: CqlValue::Text(val),
         }
     }
 

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -1,1 +1,2 @@
+pub mod request_values_tests;
 pub mod utils_tests;

--- a/src/tests/request_values_tests.rs
+++ b/src/tests/request_values_tests.rs
@@ -1,0 +1,89 @@
+use std::{
+    net::{IpAddr, Ipv4Addr},
+    str::FromStr,
+};
+
+use scylla::frame::{
+    response::result::CqlValue,
+    value::{Counter, CqlDuration, CqlTime, CqlTimestamp, CqlTimeuuid},
+};
+
+use crate::{
+    request::QueryParameterWrapper,
+    types::type_wrappers::{ComplexType, CqlType},
+};
+
+use uuid::uuid;
+
+#[napi]
+pub fn tests_from_value_get_type(test: String) -> ComplexType {
+    let v = match test.as_str() {
+        "Ascii" => (CqlType::Ascii, None, None),
+        "BigInt" => (CqlType::BigInt, None, None),
+        "Boolean" => (CqlType::Boolean, None, None),
+        "Blob" => (CqlType::Blob, None, None),
+        "Counter" => (CqlType::Counter, None, None),
+        "Double" => (CqlType::Double, None, None),
+        "Duration" => (CqlType::Duration, None, None),
+        "Float" => (CqlType::Float, None, None),
+        "Int" => (CqlType::Int, None, None),
+        "Text" => (CqlType::Text, None, None),
+        "Timestamp" => (CqlType::Timestamp, None, None),
+        "Inet" => (CqlType::Inet, None, None),
+        "List" => (CqlType::List, Some(CqlType::Text), None),
+        "Map" => (CqlType::Map, Some(CqlType::Ascii), Some(CqlType::Double)),
+        "Set" => (CqlType::Set, Some(CqlType::Int), None),
+        "SmallInt" => (CqlType::SmallInt, None, None),
+        "TinyInt" => (CqlType::TinyInt, None, None),
+        "Time" => (CqlType::Time, None, None),
+        "Timeuuid" => (CqlType::Timeuuid, None, None),
+        "Uuid" => (CqlType::Uuid, None, None),
+        _ => (CqlType::Empty, None, None),
+    };
+    ComplexType::two_support(
+        v.0,
+        v.1.map(ComplexType::simple_type),
+        v.2.map(ComplexType::simple_type),
+    )
+}
+
+#[napi]
+pub fn tests_from_value(test: String, value: &QueryParameterWrapper) {
+    let v = match test.as_str() {
+        "Ascii" => CqlValue::Ascii("Some arbitrary value".to_owned()),
+        "BigInt" => CqlValue::BigInt(i64::MAX),
+        "Boolean" => CqlValue::Boolean(false),
+        "Blob" => CqlValue::Blob(vec![0, 1, 2, 3]),
+        "Counter" => CqlValue::Counter(Counter(921)),
+        "Double" => CqlValue::Double(21.37),
+        "Duration" => CqlValue::Duration(CqlDuration {
+            months: 21,
+            days: 3,
+            nanoseconds: 7,
+        }),
+
+        "Float" => CqlValue::Float(111.222),
+        "Int" => CqlValue::Int(-1234),
+        "Text" => CqlValue::Text("Nonsense".to_owned()),
+        "Timestamp" => CqlValue::Timestamp(CqlTimestamp(0)),
+        "Inet" => CqlValue::Inet(IpAddr::V4(Ipv4Addr::from_bits(0x12345678))),
+        "List" => CqlValue::List(vec![
+            CqlValue::Text("Test value".to_owned()),
+            CqlValue::Text("Some other funny value".to_owned()),
+        ]),
+        "Map" => CqlValue::Map(vec![
+            (CqlValue::Ascii("Text".to_owned()), CqlValue::Double(0.1)),
+            (CqlValue::Ascii("Text2".to_owned()), CqlValue::Double(0.2)),
+        ]),
+        "Set" => CqlValue::Set(vec![CqlValue::Int(4), CqlValue::Int(7), CqlValue::Int(15)]),
+        "SmallInt" => CqlValue::SmallInt(1_i16),
+        "TinyInt" => CqlValue::TinyInt(-1_i8),
+        "Time" => CqlValue::Time(CqlTime(4312)),
+        "Timeuuid" => CqlValue::Timeuuid(
+            CqlTimeuuid::from_str("8e14e760-7fa8-11eb-bc66-000000000001").unwrap(),
+        ),
+        "Uuid" => CqlValue::Uuid(uuid!("ffffffff-eeee-ffff-ffff-ffffffffffff")),
+        _ => CqlValue::Empty,
+    };
+    assert_eq!(value.parameter, v);
+}

--- a/test/unit/query-parameter-tests.js
+++ b/test/unit/query-parameter-tests.js
@@ -1,0 +1,50 @@
+"use strict";
+const rust = require("../../index");
+const { getWrapped } = require("../../lib/types/cql-utils");
+const utils = require("../../lib/utils");
+const Duration = require("../../lib/types/duration");
+const InetAddress = require("../../lib/types/inet-address");
+const LocalTime = require("../../lib/types/local-time");
+const TimeUuid = require("../../lib/types/time-uuid");
+const Uuid = require("../../lib/types/uuid");
+const Long = require("long");
+
+const maxI64 = BigInt("9223372036854775807");
+
+const testCases = [
+    ["Ascii", "Some arbitrary value"],
+    ["BigInt", maxI64],
+    ["Boolean", false],
+    ["Blob", utils.allocBufferFromArray([0, 1, 2, 3])],
+    ["Counter", 921],
+    ["Double", 21.37],
+    ["Duration", new Duration(21, 3, 7)],
+    ["Float", 111.222],
+    ["Int", -1234],
+    ["Text", "Nonsense"],
+    ["Timestamp", 0],
+    [
+        "Inet",
+        new InetAddress(utils.allocBufferFromArray([0x12, 0x34, 0x56, 0x78])),
+    ],
+    ["List", ["Test value", "Some other funny value"]],
+    ["Map", { Text: 0.1, Text2: 0.2 }],
+    ["Set", [4, 7, 15]],
+    ["SmallInt", 1],
+    ["TinyInt", -1],
+    ["Time", new LocalTime(Long.fromInt(4312))],
+    ["Timeuuid", TimeUuid.fromString("8e14e760-7fa8-11eb-bc66-000000000001")],
+    ["Uuid", Uuid.fromString("ffffffff-eeee-ffff-ffff-ffffffffffff")],
+];
+
+describe("Should correctly convert values into QueryParameterWrapper", function () {
+    testCases.forEach((test) => {
+        it(test[0], function () {
+            let value = test[1];
+            let expectedType = rust.testsFromValueGetType(test[0]);
+            let converted = getWrapped(expectedType, value);
+            // Assertion appears in rust code
+            rust.testsFromValue(test[0], converted);
+        });
+    });
+});


### PR DESCRIPTION
Adds tests to check if we can pass value from JS to rust code correctly.

Adds fixes detected by the unit tests. Those fixes will be squashed into relevant commits when this PR is merged.
Add ability to pass LocalTime and Inet from JS to rust, as this was missing from PR adding those types.
