### PR TITLE
Remove usages of client.shutdown

### DIFF
--- a/examples/DataStax/README.md
+++ b/examples/DataStax/README.md
@@ -30,9 +30,8 @@ You should also visit the [Documentation][doc-index] and [FAQ][faq].
     method](concurrent-executions/execute-concurrent-array.js)
   - [Execute multiple queries in a loop with a defined concurrency level](concurrent-executions/execute-in-loop.js)
 
-Each example is generally structured in a way where the `Client` is connected at the beginning and shutdown at the end.
-While this is suitable for example single script purposes, you should reuse a single `Client` instance and
-only call `client.shutdown()` when exiting your application.
+Each example is generally structured in a way where the `Client` is connected at the beginning.
+While this is suitable for example single script purposes, you should reuse a single `Client` instance.
 
 If you have any questions regarding these examples, feel free to post your questions in the [mailing list][mailing-list].
 

--- a/examples/DataStax/basic/basic-connect.js
+++ b/examples/DataStax/basic/basic-connect.js
@@ -7,13 +7,8 @@ client
     .connect()
     .then(function () {
         console.log("Connected to cluster.");
-
-        console.log("Shutting down");
-        return client.shutdown();
+        return;
     })
     .catch(function (err) {
         console.error("There was an error when connecting", err);
-        return client.shutdown().then(() => {
-            throw err;
-        });
     });

--- a/examples/DataStax/basic/basic-execute-flow.js
+++ b/examples/DataStax/basic/basic-execute-flow.js
@@ -59,10 +59,5 @@ async.series(
             console.error("There was an error", err.message, err.stack);
         }
         console.log("Shutting down");
-        client.shutdown(() => {
-            if (err) {
-                throw err;
-            }
-        });
     },
 );

--- a/examples/DataStax/basic/basic-execute.js
+++ b/examples/DataStax/basic/basic-execute.js
@@ -16,8 +16,7 @@ client
     .then(function (result) {
         const row = result.rows[0];
         console.log("Obtained row: ", row);
-    })
-    .finally(() => client.shutdown());
+    });
 
 // Exit on unhandledRejection
 process.on("unhandledRejection", (reason) => {

--- a/examples/DataStax/concurrent-executions/execute-concurrent-array.js
+++ b/examples/DataStax/concurrent-executions/execute-concurrent-array.js
@@ -29,16 +29,12 @@ async function example() {
         x.toString(),
     ]);
 
-    try {
-        const query = "INSERT INTO tbl_sample_kv (id, value) VALUES (?, ?)";
-        await executeConcurrent(client, query, values);
+    const query = "INSERT INTO tbl_sample_kv (id, value) VALUES (?, ?)";
+    await executeConcurrent(client, query, values);
 
-        console.log(
-            `Finished executing ${values.length} queries with a concurrency level of ${concurrencyLevel}.`,
-        );
-    } finally {
-        await client.shutdown();
-    }
+    console.log(
+        `Finished executing ${values.length} queries with a concurrency level of ${concurrencyLevel}.`,
+    );
 }
 
 example();

--- a/examples/DataStax/concurrent-executions/execute-in-loop.js
+++ b/examples/DataStax/concurrent-executions/execute-in-loop.js
@@ -40,16 +40,12 @@ async function example() {
         promises[i] = executeOneAtATime(info);
     }
 
-    try {
-        // The n promises are going to be resolved when all the executions are completed.
-        await Promise.all(promises);
+    // The n promises are going to be resolved when all the executions are completed.
+    await Promise.all(promises);
 
-        console.log(
-            `Finished executing ${info.totalLength} queries with a concurrency level of ${concurrencyLevel}.`,
-        );
-    } finally {
-        await client.shutdown();
-    }
+    console.log(
+        `Finished executing ${info.totalLength} queries with a concurrency level of ${concurrencyLevel}.`,
+    );
 }
 
 async function executeOneAtATime(info) {

--- a/examples/DataStax/mapper/mapper-insert-retrieve.js.broken
+++ b/examples/DataStax/mapper/mapper-insert-retrieve.js.broken
@@ -75,11 +75,7 @@ client
     })
     .then((results) => {
         console.log("--Obtained video by user id\n", results.first());
-        return client.shutdown();
     })
     .catch(function (err) {
         console.error("There was an error", err);
-        return client.shutdown().then(() => {
-            throw err;
-        });
     });

