### PR TITLE
Caching of prepared queries

### DIFF
--- a/lib/cache.js
+++ b/lib/cache.js
@@ -1,0 +1,32 @@
+const _rust = require("../index");
+
+class PreparedCache {
+    /**
+     * @type {Map<string, _rust.PreparedStatementWrapper>}
+     */
+    #cache;
+
+    constructor() {
+        this.#cache = {};
+    }
+
+    /**
+     *
+     * @param {string} key
+     * @returns {_rust.PreparedStatementWrapper}
+     */
+    getElement(key) {
+        return this.#cache[key];
+    }
+
+    /**
+     *
+     * @param {string} key
+     * @param {_rust.PreparedStatementWrapper} element
+     */
+    storeElement(key, element) {
+        this.#cache[key] = element;
+    }
+}
+
+module.exports.PreparedCache = PreparedCache;

--- a/lib/client.js
+++ b/lib/client.js
@@ -18,6 +18,7 @@ const rust = require("../index");
 const ResultSet = require("./types/result-set.js");
 const { parseParams, convertHints } = require("./types/cql-utils.js");
 const queryOptions = require("./query-options.js");
+const { PreparedCache } = require("./cache.js");
 
 /**
  * Represents a database client that maintains multiple connections to the cluster nodes, providing methods to
@@ -567,6 +568,7 @@ class Client extends events.EventEmitter {
         let allQueries = [];
         let parametersRows = [];
         let hints = execOptions.getHints() || [];
+        let preparedCache = new PreparedCache();
 
         for (let i = 0; i < queries.length; i++) {
             let element = queries[i];
@@ -576,17 +578,24 @@ class Client extends events.EventEmitter {
             /**
              * @type {rust.PreparedStatementWrapper | string}
              */
-            let query = typeof element === "string" ? element : element.query;
+            let statement =
+                typeof element === "string" ? element : element.query;
             let params = element.params || [];
             let types;
 
