### PR TITLE
Implement ToNapiValue trait for CqlValueWrapper

### DIFF
--- a/lib/types/results-wrapper.js
+++ b/lib/types/results-wrapper.js
@@ -12,78 +12,75 @@ const Row = require("./row");
 const Tuple = require("./tuple");
 
 /**
- * Checks the type of value wrapper object and gets it from the underlying value
+ * Maps the value returned from the Rust driver into expected JS object.
+ *
+ * This function accepts the following kinds of arguments:
+ *   1. `Value` ->  When can correctly handle the value based on the type;
+ *   2. `[Type, Value]` ->  In case of ambiguity, rust side provides tuple of (CqlType, Value);
+ *   3. `Array` -> Tuple in JS is represented as an array so we need to distinguish between the previous case
+ *      and a case where the array is provided as value. We determine it based on the type of the first value.
+ *
+ * See rust.CqlValueWrapper, for more information
  * @param {rust.CqlValueWrapper} field
  * @returns {any}
  */
 function getCqlObject(field) {
-    if (field == null) return null;
-    let type = field.getType();
-    let res, fields;
-    switch (type) {
-        case rust.CqlType.Ascii:
-            return field.getAscii();
-        case rust.CqlType.BigInt:
-            return bigintToLong(field.getBigint());
-        case rust.CqlType.Blob:
-            return field.getBlob();
-        case rust.CqlType.Boolean:
-            return field.getBoolean();
-        case rust.CqlType.Counter:
-            return field.getCounter();
-        case rust.CqlType.Date:
-            return LocalDate.fromRust(field.getLocalDate());
-        case rust.CqlType.Double:
-            return field.getDouble();
-        case rust.CqlType.Duration:
-            return Duration.fromRust(field.getDuration());
-        case rust.CqlType.Empty:
+    switch (true) {
+        case field === null:
             return null;
-        case rust.CqlType.Float:
-            return field.getFloat();
-        case rust.CqlType.Int:
-            return field.getInt();
-        case rust.CqlType.Set:
-            res = [];
-            fields = field.getSet();
-            for (let i = 0; i < fields.length; i++)
-                res.push(getCqlObject(fields[i]));
-            return res;
-        case rust.CqlType.Text:
-            return field.getText();
-        case rust.CqlType.Timestamp:
-            // Currently only values inside Date safe range are supported
-            // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date#the_epoch_timestamps_and_invalid_date
-            // The same problem exists in Datastax driver. This probably should be fixed at some point,
-            // but it's unlikely someone will need timestamps almost 300.000 years into the future.
-            return new Date(Number(field.getTimestamp()));
-        case rust.CqlType.List:
-            fields = field.getList();
-            return fields.map((value) => getCqlObject(value));
-        case rust.CqlType.Map:
-            fields = field.getMap();
-            res = {};
-            for (let i = 0; i < fields.length; i++)
-                res[getCqlObject(fields[i][0])] = getCqlObject(fields[i][1]);
-            return res;
-        case rust.CqlType.SmallInt:
-            return field.getSmallInt();
-        case rust.CqlType.TinyInt:
-            return field.getTinyInt();
-        case rust.CqlType.Uuid:
-            return Uuid.fromRust(field.getUuid());
-        case rust.CqlType.Timeuuid:
-            return TimeUuid.fromRust(field.getTimeUuid());
-        case rust.CqlType.Time:
-            return LocalTime.fromRust(field.getLocalTime());
-        case rust.CqlType.Inet:
-            return InetAddress.fromRust(field.getInet());
-        case rust.CqlType.Tuple:
-            return Tuple.fromRust(field.getTuple());
-        default:
-            // Temporarily returning string representation of the field
-            return field.stringify();
+        case field instanceof rust.LocalDateWrapper:
+            return LocalDate.fromRust(field);
+        case field instanceof rust.DurationWrapper:
+            return Duration.fromRust(field);
+        case field instanceof rust.TimeUuidWrapper:
+            return TimeUuid.fromRust(field);
+        case field instanceof rust.UuidWrapper:
+            return Uuid.fromRust(field);
+        case field instanceof rust.InetAddressWrapper:
+            return InetAddress.fromRust(field);
+        case field instanceof rust.LocalTimeWrapper:
+            return LocalTime.fromRust(field);
     }
+
+    if (Array.isArray(field)) {
+        // Check if the returned value is in (Type, Value) format
+        if (!(field.length === 2 && field[0] instanceof rust.CqlTypeClass)) {
+            // If not, returned value represents array. We need to map each element of the array
+            return field.map((value) => getCqlObject(value));
+        }
+
+        let res;
+        let value = field[1];
+        switch (field[0].typ) {
+            case rust.CqlType.BigInt:
+                return bigintToLong(value);
+            case rust.CqlType.Counter:
+                return value;
+            case rust.CqlType.Timestamp:
+                // Currently only values inside Date safe range are supported
+                // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date#the_epoch_timestamps_and_invalid_date
+                // The same problem exists in Datastax driver. This probably should be fixed at some point,
+                // but it's unlikely someone will need timestamps almost 300.000 years into the future.
+                return new Date(Number(value));
+            case rust.CqlType.Map:
+                res = {};
+                for (const keyValuePair of value) {
+                    res[getCqlObject(keyValuePair[0])] = getCqlObject(
+                        keyValuePair[1],
+                    );
+                }
+                return res;
+            case rust.CqlType.Tuple:
+                return Tuple.fromArray(
+                    value.map((e) =>
+                        e === null ? undefined : getCqlObject(e),
+                    ),
+                );
+            default:
+                throw new Error("Unexpected type");
+        }
+    }
+    return field;
 }
 
 /**

--- a/lib/types/tuple.js
+++ b/lib/types/tuple.js
@@ -1,7 +1,5 @@
 "use strict";
 
-const resultWrapper = require("./results-wrapper");
-
 /** @module types */
 
 /**
@@ -104,19 +102,6 @@ class Tuple {
     values() {
         // Clone the elements
         return this.elements.slice(0);
-    }
-
-    /**
-     * Get tuple from rust object. Not intended to be exposed in the API.
-     * @param {Array<resultWrapper.CqlValueWrapper | null>} rustTuple
-     * @returns {Tuple}
-     * @package
-     */
-    static fromRust(rustTuple) {
-        let elements = rustTuple.map((e) =>
-            e === null ? undefined : resultWrapper.getCqlObject(e),
-        );
-        return new Tuple(...elements);
     }
 }
 