--- a/examples/DataStax/metadata/metadata-hosts.js.broken
+++ b/examples/DataStax/metadata/metadata-hosts.js.broken
@@ -20,11 +20,7 @@ client
             );
         });
         console.log("Shutting down");
-        return client.shutdown();
     })
     .catch(function (err) {
         console.error("There was an error when connecting", err);
-        return client.shutdown().then(() => {
-            throw err;
-        });
     });

--- a/examples/DataStax/metadata/metadata-keyspaces.js.broken
+++ b/examples/DataStax/metadata/metadata-keyspaces.js.broken
@@ -17,11 +17,7 @@ client
                 keyspace.strategyOptions,
             );
         }
-        return client.shutdown();
     })
     .catch(function (err) {
         console.error("There was an error when connecting", err);
-        return client.shutdown().then(() => {
-            throw err;
-        });
     });

--- a/examples/DataStax/metadata/metadata-table.broken
+++ b/examples/DataStax/metadata/metadata-table.broken
@@ -30,12 +30,7 @@ client
         console.log("- Columns:", table.columns);
         console.log("- Partition keys:", table.partitionKeys);
         console.log("- Clustering keys:", table.clusteringKeys);
-        console.log("Shutting down");
-        return client.shutdown();
     })
     .catch(function (err) {
         console.error("There was an error", err);
-        return client.shutdown().then(() => {
-            throw err;
-        });
     });

--- a/examples/DataStax/tracing/retrieve-query-trace.js.broken
+++ b/examples/DataStax/tracing/retrieve-query-trace.js.broken
@@ -36,11 +36,7 @@ client
         console.log("Trace for the execution of the query:");
         console.log(trace);
         console.log("The trace was retrieved successfully");
-        return client.shutdown();
     })
     .catch(function (err) {
         console.error("There was an error", err);
-        return client.shutdown().then(() => {
-            throw err;
-        });
     });

--- a/examples/DataStax/tuple/tuple-insert-select.js.broekn
+++ b/examples/DataStax/tuple/tuple-insert-select.js.broekn
@@ -48,11 +48,7 @@ client
             row["currencies"].get(1),
             row["value"],
         );
-        return client.shutdown();
     })
     .catch(function (err) {
         console.error("There was an error", err);
-        return client.shutdown().then(() => {
-            throw err;
-        });
     });

--- a/examples/DataStax/udt/udt-insert-select.js.broken
+++ b/examples/DataStax/udt/udt-insert-select.js.broken
@@ -50,11 +50,7 @@ client
     .then(function (result) {
         const row = result.first();
         console.log("Retrieved row: %j", row);
-        return client.shutdown();
     })
     .catch(function (err) {
         console.error("There was an error", err);
-        return client.shutdown().then(() => {
-            throw err;
-        });
     });

--- a/test/integration/broken/client-each-row-tests.js
+++ b/test/integration/broken/client-each-row-tests.js
@@ -898,7 +898,7 @@ describe("Client", function () {
                         assert.match(result.info.warnings[0], /batch/i);
                         assert.match(result.info.warnings[0], /exceeding/);
                         assert.ok(loggedMessage);
-                        client.shutdown(done);
+                        done();
                     },
                 );
             },

