### PR TITLE
Fix integration tests problems

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -6,6 +6,7 @@ env:
   APP_NAME: scylladb-javascript-driver
   RUST_BACKTRACE: full
   PEDANTIC: true
+  NO_CONCURRENCY: true
 "on":
   push:
     branches:

--- a/lib/concurrent/index.js
+++ b/lib/concurrent/index.js
@@ -2,6 +2,8 @@
 
 const { Stream } = require("stream");
 const utils = require("../utils");
+const { Mutex } = require("async-mutex");
+const { env } = require("process");
 
 /**
  * Utilities for concurrent query execution with the DataStax Node.js Driver.
@@ -109,6 +111,9 @@ class ArrayBasedExecutor {
             options.concurrencyLevel || 100,
             this._parameters.length,
         );
+        if (env.NO_CONCURRENCY) {
+            this._concurrencyLevel = 1;
+        }
         this._queryOptions = {
             prepare: true,
             executionProfile: options.executionProfile,
@@ -176,6 +181,7 @@ class StreamBasedExecutor {
      * @private
      */
     constructor(client, query, stream, options) {
+        this._mutex = new Mutex();
         this._client = client;
         this._query = query;
         this._stream = stream;
@@ -206,7 +212,7 @@ class StreamBasedExecutor {
         });
     }
 
-    _executeOne(params) {
+    async _executeOne(params) {
         if (!Array.isArray(params)) {
             return this._setReadEnded(
                 new TypeError(
@@ -221,8 +227,9 @@ class StreamBasedExecutor {
             return;
         }
 
-        const index = this._index++;
         this._inFlight++;
+        const release = env.NO_CONCURRENCY ? await this._mutex.acquire() : () => { };
+        const index = this._index++;
 
         this._client
             .execute(this._query, params, this._queryOptions)
@@ -235,6 +242,7 @@ class StreamBasedExecutor {
                 this._setError(index, err);
             })
             .then(() => {
+                release();
                 if (this._stream.isPaused()) {
                     this._stream.resume();
                 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@types/long": "~5.0.0",
         "@types/node": ">=8",
         "adm-zip": "~0.5.10",
+        "async-mutex": "^0.5.0",
         "jsdoc": "^4.0.4",
         "long": "~5.2.3"
       },
@@ -675,6 +676,15 @@
       "license": "MIT",
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/async-mutex": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/async-mutex/-/async-mutex-0.5.0.tgz",
+      "integrity": "sha512-1A94B18jkJ3DYq284ohPxoXbfTA5HsQ7/Mf4DEhcyLx3Bz27Rh59iScbB6EPiP+B+joue6YCxcMXSbFC1tZKwA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/async-sema": {
@@ -3895,6 +3905,12 @@
       "version": "0.0.3",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
     },
     "node_modules/tunnel-agent": {
       "version": "0.6.0",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "@types/long": "~5.0.0",
     "@types/node": ">=8",
     "adm-zip": "~0.5.10",
+    "async-mutex": "^0.5.0",
     "jsdoc": "^4.0.4",
     "long": "~5.2.3"
   },


### PR DESCRIPTION
Integration tests appear to have issues in certain conditions, when run on github CI, which depends on the order in which they are run, which tests are enabled (there is no single failing test). I was unable to reproduce the issue on any other machine than Github workers.

The issue appears as one of the following problems:
- capacity overflow
- memory allocation failure

After some investigation, while I wasn't able to pinpoint a specific issue, I determined that the issue arises from concurrent JS code interacting with the NAPI-RS layer.

This commit attempts to stop the problems, by removing the concurrency. This severely limits the speed at which executeConcurrent is performed, but appears to fully resolve the issue (test size = 30).

With this in mind, any concurrency should be implemented on Rust side, or the root issue should be determined before removing the concurrency restrictions.