### PR TITLE
Unset

### DIFF
--- a/lib/types/cql-utils.js
+++ b/lib/types/cql-utils.js
@@ -60,7 +60,7 @@ function encodeListLike(values, subtype) {
             values[i],
             "A collection can't contain null or unset values",
         );
-        res.push(getWrapped(subtype, values[i]));
+        res.push(wrapValueBasedOnType(subtype, values[i]));
     }
     return res;
 }
@@ -84,8 +84,8 @@ function encodeMap(value, parentType) {
         ensureValue(val, "A collection can't contain null or unset values");
         ensureValue(key, "A collection can't contain null or unset values");
         res.push([
-            getWrapped(keySubtype || guessTypeChecked(key), key),
-            getWrapped(valueSubtype || guessTypeChecked(val), val),
+            wrapValueBasedOnType(keySubtype || guessTypeChecked(key), key),
+            wrapValueBasedOnType(valueSubtype || guessTypeChecked(val), val),
         ]);
     }
     return res;
@@ -102,15 +102,31 @@ function ensureNumber(value) {
 }
 
 /**
- * Wrap value into QueryParameterWrapper based on the type
+ * Wrap value into MaybeUnsetQueryParameterWrapper based on the type
+ * @param {rust.ComplexType} type
+ * @param {*} value
+ * @returns {rust.MaybeUnsetQueryParameterWrapper?}
+ */
+function getWrapped(type, value) {
+    // Unsets were introduced in CQLv3, and the backend of the driver - Rust driver -
+    // works only with version >= 4 of CQL, so unset will always be supported.
+    if (value === null) {
+        return null;
+    } else if (value === types.unset) {
+        return rust.MaybeUnsetQueryParameterWrapper.unset();
+    }
+    return rust.MaybeUnsetQueryParameterWrapper.fromNonNullNonUnsetValue(
+        wrapValueBasedOnType(type, value),
+    );
+}
+
+/**
+ * Wrap value, which is not Unset, into QueryParameterWrapper based on the type
  * @param {rust.ComplexType} type
  * @param {*} value
  * @returns {rust.QueryParameterWrapper}
  */
-function getWrapped(type, value) {
-    if (value === null || value === types.unset) {
-        return null;
-    }
+function wrapValueBasedOnType(type, value) {
     let encodedElement;
     let tmpElement;
     // To increase clarity of the error messages, in case value is of different type then expected,


### PR DESCRIPTION
Since elements of complex types, such as Lists, consist of
QueryParameterWrapper elements, and according to the CQL protocol,
complex type elements cannot contain Unsets, the structure of
QueryParameterWrapper has been split into QueryParameterWrapper and
MaybeUnsetQueryParameterWrapper to enforce this rule.