--- a/test/integration/broken/client-each-row-tests.js
+++ b/test/integration/broken/client-each-row-tests.js
@@ -1037,7 +1037,7 @@ describe("Client", function () {
 function newInstance(options) {
     options = options || {};
     options = utils.deepExtend(options, helper.baseOptions);
-    return helper.shutdownAfterThisTest(new Client(options));
+    return new Client(options);
 }
 
 function insertTestData(client, table, length, callback) {

--- a/test/integration/broken/client-execute-simulator-tests.js
+++ b/test/integration/broken/client-execute-simulator-tests.js
@@ -42,8 +42,6 @@ describe("Client", function () {
             return client.connect();
         });
 
-        after(() => client.shutdown());
-
         it("should send request to host used in options", (done) => {
             utils.times(
                 10,
@@ -161,8 +159,6 @@ describe("Client", function () {
         });
 
         afterEach(() => simulacronCluster.resumeReadsAsync());
-
-        after(() => client.shutdown());
 
         context("when connections are paused", () => {
             const query = "INSERT INTO table1 (id) VALUES (?)";

--- a/test/integration/broken/client-pool-tests.js
+++ b/test/integration/broken/client-pool-tests.js
@@ -63,7 +63,7 @@ describe("Client", function () {
             client.connect(function (err) {
                 assert.ok(err);
                 helper.assertInstanceOf(err, errors.NoHostAvailableError);
-                client.shutdown(done);
+                done();
             });
         });
 
@@ -77,7 +77,7 @@ describe("Client", function () {
                     client.metadata.tokenizer,
                     Murmur3Tokenizer,
                 );
-                client.shutdown(done);
+                done();
             });
         });
 
@@ -90,7 +90,7 @@ describe("Client", function () {
                 },
                 function (err) {
                     assert.ifError(err);
-                    client.shutdown(done);
+                    done();
                 },
             );
         });
@@ -110,7 +110,7 @@ describe("Client", function () {
                 client.hosts.forEach(function (h) {
                     assert.notEqual(h.address, "localhost");
                 });
-                client.shutdown(done);
+                done();
             });
         });
 
@@ -156,7 +156,7 @@ describe("Client", function () {
                 assert.notEqual(hosts[2], contactPoints[1] + ":9042");
                 assert.notEqual(hosts[1], contactPoints[2] + ":9042");
                 assert.notEqual(hosts[2], contactPoints[2] + ":9042");
-                client.shutdown(done);
+                done();
             });
         });
 
@@ -191,7 +191,7 @@ describe("Client", function () {
                                 types.distance.local
                             ],
                         );
-                        client.shutdown(done);
+                        done();
                     },
                 );
             });
@@ -240,7 +240,7 @@ describe("Client", function () {
                                     types.distance.local
                                 ],
                             );
-                            client.shutdown(done);
+                            done();
                         }, 5000);
                     },
                 );
@@ -255,7 +255,7 @@ describe("Client", function () {
             });
             client.connect(function (err) {
                 assert.ifError(err);
-                client.shutdown(done);
+                done();
             });
         });
 
@@ -340,8 +340,6 @@ describe("Client", function () {
                     assert.strictEqual(host.pool.connections.length, 0);
                 }
             });
