### PR TITLE
Implement ToNapiValue trait for RowWrapper

### DIFF
--- a/lib/types/results-wrapper.js
+++ b/lib/types/results-wrapper.js
@@ -100,7 +100,7 @@ function getRowsFromResultsWrapper(result) {
     let rows = [];
 
     for (let i = 0; i < rustRows.length; i++) {
-        let cols = rustRows[i].getColumns();
+        let cols = rustRows[i];
         let collectedRow = new Row(colNames);
         for (let j = 0; j < cols.length; j++) {
             // By default driver returns row as a map:

--- a/src/result.rs
+++ b/src/result.rs
@@ -8,7 +8,7 @@ use crate::{
     utils::err_to_napi,
 };
 use napi::{
-    bindgen_prelude::{BigInt, Buffer},
+    bindgen_prelude::{BigInt, Buffer, ToNapiValue},
     Error, Status,
 };
 use scylla::{
@@ -36,7 +36,9 @@ pub struct QueryResultWrapper {
 }
 
 /// Wrapper for a single row of the query result
-#[napi]
+///
+/// Whenever it's returned from NAPI function call
+/// it's automatically converted to the inner vector
 pub struct RowWrapper {
     inner: Vec<Option<CqlValue>>,
 }
@@ -149,17 +151,18 @@ impl QueryResultWrapper {
     }
 }
 
-#[napi]
-impl RowWrapper {
-    #[napi]
-    /// Get the CQL value wrappers for each column in the given row
-    pub fn get_columns(&self) -> napi::Result<Vec<Option<CqlValueWrapper>>> {
-        let s: Vec<Option<CqlValueWrapper>> = self
-            .inner
-            .iter()
-            .map(|f| f.clone().map(|f| CqlValueWrapper { inner: f }))
-            .collect();
-        Ok(s)
+impl ToNapiValue for RowWrapper {
+    unsafe fn to_napi_value(
+        env: napi::sys::napi_env,
+        val: Self,
+    ) -> napi::Result<napi::sys::napi_value> {
+        Vec::to_napi_value(
+            env,
+            val.inner
+                .into_iter()
+                .map(|e| e.map(|f| CqlValueWrapper { inner: f }))
+                .collect(),
+        )
     }
 }
 


### PR DESCRIPTION
Replaces current approach of returning RowWrapper, that has get_columns attribute, we convert RowWrapper into Vec<Option<CqlValueWrapper>> when we return the wrapper, with ToNapiValue trait.

This improves the performance
and (hopefully) improves code readability.

For ``concurrent_select``

This commit and #181 - 40% / 35% improvement vs baseline (time elapsed / task-clock):

```bash
sudo perf stat node ./benchmark/logic/concurrent_select.js scylladb-javascript-driver 800000

 Performance counter stats for 'node ./benchmark/logic/concurrent_select.js scylladb-javascript-driver 800000':

        104,185.58 msec task-clock                       #    1.569 CPUs utilized             
         2,758,809      context-switches                 #   26.480 K/sec                     
            35,365      cpu-migrations                   #  339.442 /sec                      
           202,662      page-faults                      #    1.945 K/sec                     
   419,914,429,570      cycles                           #    4.030 GHz                       
   105,163,596,537      stalled-cycles-frontend          #   25.04% frontend cycles idle      
   460,645,996,814      instructions                     #    1.10  insn per cycle            
                                                  #    0.23  stalled cycles per insn   
    86,892,203,558      branches                         #  834.014 M/sec                     
     1,896,131,810      branch-misses                    #    2.18% of all branches           

      66.391177587 seconds time elapsed

      80.290494000 seconds user
      25.606673000 seconds sys
```

Just this commit - 20% / 15% improvement vs baseline (time elapsed / task-clock):

```bash
sudo perf stat node ./benchmark/logic/concurrent_select.js scylladb-javascript-driver 800000

 Performance counter stats for 'node ./benchmark/logic/concurrent_select.js scylladb-javascript-driver 800000':

        133,229.67 msec task-clock                       #    1.457 CPUs utilized             
         2,910,735      context-switches                 #   21.847 K/sec                     
            31,297      cpu-migrations                   #  234.910 /sec                      
            66,769      page-faults                      #  501.157 /sec                      
   556,588,289,850      cycles                           #    4.178 GHz                       
   115,338,213,333      stalled-cycles-frontend          #   20.72% frontend cycles idle      
   635,553,124,493      instructions                     #    1.14  insn per cycle            
                                                  #    0.18  stalled cycles per insn   
   118,887,183,982      branches                         #  892.348 M/sec                     
     2,084,625,603      branch-misses                    #    1.75% of all branches           

      91.437364101 seconds time elapsed

     109.311702000 seconds user
      25.775607000 seconds sys
```

Baseline (second iteration)

```bash
sudo perf stat  ./benchmark/logic/concurrent_select.js scylladb-javascript-driver 800000

 Performance counter stats for ' ./benchmark/logic/concurrent_select.js scylladb-javascript-driver 800000':

        156,468.26 msec task-clock                       #    1.384 CPUs utilized             
         2,974,658      context-switches                 #   19.011 K/sec                     
            77,333      cpu-migrations                   #  494.241 /sec                      
            76,393      page-faults                      #  488.233 /sec                      
   659,739,880,134      cycles                           #    4.216 GHz                       
   127,827,841,049      stalled-cycles-frontend          #   19.38% frontend cycles idle      
   701,988,202,011      instructions                     #    1.06  insn per cycle            
                                                  #    0.18  stalled cycles per insn   
   130,604,458,737      branches                         #  834.703 M/sec                     
     2,179,959,479      branch-misses                    #    1.67% of all branches           

     113.037014315 seconds time elapsed

     132.587983000 seconds user
      25.839390000 seconds sys
```