### PR TITLE
Fix eslint rule for unused vars

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -20,7 +20,7 @@ export default [
       // If a value is passed to a function but not used the error is ignored
       // Catched but unused errors are also ignored
       // Values starting with "_" are also ignored
-      "no-unused-vars": ["error", { "args": "none", "caughtErrors": "none", "varsIgnorePattern": "_*" }],
+      "no-unused-vars": ["error", { "args": "none", "caughtErrors": "none", "varsIgnorePattern": "^_" }],
 
       // Checks if var is not used
       "no-var": "error",

--- a/lib/types/result-set.js
+++ b/lib/types/result-set.js
@@ -3,7 +3,6 @@
 const utils = require("../utils");
 const errors = require("../errors");
 const rust = require("../../index");
-const Row = require("./row");
 const resultsWrapper = require("./results-wrapper");
 const Uuid = require("./uuid");
 

--- a/lib/types/time-uuid.js
+++ b/lib/types/time-uuid.js
@@ -1,5 +1,4 @@
 "use strict";
-const util = require("util");
 const crypto = require("crypto");
 const Long = require("long");
 


### PR DESCRIPTION
Fix regex in ESlint rule for unused vars.

From: `"varsIgnorePattern": "_*"` (not working) to `"varsIgnorePattern": "^_"`.