-
-            await client.shutdown();
         });
 
         it("should connect after unsuccessful attempt caused by a non-existent keyspace", function (done) {
@@ -382,15 +380,12 @@ describe("Client", function () {
         it("should set the defaults based on product type", () => {
             const client = newInstance();
 
-            return client
-                .connect()
-                .then(() => {
-                    assert.strictEqual(
-                        client.options.queryOptions.consistency,
-                        types.consistencies.localOne,
-                    );
-                })
-                .then(() => client.shutdown());
+            return client.connect().then(() => {
+                assert.strictEqual(
+                    client.options.queryOptions.consistency,
+                    types.consistencies.localOne,
+                );
+            });
         });
     });
 
@@ -431,8 +426,6 @@ describe("Client", function () {
             const username = "user2";
             const password = "12345678";
 
-            after(() => client.shutdown());
-
             return client
                 .connect()
                 .then(() => createRole(client, username, password))
@@ -445,12 +438,9 @@ describe("Client", function () {
                         ),
                     });
 
-                    after(() => client.shutdown());
-
                     return client.connect();
                 })
-                .then(() => client.execute(helper.queries.basic))
-                .then(() => client.shutdown());
+                .then(() => client.execute(helper.queries.basic));
         });
 
         it("should connect using the plain text authenticator when calling execute", function (done) {
@@ -520,7 +510,6 @@ describe("Client", function () {
                 err,
                 /requires authentication, but no authenticator found in the options/,
             );
-            await client.shutdown();
         });
 
         context("with credentials", () => {
@@ -535,8 +524,6 @@ describe("Client", function () {
                 const username = "user2";
                 const password = "12345678";
 
-                after(() => client.shutdown());
-
                 return client
                     .connect()
                     .then(() => createRole(client, username, password))
@@ -546,12 +533,9 @@ describe("Client", function () {
                             credentials: { username, password },
                         });
 
-                        after(() => client.shutdown());
-
                         return client.connect();
                     })
-                    .then(() => client.execute(helper.queries.basic))
-                    .then(() => client.shutdown());
+                    .then(() => client.execute(helper.queries.basic));
             });
 
             it("should fail with AuthenticationError when role does not exist", () => {
@@ -635,8 +619,6 @@ describe("Client", function () {
     describe("#connect() with nodes failing", function () {
         it("should connect after a failed attempt", function (done) {
             const client = newInstance();
-
-            after(() => client.shutdown());
 
             utils.series(
                 [
@@ -1133,8 +1115,6 @@ describe("Client", function () {
                 queryOptions: { isIdempotent: true },
             });
 
-            after(() => client.shutdown());
-
             const hosts = {};
             const hostsDown = [];
             utils.series(
@@ -1244,9 +1224,7 @@ describe("Client", function () {
             const hosts = {};
             const query = helper.queries.basic;
 
-            after(() => client.shutdown());
-
-            utils.series(
+                        utils.series(
                 [
                     function (next) {
                         // wait for all initial events to ensure we don't incidentally get an 'UP' event for node 2

--- a/test/integration/broken/client-pool-tests.js
+++ b/test/integration/broken/client-pool-tests.js
@@ -1386,7 +1386,6 @@ function newInstance(options) {
     const client = new Client(
         utils.deepExtend({}, helper.baseOptions, options),
     );
-    helper.shutdownAfterThisTest(client);
     return client;
 }
 

--- a/test/integration/broken/client-stream-tests.js
+++ b/test/integration/broken/client-stream-tests.js
@@ -480,7 +480,5 @@ describe("Client", function () {
  * @returns {Client}
  */
 function newInstance(options) {
-    return helper.shutdownAfterThisTest(
-        new Client(utils.deepExtend({}, helper.baseOptions, options)),
-    );
+    return new Client(utils.deepExtend({}, helper.baseOptions, options));
 }

--- a/test/integration/broken/control-connection-simulator-tests.js
+++ b/test/integration/broken/control-connection-simulator-tests.js
@@ -73,14 +73,11 @@ describe("ControlConnection", function () {
                 localDataCenter: "dc1",
             });
 
-            return client
-                .connect()
-                .then(() => {
-                    const cc = client.controlConnection;
-                    assert.strictEqual(typeof cc.getLocalAddress(), "string");
-                    assert.ok(net.isIP(cc.getLocalAddress()));
-                })
-                .then(() => client.shutdown());
+            return client.connect().then(() => {
+                const cc = client.controlConnection;
+                assert.strictEqual(typeof cc.getLocalAddress(), "string");
+                assert.ok(net.isIP(cc.getLocalAddress()));
+            });
         });
     });
 });

--- a/test/integration/broken/execution-profile-tests.js
+++ b/test/integration/broken/execution-profile-tests.js
@@ -85,7 +85,7 @@ describe("ProfileManager", function () {
             options,
         );
 
-        return helper.shutdownAfterThisTest(new Client(options));
+        return new Client(options);
     }
 
     function ensureOnlyHostsUsed(nodeIndexes, profile) {

--- a/test/integration/broken/load-balancing-simulator-tests.js
+++ b/test/integration/broken/load-balancing-simulator-tests.js
@@ -492,8 +492,6 @@ describe("LoadBalancingPolicy implementations", function () {
                 errors.ArgumentError,
                 /'localDataCenter' is not defined in Client options .* Available DCs are: \[dc1,dc2]/,
             );
-
-            await client.shutdown();
         });
 
         it("should validate that the local dc matches the topology and include available dcs in the error", async () => {
@@ -521,8 +519,6 @@ describe("LoadBalancingPolicy implementations", function () {
                 errors.ArgumentError,
                 /Datacenter dc_invalid was not found\. Available DCs are: \[dc1,dc2]/,
             );
-
-            await client.shutdown();
         });
     });
 
@@ -548,8 +544,6 @@ describe("LoadBalancingPolicy implementations", function () {
             coordinators.forEach((address) =>
                 assert.strictEqual(client.hosts.get(address).datacenter, dc),
             );
-
-            await client.shutdown();
         });
     });
 });

--- a/test/integration/broken/load-balancing-simulator-tests.js
+++ b/test/integration/broken/load-balancing-simulator-tests.js
@@ -487,8 +487,6 @@ describe("LoadBalancingPolicy implementations", function () {
                 ],
             });
 
-            helper.shutdownAfterThisTest(client);
-
             await helper.assertThrowsAsync(
                 client.connect(),
                 errors.ArgumentError,
@@ -518,8 +516,6 @@ describe("LoadBalancingPolicy implementations", function () {
                 ],
             });
 
-            helper.shutdownAfterThisTest(client);
-
             await helper.assertThrowsAsync(
                 client.connect(),
                 errors.ArgumentError,
@@ -539,8 +535,6 @@ describe("LoadBalancingPolicy implementations", function () {
                     loadBalancing: policies.defaultLoadBalancingPolicy(dc),
                 },
             });
-
-            helper.shutdownAfterThisTest(client);
 
             await client.connect();
             const coordinators = new Set();

--- a/test/integration/broken/load-balancing-tests.js
+++ b/test/integration/broken/load-balancing-tests.js
@@ -123,7 +123,7 @@ context("with a reusable 3 node cluster", function () {
                 },
                 function (err) {
                     assert.ifError(err);
-                    client.shutdown(done);
+                    done();
                 },
             );
         });
@@ -345,7 +345,7 @@ context("with a reusable 3 node cluster", function () {
                 { routingKey: "this is not valid" },
                 (err) => {
                     helper.assertInstanceOf(err, TypeError);
-                    client.shutdown(done);
+                    done();
                 },
             );
         });

--- a/test/integration/broken/mapping/mapper-test-helper.js
+++ b/test/integration/broken/mapping/mapper-test-helper.js
@@ -150,8 +150,6 @@ const mapperHelper = (module.exports = {
             utils.extend({ keyspace }, helper.baseOptions),
         );
         before(() => client.connect());
-        after(() => client.shutdown());
-
         const videoColumns = {};
         videoColumnsToProperties.forEach((v, k) => (videoColumns[k] = v));
 

--- a/test/integration/broken/mapping/mapper-tests.js
+++ b/test/integration/broken/mapping/mapper-tests.js
@@ -291,13 +291,11 @@ describe("Mapper", function () {
 
                     const methodName = item[0];
 
-                    return userMapper[methodName](item[1])
-                        .then((result) => {
-                            helper.assertInstanceOf(result, Result);
-                            assert.strictEqual(typeof result.length, "number");
-                            assert.strictEqual(result.wasApplied(), true);
-                        })
-                        .then(() => client.shutdown());
+                    return userMapper[methodName](item[1]).then((result) => {
+                        helper.assertInstanceOf(result, Result);
+                        assert.strictEqual(typeof result.length, "number");
+                        assert.strictEqual(result.wasApplied(), true);
+                    });
                 }),
             );
         });

--- a/test/integration/broken/metadata-tests.js
+++ b/test/integration/broken/metadata-tests.js
@@ -1151,7 +1151,7 @@ describe("metadata @SERVER_API", function () {
                                 "ck",
                             );
                             assert.strictEqual(table.virtual, false);
-                            client.shutdown(done);
+                            done();
                         },
                     );
                 });
