### PR TITLE
Remove no values queries

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -725,12 +725,6 @@ class Client extends events.EventEmitter {
                     parsedParams,
                     rustOptions,
                 );
-            } else if (!params) {
-                // Optimize: If we have no parameters we can skip preparation step
-                result = await this.rustClient.queryUnpagedNoValues(
-                    query,
-                    rustOptions,
-                );
             } else {
                 let expectedTypes = convertHints(execOptions.getHints() || []);
                 let parsedParams = parseParams(expectedTypes, params, true);

--- a/src/session.rs
+++ b/src/session.rs
@@ -64,24 +64,6 @@ impl SessionWrapper {
         self.inner.get_keyspace().as_deref().map(ToOwned::to_owned)
     }
 
-    /// Executes unprepared statement with no parameters.
-    ///
-    /// Returns a wrapper of the result provided by the rust driver
-    #[napi]
-    pub async fn query_unpaged_no_values(
-        &self,
-        query: String,
-        options: &QueryOptionsWrapper,
-    ) -> napi::Result<QueryResultWrapper> {
-        let statement: Statement = apply_statement_options(query.into(), options)?;
-        let query_result = self
-            .inner
-            .query_unpaged(statement, &[])
-            .await
-            .map_err(err_to_napi)?;
-        QueryResultWrapper::from_query(query_result)
-    }
-
     /// Executes unprepared statement. This assumes the types will be either guessed or provided by user.
     ///
     /// Returns a wrapper of the result provided by the rust driver


### PR DESCRIPTION
This was initially added to improve performance, when all queries were prepared.
With the implementation of type hints & type guessing, this is no longer nesesery