--- a/src/result.rs
+++ b/src/result.rs
@@ -4,15 +4,12 @@ use crate::{
     types::{
         local_date::LocalDateWrapper,
         time_uuid::TimeUuidWrapper,
-        type_wrappers::{ComplexType, CqlType},
+        type_wrappers::{ComplexType, CqlType, CqlTypeClass},
         uuid::UuidWrapper,
     },
     utils::err_to_napi,
 };
-use napi::{
-    bindgen_prelude::{BigInt, Buffer, ToNapiValue},
-    Error, Status,
-};
+use napi::bindgen_prelude::{BigInt, Buffer, ToNapiValue};
 use scylla::{
     cluster::metadata::{CollectionType, NativeType},
     errors::IntoRowsResultError,
@@ -24,7 +21,6 @@ use scylla::{
 use crate::types::duration::DurationWrapper;
 use crate::types::inet::InetAddressWrapper;
 use crate::types::local_time::LocalTimeWrapper;
-use crate::utils::js_error;
 
 enum QueryResultVariant {
     EmptyResult(QueryResult),
@@ -56,10 +52,16 @@ pub struct PagedRowWrapper {
 
 /// Wrapper for a single CQL value
 ///
-/// CqlValueWrapper exposes functions get____ for each CQL type,
-/// which extract value from the object,
-/// assuming this wrapper stores a value of the requested CQL type.
-#[napi]
+/// When returned from NAPI-RS, returns either just a inner value or tuple of elements: ``(cqlType, value)``
+///
+/// Plain value is returned, when we know how to treat the value, based on the value type.
+/// The tuple is returned when there is ambiguity how the given value
+/// should be handled, based on its type.
+///
+/// For example if we return String, no matter if it's CqlAscii or CqlText,
+/// we treat it the same, and don't need to specify CqlType.
+/// On the other hand, CqlBigInt and CqlTimestamp are returned from rust layer
+/// as BigInt, but are provided to driver's user as BigInt and Date, respectively.
 pub struct CqlValueWrapper {
     pub(crate) inner: CqlValue,
 }
@@ -210,246 +212,128 @@ impl PagedRowWrapper {
     }
 }
 
-#[napi]
-impl CqlValueWrapper {
-    #[napi]
-    /// This uses rust Debug to return string representation of underlying value
-    pub fn stringify(&self) -> String {
-        format!("{:?}", self.inner)
+/// Converts value into tuple of elements:
+/// ``(typ, value)``
+/// for a given CQL Value.
+///
+/// Intended to be used when there is ambiguity how the given value
+/// should be provided, based on its type.
+///
+/// # Safety
+///
+/// Valid pointer to napi env must be provided
+unsafe fn add_type_to_napi_obj(
+    env: napi::sys::napi_env,
+    value: napi::Result<napi::sys::napi_value>,
+    typ: CqlType,
+) -> napi::Result<napi::sys::napi_value> {
+    // Caller of this function ensures a valid pointer to napi env is provided
+    unsafe {
+        // We need to use CqlTypeClass for JS to recognize the value if of enum type
+        Vec::to_napi_value(
+            env,
+            vec![
+                CqlTypeClass::to_napi_value(env, CqlTypeClass { typ }),
+                value,
+            ],
+        )
     }
+}
 
-    #[napi]
-    /// Get type of CQL value that is stored in this object
-    pub fn get_type(&self) -> CqlType {
-        match &self.inner {
-            CqlValue::Ascii(_) => CqlType::Ascii,
-            CqlValue::BigInt(_) => CqlType::BigInt,
-            CqlValue::Boolean(_) => CqlType::Boolean,
-            CqlValue::Blob(_) => CqlType::Blob,
-            CqlValue::Counter(_) => CqlType::Counter,
-            CqlValue::Decimal(_) => CqlType::Decimal, // NOI
-            CqlValue::Date(_) => CqlType::Date,
-            CqlValue::Double(_) => CqlType::Double,
-            CqlValue::Duration(_) => CqlType::Duration,
-            CqlValue::Empty => CqlType::Empty,
-            CqlValue::Float(_) => CqlType::Float,
-            CqlValue::Int(_) => CqlType::Int,
-            CqlValue::Text(_) => CqlType::Text,
-            CqlValue::Timestamp(_) => CqlType::Timestamp,
-            CqlValue::Inet(_) => CqlType::Inet,
-            CqlValue::List(_) => CqlType::List,
-            CqlValue::Map(_) => CqlType::Map,
-            CqlValue::Set(_) => CqlType::Set,
-            CqlValue::UserDefinedType { .. } => CqlType::UserDefinedType, // NOI
-            CqlValue::SmallInt(_) => CqlType::SmallInt,
-            CqlValue::TinyInt(_) => CqlType::TinyInt,
-            CqlValue::Time(_) => CqlType::Time,
-            CqlValue::Timeuuid(_) => CqlType::Timeuuid,
-            CqlValue::Tuple(_) => CqlType::Tuple,
-            CqlValue::Uuid(_) => CqlType::Uuid,
-            CqlValue::Varint(_) => CqlType::Varint, // NOI
+impl ToNapiValue for CqlValueWrapper {
+    unsafe fn to_napi_value(
+        env: napi::sys::napi_env,
+        value: Self,
+    ) -> napi::Result<napi::sys::napi_value> {
+        match value.inner {
+            CqlValue::Ascii(val) => String::to_napi_value(env, val),
+            CqlValue::Boolean(val) => bool::to_napi_value(env, val),
+            CqlValue::Blob(val) => Buffer::to_napi_value(env, val.into()),
+            CqlValue::Counter(val) => add_type_to_napi_obj(
+                env,
+                BigInt::to_napi_value(env, val.0.into()),
+                CqlType::Counter,
+            ),
+            CqlValue::Decimal(_) => todo!(),
+            CqlValue::Date(val) => {
+                LocalDateWrapper::to_napi_value(env, LocalDateWrapper::from_cql_date(val))
+            }
+            CqlValue::Double(val) => f64::to_napi_value(env, val),
+            CqlValue::Duration(val) => {
+                DurationWrapper::to_napi_value(env, DurationWrapper::from_cql_duration(val))
+            }
+            CqlValue::Empty => todo!(),
+            CqlValue::Float(val) => f32::to_napi_value(env, val),
+            CqlValue::Int(val) => i32::to_napi_value(env, val),
+            CqlValue::BigInt(val) => {
+                add_type_to_napi_obj(env, BigInt::to_napi_value(env, val.into()), CqlType::BigInt)
+            }
+            CqlValue::Text(val) => String::to_napi_value(env, val),
+            CqlValue::Timestamp(val) => add_type_to_napi_obj(
+                env,
+                BigInt::to_napi_value(env, val.0.into()),
+                CqlType::Timestamp,
+            ),
+            CqlValue::Inet(val) => {
+                InetAddressWrapper::to_napi_value(env, InetAddressWrapper::from_ip_addr(val))
+            }
+            CqlValue::List(val) => Vec::to_napi_value(
+                env,
+                val.into_iter()
+                    .map(|e| CqlValueWrapper::to_napi_value(env, CqlValueWrapper { inner: e }))
+                    .collect(),
+            ),
+            CqlValue::Map(val) => add_type_to_napi_obj(
+                env,
+                Vec::to_napi_value(
+                    env,
+                    val.into_iter()
+                        .map(|e: (CqlValue, CqlValue)| {
+                            vec![
+                                CqlValueWrapper { inner: e.0 },
+                                CqlValueWrapper { inner: e.1 },
+                            ]
+                        })
+                        .collect(),
+                ),
+                CqlType::Map,
+            ),
+            CqlValue::Set(val) => Vec::to_napi_value(
+                env,
+                val.into_iter()
+                    .map(|e| CqlValueWrapper::to_napi_value(env, CqlValueWrapper { inner: e }))
+                    .collect(),
+            ),
+            CqlValue::UserDefinedType { .. } => todo!(),
+            CqlValue::SmallInt(val) => i16::to_napi_value(env, val),
+            CqlValue::TinyInt(val) => i8::to_napi_value(env, val),
+            CqlValue::Time(val) => {
+                LocalTimeWrapper::to_napi_value(env, LocalTimeWrapper::from_cql_time(val))
+            }
+            CqlValue::Timeuuid(val) => {
+                TimeUuidWrapper::to_napi_value(env, TimeUuidWrapper::from_cql_time_uuid(val))
+            }
+            CqlValue::Tuple(val) => add_type_to_napi_obj(
+                env,
+                Vec::to_napi_value(
+                    env,
+                    val.into_iter()
+                        .map(|v| {
+                            v.map(|e| {
+                                CqlValueWrapper::to_napi_value(
+                                    env,
+                                    CqlValueWrapper { inner: e.clone() },
+                                )
+                            })
+                        })
+                        .collect(),
+                ),
+                CqlType::Tuple,
+            ),
+
+            CqlValue::Uuid(val) => UuidWrapper::to_napi_value(env, UuidWrapper::from_cql_uuid(val)),
+            CqlValue::Varint(_) => todo!(),
             other => unimplemented!("Missing implementation for CQL value {:?}", other),
-        }
-    }
-
-    fn generic_error(expected_type: &str) -> Error<Status> {
-        js_error(format!(
-            "Could not get value of type {} from CqlValueWrapper",
-            expected_type
-        ))
-    }
-
-    #[napi]
-    pub fn get_ascii(&self) -> napi::Result<String> {
-        match self.inner.as_ascii() {
-            Some(r) => Ok(r.clone()),
-            None => Err(Self::generic_error("ascii")),
-        }
-    }
-
-    #[napi]
-    pub fn get_bigint(&self) -> napi::Result<BigInt> {
-        match self.inner.as_bigint() {
-            Some(r) => Ok(BigInt::from(r)),
-            None => Err(Self::generic_error("bigint")),
-        }
-    }
-
-    #[napi]
-    pub fn get_boolean(&self) -> napi::Result<bool> {
-        match self.inner.as_boolean() {
-            Some(r) => Ok(r),
-            None => Err(Self::generic_error("boolean")),
-        }
-    }
-
-    #[napi]
-    pub fn get_blob(&self) -> napi::Result<Buffer> {
-        match self.inner.as_blob() {
-            Some(r) => Ok(r.clone().into()),
-            None => Err(Self::generic_error("blob")),
-        }
-    }
-
-    #[napi]
-    pub fn get_counter(&self) -> napi::Result<BigInt> {
-        match self.inner.as_counter() {
-            Some(r) => Ok(r.0.into()),
-            None => Err(Self::generic_error("counter")),
-        }
-    }
-
-    #[napi]
-    pub fn get_local_date(&self) -> napi::Result<LocalDateWrapper> {
-        match self.inner.as_cql_date() {
-            Some(r) => Ok(LocalDateWrapper::from_cql_date(r)),
-            None => Err(Self::generic_error("local_date")),
-        }
-    }
-
-    #[napi]
-    pub fn get_double(&self) -> napi::Result<f64> {
-        match self.inner.as_double() {
-            Some(r) => Ok(r),
-            None => Err(Self::generic_error("double")),
-        }
-    }
-
-    #[napi]
-    pub fn get_duration(&self) -> napi::Result<DurationWrapper> {
-        match self.inner.as_cql_duration() {
-            Some(r) => Ok(DurationWrapper::from_cql_duration(r)),
-            None => Err(Self::generic_error("duration")),
-        }
-    }
-    #[napi]
-    pub fn get_float(&self) -> napi::Result<f32> {
-        match self.inner.as_float() {
-            Some(r) => Ok(r),
-            None => Err(Self::generic_error("float")),
-        }
-    }
-
-    #[napi]
-    pub fn get_int(&self) -> napi::Result<i32> {
-        match self.inner.as_int() {
-            Some(r) => Ok(r),
-            None => Err(Self::generic_error("int")),
-        }
-    }
-
-    #[napi]
-    pub fn get_text(&self) -> napi::Result<String> {
-        match self.inner.as_text() {
-            Some(r) => Ok(r.clone()),
-            None => Err(Self::generic_error("text")),
-        }
-    }
-
-    #[napi]
-    pub fn get_timestamp(&self) -> napi::Result<BigInt> {
-        match self.inner.as_cql_timestamp() {
-            Some(r) => Ok(r.0.into()),
-            None => Err(Self::generic_error("text")),
-        }
-    }
-
-    #[napi]
-    pub fn get_inet(&self) -> napi::Result<InetAddressWrapper> {
-        match self.inner.as_inet() {
-            Some(r) => Ok(InetAddressWrapper::from_ip_addr(r)),
-            None => Err(Self::generic_error("inet")),
-        }
-    }
-
-    #[napi]
-    pub fn get_list(&self) -> napi::Result<Vec<CqlValueWrapper>> {
-        match self.inner.as_list() {
-            Some(r) => Ok(r
-                .iter()
-                .map(|f| CqlValueWrapper { inner: f.clone() })
-                .collect()),
-            None => Err(Self::generic_error("list")),
-        }
-    }
-
-    #[napi]
-    /// Return array of "tuples" keeping (key, value) for each element in the map
-    /// Currently NAPI doesn't implement ToNapiValue for tuples,
-    /// but the returned typed here will be the same as if we returned tuple.
-    pub fn get_map(&self) -> napi::Result<Vec<Vec<CqlValueWrapper>>> {
-        match self.inner.as_map() {
-            Some(r) => Ok(r
-                .iter()
-                .map(|f| {
-                    vec![
-                        CqlValueWrapper { inner: f.0.clone() },
-                        CqlValueWrapper { inner: f.1.clone() },
-                    ]
-                })
-                .collect()),
-            None => Err(Self::generic_error("map")),
-        }
-    }
-
-    #[napi]
-    pub fn get_set(&self) -> napi::Result<Vec<CqlValueWrapper>> {
-        match self.inner.as_set() {
-            Some(r) => Ok(r
-                .iter()
-                .map(|f| CqlValueWrapper { inner: f.clone() })
-                .collect()),
-            None => Err(Self::generic_error("set")),
-        }
-    }
-
-    #[napi]
-    pub fn get_small_int(&self) -> napi::Result<i16> {
-        match self.inner.as_smallint() {
-            Some(r) => Ok(r),
-            None => Err(Self::generic_error("small_int")),
-        }
-    }
-
-    #[napi]
-    pub fn get_tiny_int(&self) -> napi::Result<i8> {
-        match self.inner.as_tinyint() {
-            Some(r) => Ok(r),
-            None => Err(Self::generic_error("tiny_int")),
-        }
-    }
-    #[napi]
-    pub fn get_local_time(&self) -> napi::Result<LocalTimeWrapper> {
-        match self.inner.as_cql_time() {
-            Some(r) => Ok(LocalTimeWrapper::from_cql_time(r)),
-            None => Err(Self::generic_error("local_time")),
-        }
-    }
-
-    #[napi]
-    pub fn get_time_uuid(&self) -> napi::Result<TimeUuidWrapper> {
-        match self.inner.as_timeuuid() {
-            Some(r) => Ok(TimeUuidWrapper::from_cql_time_uuid(r)),
-            None => Err(Self::generic_error("time_uuid")),
-        }
-    }
-
-    #[napi]
-    pub fn get_tuple(&self) -> napi::Result<Vec<Option<CqlValueWrapper>>> {
-        match &self.inner {
-            CqlValue::Tuple(r) => Ok(r
-                .iter()
-                .map(|v| v.as_ref().map(|e| CqlValueWrapper { inner: e.clone() }))
-                .collect()),
-            _ => Err(Self::generic_error("tuple")),
-        }
-    }
-
-    #[napi]
-    pub fn get_uuid(&self) -> napi::Result<UuidWrapper> {
-        match self.inner.as_uuid() {
-            Some(r) => Ok(UuidWrapper::from_cql_uuid(r)),
-            None => Err(Self::generic_error("uuid")),
         }
     }
 }

--- a/src/types/type_wrappers.rs
+++ b/src/types/type_wrappers.rs
@@ -32,6 +32,14 @@ pub enum CqlType {
     Custom,
 }
 
+/// The goal of this class is to have an enum, that can be type checked.
+/// By default, it's not possible to check in JS if value is of given enum type.
+/// For this reason we create a class containing just an enum.
+#[napi]
+pub struct CqlTypeClass {
+    pub typ: CqlType,
+}
+
 /// Keeps whole CQL type, including support types.
 /// It has similar information to [scylla::frame::response::result::ColumnType],
 /// but can be passes to NAPI-RS

--- a/test/unit/cql-value-wrapper-tests.js
+++ b/test/unit/cql-value-wrapper-tests.js
@@ -17,8 +17,6 @@ const maxI32 = Number(2147483647);
 describe("Cql value wrapper", function () {
     it("should get ascii type correctly from napi", function () {
         let element = rust.testsGetCqlWrapperAscii();
-        let type = element.getType();
-        assert.strictEqual(type, rust.CqlType.Ascii);
         let value = getCqlObject(element);
         /* Corresponding value:
         let element = CqlValue::Ascii("test value".to_owned()); */
@@ -27,8 +25,6 @@ describe("Cql value wrapper", function () {
 
     it("should get bigInt type correctly from napi", function () {
         let element = rust.testsGetCqlWrapperBigint();
-        let type = element.getType();
-        assert.strictEqual(type, rust.CqlType.BigInt);
         let value = getCqlObject(element);
         /* Corresponding value:
         let element = CqlValue::BigInt(69); */
@@ -37,8 +33,6 @@ describe("Cql value wrapper", function () {
 
     it("should get boolean type correctly from napi", function () {
         let element = rust.testsGetCqlWrapperBoolean();
-        let type = element.getType();
-        assert.strictEqual(type, rust.CqlType.Boolean);
         let value = getCqlObject(element);
         /* Corresponding value:
         let element = CqlValue::Boolean(false); */
@@ -47,8 +41,6 @@ describe("Cql value wrapper", function () {
 
     it("should get blob type correctly from napi", function () {
         let element = rust.testsGetCqlWrapperBlob();
-        let type = element.getType();
-        assert.strictEqual(type, rust.CqlType.Blob);
         let value = getCqlObject(element);
         /* Corresponding value:
         let element = CqlValue::Blob((0..4).collect()); */
@@ -58,8 +50,6 @@ describe("Cql value wrapper", function () {
 
     it("should get counter type correctly from napi", function () {
         let element = rust.testsGetCqlWrapperCounter();
-        let type = element.getType();
-        assert.strictEqual(type, rust.CqlType.Counter);
         let value = getCqlObject(element);
         /* Corresponding value:
         let element = CqlValue::Counter(Counter(i64::MAX)); */
@@ -68,8 +58,6 @@ describe("Cql value wrapper", function () {
 
     it("should get LocalDate type correctly from napi", function () {
         let element = rust.testsGetCqlWrapperDate();
-        let type = element.getType();
-        assert.strictEqual(type, rust.CqlType.Date);
         let value = getCqlObject(element);
         assert.instanceOf(value, LocalDate);
         /* Corresponding value: 
@@ -80,8 +68,6 @@ describe("Cql value wrapper", function () {
 
     it("should get double type correctly from napi", function () {
         let element = rust.testsGetCqlWrapperDouble();
-        let type = element.getType();
-        assert.strictEqual(type, rust.CqlType.Double);
         let value = getCqlObject(element);
         /* Corresponding value: 
         let element = CqlValue::Double(f64::MAX); */
@@ -90,8 +76,6 @@ describe("Cql value wrapper", function () {
 
     it("should get duration type correctly from napi", function () {
         let element = rust.testsGetCqlWrapperDuration();
-        let type = element.getType();
-        assert.strictEqual(type, rust.CqlType.Duration);
         let value = getCqlObject(element);
         assert.instanceOf(value, Duration);
         /* Corresponding value: 
@@ -106,8 +90,6 @@ describe("Cql value wrapper", function () {
 
     it("should get float type correctly from napi", function () {
         let element = rust.testsGetCqlWrapperFloat();
-        let type = element.getType();
-        assert.strictEqual(type, rust.CqlType.Float);
         let value = getCqlObject(element);
         /* Corresponding value: 
         let element = CqlValue::Float(0_f32); */
@@ -116,8 +98,6 @@ describe("Cql value wrapper", function () {
 
     it("should get int type correctly from napi", function () {
         let element = rust.testsGetCqlWrapperInt();
-        let type = element.getType();
-        assert.strictEqual(type, rust.CqlType.Int);
         let value = getCqlObject(element);
         /* Corresponding value: 
         let element = CqlValue::Int(i32::MAX); */
@@ -126,8 +106,6 @@ describe("Cql value wrapper", function () {
 
     it("should get text type correctly from napi", function () {
         let element = rust.testsGetCqlWrapperText();
-        let type = element.getType();
-        assert.strictEqual(type, rust.CqlType.Text);
         let value = getCqlObject(element);
         /* Corresponding value: 
         let element = CqlValue::Text("".to_owned()); */
@@ -136,8 +114,6 @@ describe("Cql value wrapper", function () {
 
     it("should get timestamp type correctly from napi", function () {
         let element = rust.testsGetCqlWrapperTimestamp();
-        let type = element.getType();
-        assert.strictEqual(type, rust.CqlType.Timestamp);
         let value = getCqlObject(element);
         /* Corresponding value:
         let element = CqlValue::Timestamp(CqlTimestamp(1_000_000_i64)); */
@@ -149,8 +125,6 @@ describe("Cql value wrapper", function () {
 
     it("should get list type correctly from napi", function () {
         let element = rust.testsGetCqlWrapperList();
-        let type = element.getType();
-        assert.strictEqual(type, rust.CqlType.List);
         let value = getCqlObject(element);
         /* Corresponding value:
         let element = CqlValue::List(vec![
@@ -170,8 +144,6 @@ describe("Cql value wrapper", function () {
 
     it("should get set type correctly from napi", function () {
         let element = rust.testsGetCqlWrapperSet();
-        let type = element.getType();
-        assert.strictEqual(type, rust.CqlType.Set);
         let value = getCqlObject(element);
         /* Corresponding value: 
         let element = CqlValue::Set(vec![
@@ -183,8 +155,6 @@ describe("Cql value wrapper", function () {
 
     it("should get map type correctly from napi", function () {
         let element = rust.testsGetCqlWrapperMap();
-        let type = element.getType();
-        assert.strictEqual(type, rust.CqlType.Map);
         let value = getCqlObject(element);
         /* Corresponding value:
         let element = CqlValue::Map(vec![(
@@ -200,8 +170,6 @@ describe("Cql value wrapper", function () {
 
     it("should get small int type correctly from napi", function () {
         let element = rust.testsGetCqlWrapperSmallInt();
-        let type = element.getType();
-        assert.strictEqual(type, rust.CqlType.SmallInt);
         let value = getCqlObject(element);
         /* Corresponding value: 
         let element = CqlValue::SmallInt(-1); */
@@ -210,8 +178,6 @@ describe("Cql value wrapper", function () {
 
     it("should get tiny int type correctly from napi", function () {
         let element = rust.testsGetCqlWrapperTinyInt();
-        let type = element.getType();
-        assert.strictEqual(type, rust.CqlType.TinyInt);
         let value = getCqlObject(element);
         /* Corresponding value: 
         let element = CqlValue::TinyInt(3); */
@@ -220,8 +186,6 @@ describe("Cql value wrapper", function () {
 
     it("should get uuid type correctly from napi", function () {
         let element = rust.testsGetCqlWrapperUuid();
-        let type = element.getType();
-        assert.strictEqual(type, rust.CqlType.Uuid);
         let value = getCqlObject(element);
         assert.instanceOf(value, Uuid);
         /* Corresponding value: 
@@ -234,8 +198,6 @@ describe("Cql value wrapper", function () {
 
     it("should get tuple type correctly from napi", function () {
         let element = rust.testsGetCqlWrapperTuple();
-        let type = element.getType();
-        assert.strictEqual(type, rust.CqlType.Tuple);
         let value = getCqlObject(element);
         assert.instanceOf(value, Tuple);
         /* Corresponding value:
@@ -253,8 +215,6 @@ describe("Cql value wrapper", function () {
 
     it("should get time uuid type correctly from napi", function () {
         let element = rust.testsGetCqlWrapperTimeUuid();
-        let type = element.getType();
-        assert.strictEqual(type, rust.CqlType.Timeuuid);
         let value = getCqlObject(element);
         assert.instanceOf(value, TimeUuid);
         /* Corresponding value: 
@@ -268,8 +228,6 @@ describe("Cql value wrapper", function () {
 
     it("should get LocalTime type correctly from napi", function () {
         let element = rust.testsGetCqlWrapperTime();
-        let type = element.getType();
-        assert.strictEqual(type, rust.CqlType.Time);
         let value = getCqlObject(element);
         assert.instanceOf(value, LocalTime);
         /* Corresponding value: 
@@ -280,8 +238,6 @@ describe("Cql value wrapper", function () {
 
     it("should get inet type correctly from napi", function () {
         let element = rust.testsGetCqlWrapperInet();
-        let type = element.getType();
-        assert.strictEqual(type, rust.CqlType.Inet);
         let value = getCqlObject(element);
         assert.instanceOf(value, InetAddress);
         /* Corresponding value: 


### PR DESCRIPTION
Replaces current approach of returning CQL values from rust driver to JS.
Instead of calling NAPI twice:
    - first to get value type
    - second to get value itself
we convert the value when we return CQL wrapper.

This improves both code performance, by reducing native calls
and (hopefully) increases code clarity.

For ``select`` benchmark ~20/15% improvement (task-clock/time elapsed)
After:

```bash
sudo perf stat node ./benchmark/logic/select.js scylladb-javascript-driver 300000

 Performance counter stats for 'node ./benchmark/logic/select.js scylladb-javascript-driver 300000':

         39,031.27 msec task-clock                       #    0.672 CPUs utilized             
         1,213,807      context-switches                 #   31.098 K/sec                     
            27,146      cpu-migrations                   #  695.494 /sec                      
            13,186      page-faults                      #  337.832 /sec                      
   156,124,848,515      cycles                           #    4.000 GHz                       
    52,655,487,799      stalled-cycles-frontend          #   33.73% frontend cycles idle      
   183,755,495,921      instructions                     #    1.18  insn per cycle            
                                                  #    0.29  stalled cycles per insn   
    34,349,924,021      branches                         #  880.062 M/sec                     
       828,124,176      branch-misses                    #    2.41% of all branches           

      58.087041914 seconds time elapsed

      30.632502000 seconds user
       9.542099000 seconds sys
```

Before:

```bash
sudo perf stat node ./benchmark/logic/select.js scylladb-javascript-driver 300000

 Performance counter stats for 'node ./benchmark/logic/select.js scylladb-javascript-driver 300000':

         49,734.48 msec task-clock                       #    0.721 CPUs utilized             
         1,213,460      context-switches                 #   24.399 K/sec                     
            26,151      cpu-migrations                   #  525.812 /sec                      
            11,224      page-faults                      #  225.678 /sec                      
   204,333,765,051      cycles                           #    4.108 GHz                       
    57,481,147,481      stalled-cycles-frontend          #   28.13% frontend cycles idle      
   245,798,008,598      instructions                     #    1.20  insn per cycle            
                                                  #    0.23  stalled cycles per insn   
    45,616,064,580      branches                         #  917.192 M/sec                     
       876,843,759      branch-misses                    #    1.92% of all branches           

      68.992424536 seconds time elapsed

      41.575543000 seconds user
       9.419669000 seconds sys
```

For ``concurrent_select`` benchmark ~20/25% improvement (task-clock/time elapsed)

After:

```bash
sudo perf stat  ./benchmark/logic/concurrent_select.js scylladb-javascript-driver 800000

 Performance counter stats for ' ./benchmark/logic/concurrent_select.js scylladb-javascript-driver 800000':

        122,188.18 msec task-clock                       #    1.497 CPUs utilized             
         2,913,728      context-switches                 #   23.846 K/sec                     
            65,356      cpu-migrations                   #  534.880 /sec                      
            65,304      page-faults                      #  534.454 /sec                      
   501,089,264,243      cycles                           #    4.101 GHz                       
   116,760,887,470      stalled-cycles-frontend          #   23.30% frontend cycles idle      
   531,594,212,335      instructions                     #    1.06  insn per cycle            
                                                  #    0.22  stalled cycles per insn   
    99,554,837,139      branches                         #  814.766 M/sec                     
     2,015,453,685      branch-misses                    #    2.02% of all branches           

      81.617669943 seconds time elapsed

      98.907247000 seconds user
      25.066759000 seconds sys
```

Before:

```bash
sudo perf stat  ./benchmark/logic/concurrent_select.js scylladb-javascript-driver 800000

 Performance counter stats for ' ./benchmark/logic/concurrent_select.js scylladb-javascript-driver 800000':

        156,468.26 msec task-clock                       #    1.384 CPUs utilized             
         2,974,658      context-switches                 #   19.011 K/sec                     
            77,333      cpu-migrations                   #  494.241 /sec                      
            76,393      page-faults                      #  488.233 /sec                      
   659,739,880,134      cycles                           #    4.216 GHz                       
   127,827,841,049      stalled-cycles-frontend          #   19.38% frontend cycles idle      
   701,988,202,011      instructions                     #    1.06  insn per cycle            
                                                  #    0.18  stalled cycles per insn   
   130,604,458,737      branches                         #  834.703 M/sec                     
     2,179,959,479      branch-misses                    #    1.67% of all branches           

     113.037014315 seconds time elapsed

     132.587983000 seconds user
      25.839390000 seconds sys
```