@@ -1176,7 +1176,7 @@ describe("metadata @SERVER_API", function () {
                             assert.strictEqual(index.isCustomKind(), false);
                             assert.strictEqual(index.isKeysKind(), false);
                             assert.ok(index.options);
-                            client.shutdown(done);
+                            done();
                         },
                     );
                 });
@@ -1215,7 +1215,7 @@ describe("metadata @SERVER_API", function () {
                                 assert.strictEqual(index.isCustomKind(), false);
                                 assert.strictEqual(index.isKeysKind(), false);
                                 assert.ok(index.options);
-                                client.shutdown(done);
+                                done();
                             },
                         );
                     });
@@ -1255,7 +1255,7 @@ describe("metadata @SERVER_API", function () {
                                 assert.strictEqual(index.isCustomKind(), false);
                                 assert.strictEqual(index.isKeysKind(), false);
                                 assert.ok(index.options);
-                                client.shutdown(done);
+                                done();
                             },
                         );
                     });
@@ -1310,7 +1310,7 @@ describe("metadata @SERVER_API", function () {
                                 assert.strictEqual(index.isCustomKind(), false);
                                 assert.strictEqual(index.isKeysKind(), false);
                                 assert.ok(index.options);
-                                client.shutdown(done);
+                                done();
                             },
                         );
                     });
