### PR TITLE
Introduce CachingSession instead of Session

### DIFF
--- a/lib/client-options.js
+++ b/lib/client-options.js
@@ -96,8 +96,7 @@ const errors = require("./errors.js");
  * @property {Number} [maxPrepared] Determines the maximum amount of different prepared queries before evicting items
  * from the internal cache. Reaching a high threshold hints that the queries are not being reused, like when
  * hard-coding parameter values inside the queries.
- * Default: ``500``.
- * [TODO: Add support for this field]
+ * Default: `512`.
  * @property {Object} [policies]
  * [TODO: Add support for this field]
  * @property {LoadBalancingPolicy} [policies.loadBalancing] The load balancing policy instance to be used to determine
@@ -330,7 +329,7 @@ function defaultOptions() {
         authProvider: null,
         requestTracker: null,
         metrics: new metrics.DefaultMetrics(),
-        maxPrepared: 500,
+        maxPrepared: null, // Default is 512, defined on the Rust side
         refreshSchemaDelay: 1000,
         isMetadataSyncEnabled: true,
         prepareOnAllHosts: true,
@@ -668,6 +667,7 @@ function setRustOptions(options) {
     rustOptions.applicationName = options.applicationName;
     rustOptions.applicationVersion = options.applicationVersion;
     rustOptions.keyspace = options.keyspace;
+    rustOptions.cacheSize = options.maxPrepared;
     if (options.credentials) {
         rustOptions.credentialsUsername = options.credentials.username;
         rustOptions.credentialsPassword = options.credentials.password;


### PR DESCRIPTION
This PR introduces caching session for optimizing the execution of prepared statements. It also adds support for the maxPrepared option of ``Client`` and changes the default value of the cache from ``500`` to ``512``.

Slightly improves performance and significantly improves amount of transferred data (number of packet measured with wireshark):
Before:

2.74 milion packets transferred

```bash
sudo perf stat node ./benchmark/logic/concurrent_insert.js scylladb-javascript-driver 1000000


 Performance counter stats for 'node ./benchmark/logic/concurrent_insert.js scylladb-javascript-driver 1000000':

        105,883.59 msec task-clock                       #    1.908 CPUs utilized             
         3,518,881      context-switches                 #   33.233 K/sec                     
           116,370      cpu-migrations                   #    1.099 K/sec                     
           191,451      page-faults                      #    1.808 K/sec                     
   426,824,192,831      cycles                           #    4.031 GHz                       
   129,342,909,399      stalled-cycles-frontend          #   30.30% frontend cycles idle      
   310,650,304,423      instructions                     #    0.73  insn per cycle            
                                                  #    0.42  stalled cycles per insn   
    59,643,874,497      branches                         #  563.297 M/sec                     
     2,479,172,913      branch-misses                    #    4.16% of all branches           

      55.494683305 seconds time elapsed

      72.364812000 seconds user
      35.192590000 seconds sys
```

After:

1.47 milion packets transferred

```bash
sudo perf stat node ./benchmark/logic/concurrent_insert.js scylladb-javascript-driver 1000000

 Performance counter stats for 'node ./benchmark/logic/concurrent_insert.js scylladb-javascript-driver 1000000':

         89,110.66 msec task-clock                       #    1.644 CPUs utilized             
         3,253,277      context-switches                 #   36.508 K/sec                     
            79,698      cpu-migrations                   #  894.371 /sec                      
           190,646      page-faults                      #    2.139 K/sec                     
   357,511,281,194      cycles                           #    4.012 GHz                       
    95,049,526,873      stalled-cycles-frontend          #   26.59% frontend cycles idle      
   272,851,008,791      instructions                     #    0.76  insn per cycle            
                                                  #    0.35  stalled cycles per insn   
    52,113,507,640      branches                         #  584.818 M/sec                     
     1,816,498,178      branch-misses                    #    3.49% of all branches           

      54.199610935 seconds time elapsed

      62.085423000 seconds user
      28.553035000 seconds sys
```
 