-            if (!query) {
+            if (!statement) {
                 throw new errors.ArgumentError(`Invalid query at index ${i}`);
             }
 
             if (shouldBePrepared) {
-                query = await this.rustClient.prepareStatement(query);
-                types = query.getExpectedTypes();
+                let prepared = preparedCache.getElement(statement);
+                if (!prepared) {
+                    prepared =
+                        await this.rustClient.prepareStatement(statement);
+                    preparedCache.storeElement(statement, prepared);
+                }
+                types = prepared.getExpectedTypes();
+                statement = prepared;
             } else {
                 types = convertHints(hints[i] || []);
             }
@@ -594,7 +603,7 @@ class Client extends events.EventEmitter {
             if (params) {
                 params = parseParams(types, params, shouldBePrepared === false);
             }
-            allQueries.push(query);
+            allQueries.push(statement);
             parametersRows.push(params);
         }
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -140,6 +140,16 @@ class Client extends events.EventEmitter {
     }
 
     /**
+     * Manually prepare query into prepared statement
+     * @param {string} query
+     * @returns {Promise<rust.PreparedStatementWrapper>}
+     * @package
+     */
+    async prepareQuery(query) {
+        return await this.rustClient.prepareStatement(query);
+    }
+
+    /**
      * Attempts to connect to one of the [contactPoints]{@link ClientOptions} and discovers the rest the nodes of the
      * cluster.
      *
@@ -256,7 +266,7 @@ class Client extends events.EventEmitter {
         try {
             const execOptions = this.createOptions(options);
             return promiseUtils.optionalCallback(
-                this.#rustyExecute(query, params, execOptions),
+                this.rustyExecute(query, params, execOptions),
                 callback,
             );
         } catch (err) {
@@ -658,13 +668,13 @@ class Client extends events.EventEmitter {
 
     /**
      * Wrapper for executing queries by rust driver
-     * @param {string} query
+     * @param {string | rust.PreparedStatementWrapper} query
      * @param {Array} params
      * @param {ExecOptions.ExecutionOptions} execOptions
      * @returns {Promise<ResultSet>}
-     * @private
+     * @package
      */
-    async #rustyExecute(query, params, execOptions) {
+    async rustyExecute(query, params, execOptions) {
         if (
             // !execOptions.isPrepared() &&
             params &&
@@ -709,7 +719,7 @@ class Client extends events.EventEmitter {
      * Core part of executing rust queries
      * @param {ResolveCallback} resolve
      * @param {RejectCallback} reject
-     * @param {string} query
+     * @param {string | rust.PreparedStatementWrapper} query
      * @param {Array} params
      * @param {ExecOptions.ExecutionOptions} execOptions
      */
@@ -719,7 +729,10 @@ class Client extends events.EventEmitter {
             let result;
             if (execOptions.isPrepared()) {
                 // Execute prepared statement, as requested by the user
-                let statement = await this.rustClient.prepareStatement(query);
+                let statement =
+                    query instanceof rust.PreparedStatementWrapper
+                        ? query
+                        : await this.rustClient.prepareStatement(query);
                 let parsedParams = parseParams(
                     statement.getExpectedTypes(),
                     params,
@@ -730,6 +743,11 @@ class Client extends events.EventEmitter {
                     rustOptions,
                 );
             } else {
+                if (query instanceof rust.PreparedStatementWrapper) {
+                    throw new Error(
+                        "Unexpected prepared statement wrapper for unprepared queries",
+                    );
+                }
                 let expectedTypes = convertHints(execOptions.getHints() || []);
                 let parsedParams = parseParams(expectedTypes, params, true);
                 result = await this.rustClient.queryUnpaged(

--- a/lib/concurrent/index.js
+++ b/lib/concurrent/index.js
@@ -5,6 +5,7 @@ const utils = require("../utils");
 const { Stream } = require("stream");
 const { Mutex } = require("async-mutex");
 const { env } = require("process");
+const { PreparedCache } = require("../cache");
 
 /**
  * Utilities for concurrent query execution with the DataStax Node.js Driver.
@@ -123,9 +124,10 @@ class ArrayBasedExecutor {
         });
         this._result = new ResultSetGroup(options);
         this._stop = false;
+        this._cache = new PreparedCache();
     }
 
-    execute() {
+    async execute() {
         const promises = new Array(this._concurrencyLevel);
 
         for (let i = 0; i < this._concurrencyLevel; i++) {
@@ -135,7 +137,7 @@ class ArrayBasedExecutor {
         return Promise.all(promises).then(() => this._result);
     }
 
-    _executeOneAtATime(initialIndex, iteration) {
+    async _executeOneAtATime(initialIndex, iteration) {
         const index = initialIndex + this._concurrencyLevel * iteration;
 
         if (index >= this._parameters.length || this._stop) {
@@ -154,8 +156,14 @@ class ArrayBasedExecutor {
             params = item;
         }
 
+        let prepared = this._cache.getElement(query);
+        if (!prepared) {
+            prepared = await (this._client.prepareQuery(query));
+            this._cache.storeElement(query, prepared);
+        }
+
         return this._client
-            .execute(query, params, this._queryOptions)
+            .rustyExecute(prepared, params, this._queryOptions)
             .then((rs) => this._result.setResultItem(index, rs))
             .catch((err) => this._setError(index, err))
             .then(() => this._executeOneAtATime(initialIndex, iteration + 1));


### PR DESCRIPTION
Cache prepared statements on the JS side within single call of batch and concurrent execute.

About 20% improvement on concurrent insert (both task clock and time elapsed).

Before (js-caching branch):

```bash
sudo perf stat node ./benchmark/logic/concurrent_insert.js scylladb-javascript-driver 1000000

 Performance counter stats for 'node ./benchmark/logic/concurrent_insert.js scylladb-javascript-driver 1000000':

         69,564.54 msec task-clock                       #    1.639 CPUs utilized             
         2,702,067      context-switches                 #   38.843 K/sec                     
            24,744      cpu-migrations                   #  355.698 /sec                      
           190,975      page-faults                      #    2.745 K/sec                     
   283,675,180,415      cycles                           #    4.078 GHz                       
    75,943,317,270      stalled-cycles-frontend          #   26.77% frontend cycles idle      
   238,391,112,023      instructions                     #    0.84  insn per cycle            
                                                  #    0.32  stalled cycles per insn   
    45,454,104,968      branches                         #  653.409 M/sec                     
     1,559,027,745      branch-misses                    #    3.43% of all branches           

      42.448039778 seconds time elapsed

      47.783400000 seconds user
      23.049097000 seconds sys
```

After:

```bash
sudo perf stat node ./benchmark/logic/concurrent_insert.js scylladb-javascript-driver 1000000

 Performance counter stats for 'node ./benchmark/logic/concurrent_insert.js scylladb-javascript-driver 1000000':

         54,311.66 msec task-clock                       #    1.619 CPUs utilized             
         1,910,653      context-switches                 #   35.179 K/sec                     
            18,347      cpu-migrations                   #  337.810 /sec                      
           213,348      page-faults                      #    3.928 K/sec                     
   225,277,325,784      cycles                           #    4.148 GHz                       
    59,589,673,035      stalled-cycles-frontend          #   26.45% frontend cycles idle      
   203,600,992,694      instructions                     #    0.90  insn per cycle            
                                                  #    0.29  stalled cycles per insn   
    38,835,678,700      branches                         #  715.052 M/sec                     
     1,230,468,744      branch-misses                    #    3.17% of all branches           

      33.556679150 seconds time elapsed

      37.259389000 seconds user
      17.954469000 seconds sys

```