@@ -1371,7 +1371,7 @@ describe("metadata @SERVER_API", function () {
                                     );
                                     assert.ok(index.options);
                                 });
-                                client.shutdown(done);
+                                done();
                             },
                         );
                     });
@@ -1410,7 +1410,7 @@ describe("metadata @SERVER_API", function () {
                                 assert.strictEqual(index.isCustomKind(), false);
                                 assert.strictEqual(index.isKeysKind(), false);
                                 assert.ok(index.options);
-                                client.shutdown(done);
+                                done();
                             },
                         );
                     });
@@ -1922,8 +1922,6 @@ describe("metadata @SERVER_API", function () {
                 );
 
                 before(() => client.connect());
-                after(() => client.shutdown());
-
                 it("should retrieve the table metadata using the same representation", () =>
                     client.metadata.getTable(keyspace, "tbl7").then((table) => {
                         assert.ok(table);
@@ -2378,8 +2376,6 @@ describe("metadata @SERVER_API", function () {
                 );
 
                 before(() => client.connect());
-                after(() => client.shutdown());
-
                 it("should retrieve the view metadata using the same representation", () =>
                     client.metadata
                         .getMaterializedView(keyspace, "dailyhigh")

--- a/test/integration/broken/metadata-tests.js
+++ b/test/integration/broken/metadata-tests.js
@@ -2463,7 +2463,5 @@ describe("metadata @SERVER_API", function () {
 
 /** @returns {Client}  */
 function newInstance(options) {
-    return helper.shutdownAfterThisTest(
-        new Client(utils.deepExtend({}, helper.baseOptions, options)),
-    );
+    return new Client(utils.deepExtend({}, helper.baseOptions, options));
 }

--- a/test/integration/broken/pool-simulator-tests.js
+++ b/test/integration/broken/pool-simulator-tests.js
@@ -1196,7 +1196,5 @@ function newInstance(simulacronCluster, options) {
         ),
     );
 
-    helper.shutdownAfterThisTest(client);
-
     return client;
 }

--- a/test/integration/broken/timeout-simulator-tests.js
+++ b/test/integration/broken/timeout-simulator-tests.js
@@ -137,7 +137,6 @@ describe("client read timeouts", function () {
             }),
             errors.OperationTimedOutError,
         );
-        await client.shutdown();
     });
 
     it("defunct the connection when the threshold passed", async () => {
@@ -166,8 +165,6 @@ describe("client read timeouts", function () {
         // Node should be marked as down
         assert.ok(hostDown);
         assert.strictEqual(hostDown.address, simulacronCluster.node(0).address);
-
-        await client.shutdown();
     });
 
     describe("with prepared batches", function () {
@@ -187,7 +184,6 @@ describe("client read timeouts", function () {
                 rs.info.queriedHost,
                 simulacronCluster.node(1).address,
             );
-            await client.shutdown();
         });
 
         it("should produce a NoHostAvailableError when execution timed out on all hosts", async () => {
@@ -205,8 +201,6 @@ describe("client read timeouts", function () {
             Object.values(err.innerErrors).forEach((err) => {
                 assert.instanceOf(err, errors.OperationTimedOutError);
             });
-
-            await client.shutdown();
         });
 
         it("should produce a NoHostAvailableError when prepare tried and timed out on all hosts", async () => {
@@ -228,8 +222,6 @@ describe("client read timeouts", function () {
                 ),
                 errors.NoHostAvailableError,
             );
-
-            await client.shutdown();
         });
     });
 });
@@ -271,7 +263,5 @@ function testNodeUsedAsCoordinator(nodeIndex, queryOptions, query) {
             rs.info.queriedHost,
             simulacronCluster.node(nodeIndex).address,
         );
-
-        await client.shutdown();
     };
 }

--- a/test/integration/broken/timeout-simulator-tests.js
+++ b/test/integration/broken/timeout-simulator-tests.js
@@ -252,8 +252,6 @@ function newInstance(options) {
         ),
     );
 
-    helper.shutdownAfterThisTest(client);
-
     return client;
 }
 

--- a/test/integration/broken/tracker-simulator-tests.js
+++ b/test/integration/broken/tracker-simulator-tests.js
@@ -71,8 +71,7 @@ describe("tracker", function () {
                                     query,
                                     parameters,
                                 ),
-                            )
-                            .then(() => client.shutdown());
+                            );
                     },
                 );
             });
@@ -96,8 +95,7 @@ describe("tracker", function () {
                         verifyError(requestTracker, query, parameters);
                         err = e;
                     })
-                    .then(() => assert.instanceOf(err, errors.ResponseError))
-                    .then(() => client.shutdown());
+                    .then(() => assert.instanceOf(err, errors.ResponseError));
             });
         });
 
@@ -127,8 +125,9 @@ describe("tracker", function () {
                         return client
                             .connect()
                             .then(() => client.batch(queries, { prepare }))
-                            .then(() => verifyResponse(requestTracker, queries))
-                            .then(() => client.shutdown());
+                            .then(() =>
+                                verifyResponse(requestTracker, queries),
+                            );
                     },
                 );
             });
@@ -147,8 +146,9 @@ describe("tracker", function () {
                 return client
                     .connect()
                     .then(() => client.execute(query, parameters))
-                    .catch(() => verifyError(requestTracker, query, parameters))
-                    .then(() => client.shutdown());
+                    .catch(() =>
+                        verifyError(requestTracker, query, parameters),
+                    );
             });
         });
 
@@ -192,8 +192,7 @@ describe("tracker", function () {
                                     query,
                                     parameters,
                                 ),
-                            )
-                            .then(() => client.shutdown());
+                            );
                     },
                 );
             });
@@ -232,8 +231,6 @@ describe("tracker", function () {
         });
 
         before(() => client.connect());
-        after(() => client.shutdown());
-
         const slowMessages = [];
         const largeMessages = [];
 

--- a/test/integration/supported/client-batch-tests.js
+++ b/test/integration/supported/client-batch-tests.js
@@ -1084,7 +1084,5 @@ describe("Client @SERVER_API", function () {
  * @returns {Client}
  */
 function newInstance(options) {
-    return helper.shutdownAfterThisTest(
-        new Client(utils.deepExtend({}, helper.baseOptions, options)),
-    );
+    return new Client(utils.deepExtend({}, helper.baseOptions, options));
 }

--- a/test/integration/supported/client-execute-prepared-tests.js
+++ b/test/integration/supported/client-execute-prepared-tests.js
@@ -1075,7 +1075,7 @@ describe("Client @SERVER_API", function () {
                         assert.ok(result.info.warnings.length >= 1);
                         helper.assertContains(result.info.warnings[0], "batch");
                         assert.ok(loggedMessage);
-                        client.shutdown(done);
+                        done();
                     },
                 );
             },

--- a/test/integration/supported/client-execute-prepared-tests.js
+++ b/test/integration/supported/client-execute-prepared-tests.js
@@ -2363,8 +2363,6 @@ describe("Client @SERVER_API", function () {
                     contactPoints: helper.baseOptions.contactPoints,
                 });
 
-                helper.shutdownAfterThisTest(client);
-
                 /** Pre-calculated based on partitioner and initial tokens *\/
                 const replicaByKey = new Map([
                     ["0", "1"],
@@ -2644,7 +2642,7 @@ function newInstance(options) {
         helper.baseOptions,
     );
 
-    return helper.shutdownAfterThisTest(new Client(options));
+    return new Client(options);
 }
 
 function serializationTest(client, values, columns, done) {

--- a/test/integration/supported/client-execute-tests.js
+++ b/test/integration/supported/client-execute-tests.js
@@ -2199,7 +2199,5 @@ function verifyRow(table, id, fields, values, callback) {
  * @returns {Client}
  */
 function newInstance(options) {
-    return helper.shutdownAfterThisTest(
-        new Client(utils.deepExtend({}, helper.baseOptions, options)),
-    );
+    return new Client(utils.deepExtend({}, helper.baseOptions, options));
 }

--- a/test/integration/supported/numeric-tests.js
+++ b/test/integration/supported/numeric-tests.js
@@ -37,7 +37,6 @@ module.exports = function (keyspace, prepare) {
         before(() => client.connect());
         before(() => client.execute(createTableNumericValuesCql));
         before(() => client.execute(createTableNumericCollectionsCql));
-        after(() => client.shutdown());
 
         it("should support setting numeric values using strings", () => {
             const insertQuery = `INSERT INTO tbl_numeric_values
@@ -141,8 +140,6 @@ module.exports = function (keyspace, prepare) {
                 },
             });
 
-            after(() => client.shutdown());
-
             const insertQuery =
                 "INSERT INTO tbl_numeric_values (id, bigint_value, varint_value) VALUES (?, ?, ?)";
             const hints = !prepare ? [null, "bigint", "varint"] : null;
@@ -197,7 +194,6 @@ module.exports = function (keyspace, prepare) {
          set2 set<varint>, PRIMARY KEY ((id1, id2)))`,
             ),
         );
-        after(() => client.shutdown());
 
         const int64TextValues = [
             "1",

--- a/test/integration/supported/paging-tests.js
+++ b/test/integration/supported/paging-tests.js
@@ -52,8 +52,6 @@ module.exports = function (keyspace, prepare) {
             ),
         );
 
-        after(() => client.shutdown());
-
         it("should use pageState and fetchSize", async () => {
             const fetchSize = 70;
 

--- a/test/test-helper.js
+++ b/test/test-helper.js
@@ -388,17 +388,6 @@ const helper = {
     },
 
     /**
-     * Invokes client.shutdown() after this test finishes.
-     * @param {Client} client
-     * @returns {Client}
-     */
-    shutdownAfterThisTest: function (client) {
-        this.afterThisTest(() => client.shutdown());
-
-        return client;
-    },
-
-    /**
      * Returns a function that waits on schema agreement before executing callback
      * @param {Client} client
      * @param {Function} callback


### PR DESCRIPTION
Removes (most?) usages of client.shutdown from examples and integration tests. This is a follow up to https://github.com/scylladb-zpp-2024-javascript-driver/scylladb-javascript-driver/commit/d9cbe8f3023332c3d298791c61db6ba9167af3f9