### PR TITLE
FromNapiValue trait for parameters

### DIFF
--- a/docs/src/internal/parameter_wrapper.md
+++ b/docs/src/internal/parameter_wrapper.md
@@ -1,0 +1,25 @@
+# ParameterWrapper
+
+Parameter wrapper is used to pass parameters for all queries.
+It can pass any CQL Value, null and unset values.
+On the Rust side, the value is represented by:
+`Option<MaybeUnset<CqlValue>>`
+and on the JavaScript side it's represented by:
+`[ComplexType, Value]` with the null being `[]` and unset being `[undefined]`.
+
+The conversion from the user provided values to accepted format is done in `types/cql-utils.js`.
+
+On the Rust side `requests/parameter_wrappers.rs` is responsible for value conversion
+into format recognized by the Rust driver. It's done via the `FromNapiValue` trait.
+The specific format containing both type and value is necessary to create a correct CQL Value,
+without using [env](https://napi.rs/docs/compat-mode/concepts/env) in function.
+
+As driver allows values to be provided in multiple formats:
+
+- one of the predefined types,
+- as a string representation of the type,
+- as a pre-serialized byte array
+
+which are converted into predefined type, before passing it to Rust.
+It's possible to do this conversion also on the Rust side
+(but it's necessary to check the performance impact of such change).

--- a/lib/types/cql-utils.js
+++ b/lib/types/cql-utils.js
@@ -43,7 +43,7 @@ function guessTypeChecked(value) {
  * Wraps each of the elements into given subtype
  * @param {Array} values
  * @param {rust.ComplexType} subtype
- * @returns {Array<rust.QueryParameterWrapper>}
+ * @returns {Array<rust.ComplexType|any[]>} Returns tuple: [rust.ComplexType, any[]]
  */
 function encodeListLike(values, subtype) {
     if (!Array.isArray(values))
@@ -60,19 +60,19 @@ function encodeListLike(values, subtype) {
             values[i],
             "A collection can't contain null or unset values",
         );
-        res.push(wrapValueBasedOnType(subtype, values[i]));
+        res.push(wrapValueBasedOnType(subtype, values[i])[1]);
     }
-    return res;
+    return [subtype, res];
 }
 
 /**
  * @param {*} value
  * @param {rust.ComplexType} parentType
- * @returns {Array<Array<rust.QueryParameterWrapper>>}
+ * @returns {Array<rust.ComplexType|any[][]>} Returns tuple: [rust.ComplexType, any[][]]
  */
 function encodeMap(value, parentType) {
-    const keySubtype = parentType.getFirstSupportType();
-    const valueSubtype = parentType.getSecondSupportType();
+    let keySubtype = parentType.getFirstSupportType();
+    let valueSubtype = parentType.getSecondSupportType();
 
     let res = [];
 
@@ -83,12 +83,25 @@ function encodeMap(value, parentType) {
         const val = value[key];
         ensureValue(val, "A collection can't contain null or unset values");
         ensureValue(key, "A collection can't contain null or unset values");
+        if (!keySubtype || !valueSubtype) {
+            if (valueSubtype || keySubtype) {
+                throw new Error(
+                    `Internal error: Invalid support types for map`,
+                );
+            }
+            keySubtype = guessTypeChecked(key);
+            valueSubtype = guessTypeChecked(val);
+            parentType = parentType.remapMapSupportType(
+                keySubtype,
+                valueSubtype,
+            );
+        }
         res.push([
-            wrapValueBasedOnType(keySubtype || guessTypeChecked(key), key),
-            wrapValueBasedOnType(valueSubtype || guessTypeChecked(val), val),
+            wrapValueBasedOnType(keySubtype, key)[1],
+            wrapValueBasedOnType(valueSubtype, val)[1],
         ]);
     }
-    return res;
+    return [parentType, res];
 }
 
 /**
@@ -102,86 +115,95 @@ function ensureNumber(value) {
 }
 
 /**
- * Encodes tuple into QueryParameterWrapper
+ * Wraps tuple into format recognized by ParameterWrapper
  * @param {types.Tuple} value
  * @param {rust.ComplexType} type
- * @returns {Array<rust.QueryParameterWrapper>}
+ * @returns {Array<rust.ComplexType|Array<any>>} Returns tuple: [rust.ComplexType, Array<any>]
  */
 function encodeTuple(value, type) {
     let res = [];
+    // TODO:
+    // Add proper type guessing for tuples
+    // If some of the types are not provided (as it's a possible case in type guessing)
+    // then the returned type will have this information, while type provided in argument - not.
+    let newTypes = [];
     let types = type.getInnerTypes();
     for (let i = 0; i < types.length; i++) {
-        const element = value.get(i) !== undefined ? value.get(i) : null;
-        res.push(getWrapped(types[i], element));
+        const element = getWrapped(
+            types[i],
+            value.get(i) !== undefined ? value.get(i) : null,
+        );
+        newTypes.push(element[0]);
+        res.push(element[1]);
     }
-    return res;
+    return [rust.ComplexType.remapTupleSupportType(newTypes), res];
 }
 
 /**
- * Wrap value into MaybeUnsetQueryParameterWrapper based on the type
+ * Wraps value into format recognized by ParameterWrapper, based on the provided type
  * @param {rust.ComplexType} type
  * @param {*} value
- * @returns {rust.MaybeUnsetQueryParameterWrapper?}
+ * @returns {Array<rust.ComplexType|any>} Returns tuple: [rust.ComplexType, any] or []
  */
 function getWrapped(type, value) {
-    // Unsets were introduced in CQLv3, and the backend of the driver - Rust driver -
+    // Unset was introduced in CQLv3, and the backend of the driver - Rust driver -
     // works only with version >= 4 of CQL, so unset will always be supported.
     if (value === null) {
-        return null;
+        return [];
     } else if (value === types.unset) {
-        return rust.MaybeUnsetQueryParameterWrapper.unset();
+        return [undefined];
     }
-    return rust.MaybeUnsetQueryParameterWrapper.fromNonNullNonUnsetValue(
-        wrapValueBasedOnType(type, value),
-    );
+    return wrapValueBasedOnType(type, value);
 }
 
 /**
- * Wrap value, which is not Unset, into QueryParameterWrapper based on the type
+ * Wrap value, which is not Unset, into type and value pair,
+ * ensuring value is converted into expected form
  * @param {rust.ComplexType} type
  * @param {*} value
- * @returns {rust.QueryParameterWrapper}
+ * @returns {Array<rust.ComplexType|any>} Returns tuple: [rust.ComplexType, any]
  */
 function wrapValueBasedOnType(type, value) {
-    let encodedElement;
     let tmpElement;
     // To increase clarity of the error messages, in case value is of different type then expected,
     // when we call some methods on value variable, type is checked explicitly.
     // In other cases default Error will be thrown, which has message meaningful for the user.
     switch (type.baseType) {
+        // For these types, no action is required
         case rust.CqlType.Ascii:
-            return rust.QueryParameterWrapper.fromAscii(value);
-        case rust.CqlType.BigInt:
-            return rust.QueryParameterWrapper.fromBigint(
-                arbitraryValueToBigInt(value),
-            );
-        case rust.CqlType.Blob:
-            return rust.QueryParameterWrapper.fromBlob(value);
         case rust.CqlType.Boolean:
-            return rust.QueryParameterWrapper.fromBoolean(value);
+        case rust.CqlType.Blob:
+        case rust.CqlType.Decimal:
+        case rust.CqlType.Double:
+        case rust.CqlType.Empty:
+        case rust.CqlType.Float:
+        case rust.CqlType.Text:
+            break;
+        case rust.CqlType.BigInt:
+            value = arbitraryValueToBigInt(value);
+            break;
         case rust.CqlType.Counter:
-            return rust.QueryParameterWrapper.fromCounter(BigInt(value));
+            value = BigInt(value);
+            break;
         case rust.CqlType.Date:
             if (!(value instanceof LocalDate))
                 throw new TypeError(
                     "Expected LocalDate type to parse into Cql Date",
                 );
-            return rust.QueryParameterWrapper.fromLocalDate(
-                value.getInternal(),
-            );
-        case rust.CqlType.Double:
-            return rust.QueryParameterWrapper.fromDouble(value);
+            value = value.getInternal();
+            break;
         case rust.CqlType.Duration:
             if (!(value instanceof Duration))
                 throw new TypeError(
                     "Expected Duration type to parse into Cql Duration",
                 );
-            return rust.QueryParameterWrapper.fromDuration(value.getInternal());
-        case rust.CqlType.Float:
-            return rust.QueryParameterWrapper.fromFloat(value);
+            value = value.getInternal();
+            break;
         case rust.CqlType.Int:
+        case rust.CqlType.SmallInt:
+        case rust.CqlType.TinyInt:
             ensureNumber(value);
-            return rust.QueryParameterWrapper.fromInt(value);
+            break;
         case rust.CqlType.Set:
             // TODO:
             // This is part of the datastax logic for encoding set.
@@ -196,10 +218,11 @@ function wrapValueBasedOnType(type, value) {
                 });
                 return this.encodeList(arr, subtype);
             } */
-            encodedElement = encodeListLike(value, type.getFirstSupportType());
-            return rust.QueryParameterWrapper.fromSet(encodedElement);
-        case rust.CqlType.Text:
-            return rust.QueryParameterWrapper.fromText(value);
+            value = encodeListLike(value, type.getFirstSupportType());
+            if (!type.getFirstSupportType())
+                type = type.remapListSupportType(value[0]);
+            value = value[1];
+            break;
         case rust.CqlType.Timestamp:
             tmpElement = value;
             if (typeof value === "string") {
@@ -212,8 +235,8 @@ function wrapValueBasedOnType(type, value) {
                     throw new TypeError("Invalid date: " + tmpElement);
                 }
             }
-
-            return rust.QueryParameterWrapper.fromTimestamp(BigInt(value));
+            value = BigInt(value);
+            break;
         case rust.CqlType.Inet:
             // Other forms of providing InetAddress are kept as parity with old driver
             if (typeof value === "string") {
@@ -227,10 +250,14 @@ function wrapValueBasedOnType(type, value) {
                     "Expected InetAddress type to parse into Cql Inet",
                 );
             }
-            return rust.QueryParameterWrapper.fromInet(value.getInternal());
+            value = value.getInternal();
+            break;
         case rust.CqlType.List:
-            encodedElement = encodeListLike(value, type.getFirstSupportType());
-            return rust.QueryParameterWrapper.fromList(encodedElement);
+            value = encodeListLike(value, type.getFirstSupportType());
+            if (!type.getFirstSupportType())
+                type = type.remapListSupportType(value[0]);
+            value = value[1];
+            break;
         case rust.CqlType.Map:
             // TODO:
             // This is part of the datastax logic for encoding map.
@@ -242,11 +269,10 @@ function wrapValueBasedOnType(type, value) {
                 // Use Map#forEach() method to iterate
                 value.forEach(addItem);
             } */
-            encodedElement = encodeMap(value, type);
-            return rust.QueryParameterWrapper.fromMap(encodedElement);
-        case rust.CqlType.SmallInt:
-            ensureNumber(value);
-            return rust.QueryParameterWrapper.fromSmallInt(value);
+            value = encodeMap(value, type);
+            type = value[0];
+            value = value[1];
+            break;
         case rust.CqlType.Time:
             // Other forms of providing LocalTime are kept as parity with old driver
             if (typeof value == "string") {
@@ -258,12 +284,8 @@ function wrapValueBasedOnType(type, value) {
                 );
             }
 
-            return rust.QueryParameterWrapper.fromLocalTime(
-                value.getInternal(),
-            );
-        case rust.CqlType.TinyInt:
-            ensureNumber(value);
-            return rust.QueryParameterWrapper.fromTinyInt(value);
+            value = value.getInternal();
+            break;
         case rust.CqlType.Uuid:
             // Other forms of providing UUID are kept as parity with old driver
             if (typeof value === "string") {
@@ -275,10 +297,13 @@ function wrapValueBasedOnType(type, value) {
                     "Expected UUID type to parse into Cql Uuid",
                 );
             }
-            return rust.QueryParameterWrapper.fromUuid(value.getInternal());
+            value = value.getInternal();
+            break;
         case rust.CqlType.Tuple:
-            encodedElement = encodeTuple(value, type);
-            return rust.QueryParameterWrapper.fromTuple(encodedElement);
+            value = encodeTuple(value, type);
+            type = value[0];
+            value = value[1];
+            break;
         case rust.CqlType.Timeuuid:
             // Other forms of providing TimeUUID are kept as parity with old driver
             if (typeof value === "string") {
@@ -289,26 +314,28 @@ function wrapValueBasedOnType(type, value) {
                     "Expected Time UUID type to parse into Cql Uuid",
                 );
             }
-            return rust.QueryParameterWrapper.fromTimeUuid(value.getInternal());
+            value = value.getInternal();
+            break;
         default:
             // Or not yet implemented type
             throw new ReferenceError(
                 `[INTERNAL DRIVER ERROR] Unknown type: ${type}`,
             );
     }
+    return [type, value];
 }
 
 /**
- * Parses array of params into rust objects according to preparedStatement expected types
- * Throws ResponseError when received different amount of parameters than expected
+ * Parses array of params into expected format according to preparedStatement expected types
  *
  * If `allowGuessing` is true, then for each missing field of `expectedTypes`, this function will try to guess a type.
  * If the type cannot be guessed, error will be thrown.
- * Field is missing if it is null, undefined (or if the `expectedTypes` list is to short)
+ * Field is missing if it is null, undefined or if the `expectedTypes` list is too short
  * @param {Array<rust.ComplexType | null>} expectedTypes List of expected types.
  * @param {Array<any>} params
  * @param {boolean} [allowGuessing]
- * @returns {Array<rust.QueryParameterWrapper>}
+ * @returns {Array<rust.ComplexType|any>} Returns tuple: [rust.ComplexType, any] or []
+ * @throws ResponseError when received different amount of parameters than expected
  */
 function parseParams(expectedTypes, params, allowGuessing) {
     if (expectedTypes.length == 0 && !params) return [];
@@ -327,8 +354,10 @@ function parseParams(expectedTypes, params, allowGuessing) {
             params[i] = null;
         }
 
-        if (params[i] === null) {
-            res.push(null);
+        // undefined as null depends on encodingOptions.useUndefinedAsUnset option
+        // TODO: Add support for this option
+        if (params[i] === null || params[i] === undefined) {
+            res.push([]);
             continue;
         }
 

--- a/src/requests/parameter_wrappers.rs
+++ b/src/requests/parameter_wrappers.rs
@@ -1,235 +1,198 @@
-use napi::bindgen_prelude::{BigInt, Buffer};
+use napi::{
+    bindgen_prelude::{Array, BigInt, Buffer, FromNapiValue, Undefined},
+    Status,
+};
 use scylla::value::{Counter, CqlTimestamp, CqlTimeuuid, CqlValue, MaybeUnset};
 
 use crate::{
     types::{
-        duration::DurationWrapper, inet::InetAddressWrapper, local_date::LocalDateWrapper,
-        local_time::LocalTimeWrapper, uuid::UuidWrapper,
+        duration::DurationWrapper,
+        inet::InetAddressWrapper,
+        local_date::LocalDateWrapper,
+        local_time::LocalTimeWrapper,
+        type_wrappers::{ComplexType, CqlType},
+        uuid::UuidWrapper,
     },
     utils::{bigint_to_i64, js_error},
 };
 
-#[napi]
-pub struct MaybeUnsetQueryParameterWrapper {
-    pub(crate) parameter: MaybeUnset<CqlValue>,
+pub struct ParameterWrapper {
+    pub(crate) row: Option<MaybeUnset<CqlValue>>,
 }
 
-/// Structure wraps CqlValue type. Use for passing parameters for requests.
+/// Converts an array of values into Vec of CqlValue based on the provided type.
+fn cql_value_vec_from_array(typ: &ComplexType, arr: &Array) -> napi::Result<Vec<CqlValue>> {
+    Result::from_iter((0..arr.len()).map(|i| cql_value_from_napi_value(typ, arr, i)))
+}
+/// Creates a Vec of (key, value) pairs, each of CqlValue type,
+/// from provided array and type.
 ///
-/// Exposes functions from___ for each CQL type. They can be used to
-/// create QueryParameterWrapper from a given value. For complex types,
-/// like list or map, it requires the values to be provided as QueryParameterWrapper.
-///
-/// Currently there is no type validation for complex types, meaning this code
-/// will accept for example vector with multiple types of values, which is not a valid CQL object.
-#[napi]
-pub struct QueryParameterWrapper {
-    pub(crate) parameter: CqlValue,
+/// It requires that each element of the `arr` array is at least two element array itself.
+fn cql_value_vec_from_map(
+    typ: &ComplexType,
+    arr: &Array,
+) -> napi::Result<Vec<(CqlValue, CqlValue)>> {
+    let mut res = vec![];
+    let parsing_error = || {
+        napi::Error::new(
+            Status::InvalidArg,
+            "Unexpected data when parsing parameters row".to_owned(),
+        )
+    };
+    for i in 0..arr.len() {
+        let elem = arr.get::<Array>(i)?.ok_or_else(parsing_error)?;
+
+        let key = cql_value_from_napi_value(
+            &(typ.get_first_support_type().ok_or_else(parsing_error)?),
+            &elem,
+            0,
+        )?;
+        let val = cql_value_from_napi_value(
+            &(typ.get_second_support_type().ok_or_else(parsing_error)?),
+            &elem,
+            1,
+        )?;
+        res.push((key, val));
+    }
+    Ok(res)
 }
 
-#[napi]
-impl QueryParameterWrapper {
-    #[napi]
-    pub fn from_ascii(val: String) -> QueryParameterWrapper {
-        QueryParameterWrapper {
-            parameter: CqlValue::Ascii(val),
+fn cql_value_vec_from_tuple(
+    types: &ComplexType,
+    arr: &Array,
+) -> napi::Result<Vec<Option<CqlValue>>> {
+    let mut res = vec![];
+    let support_types = types.get_inner_types();
+
+    // JS arrays can hold up to 2^32 - 2 values.
+    // Here we assume usize is at least 4 bytes.
+    if support_types.len() != arr.len().try_into().unwrap() {
+        return Err(napi::Error::new(
+            Status::InvalidArg,
+            "Tuple has different amount of types and values".to_owned(),
+        ));
+    }
+
+    // i will be capped at JS array size: an unsigned 32 bit value
+    // this allows us to safely convert i to u32
+    for (i, typ) in support_types.into_iter().enumerate() {
+        if let Ok(Some(_)) = arr.get::<Undefined>(i.try_into().unwrap()) {
+            res.push(None);
+        } else {
+            let value = cql_value_from_napi_value(&typ, arr, i.try_into().unwrap())?;
+            res.push(Some(value));
         }
     }
 
-    #[napi]
-    pub fn from_bigint(val: BigInt) -> napi::Result<QueryParameterWrapper> {
-        Ok(QueryParameterWrapper {
-            parameter: CqlValue::BigInt(bigint_to_i64(val, "Cannot fit value in CqlBigInt")?),
-        })
-    }
-
-    #[napi]
-    pub fn from_boolean(val: bool) -> QueryParameterWrapper {
-        QueryParameterWrapper {
-            parameter: CqlValue::Boolean(val),
-        }
-    }
-
-    #[napi]
-    pub fn from_blob(val: Buffer) -> QueryParameterWrapper {
-        QueryParameterWrapper {
-            parameter: CqlValue::Blob(val.to_vec()),
-        }
-    }
-
-    #[napi]
-    pub fn from_counter(val: BigInt) -> napi::Result<QueryParameterWrapper> {
-        Ok(QueryParameterWrapper {
-            parameter: CqlValue::Counter(Counter(bigint_to_i64(
-                val,
-                "Value casted into counter type shouldn't overflow i64",
-            )?)),
-        })
-    }
-
-    #[napi]
-    pub fn from_local_date(val: &LocalDateWrapper) -> QueryParameterWrapper {
-        QueryParameterWrapper {
-            parameter: CqlValue::Date(val.get_cql_date()),
-        }
-    }
-
-    #[napi]
-    pub fn from_double(val: f64) -> QueryParameterWrapper {
-        QueryParameterWrapper {
-            parameter: CqlValue::Double(val),
-        }
-    }
-
-    #[napi]
-    pub fn from_duration(val: &DurationWrapper) -> QueryParameterWrapper {
-        QueryParameterWrapper {
-            parameter: CqlValue::Duration(val.get_cql_duration()),
-        }
-    }
-
-    #[napi]
-    pub fn from_float(val: f64) -> QueryParameterWrapper {
-        QueryParameterWrapper {
-            parameter: CqlValue::Float(val as f32),
-        }
-    }
-
-    #[napi]
-    pub fn from_int(val: i32) -> QueryParameterWrapper {
-        QueryParameterWrapper {
-            parameter: CqlValue::Int(val),
-        }
-    }
-
-    #[napi]
-    pub fn from_text(val: String) -> QueryParameterWrapper {
-        QueryParameterWrapper {
-            parameter: CqlValue::Text(val),
-        }
-    }
-
-    #[napi]
-    pub fn from_timestamp(val: BigInt) -> napi::Result<QueryParameterWrapper> {
-        Ok(QueryParameterWrapper {
-            parameter: CqlValue::Timestamp(CqlTimestamp(bigint_to_i64(
-                val,
-                "timestamp cannot overflow i64",
-            )?)),
-        })
-    }
-
-    #[napi]
-    pub fn from_inet(val: &InetAddressWrapper) -> QueryParameterWrapper {
-        QueryParameterWrapper {
-            parameter: CqlValue::Inet(val.get_ip_addr()),
-        }
-    }
-
-    #[napi]
-    pub fn from_list(val: Vec<&QueryParameterWrapper>) -> QueryParameterWrapper {
-        QueryParameterWrapper {
-            parameter: CqlValue::List(val.iter().map(|f| f.parameter.clone()).collect()),
-        }
-    }
-
-    #[napi]
-    pub fn from_set(val: Vec<&QueryParameterWrapper>) -> QueryParameterWrapper {
-        QueryParameterWrapper {
-            parameter: CqlValue::Set(val.iter().map(|f| f.parameter.clone()).collect()),
-        }
-    }
-
-    #[napi]
-    pub fn from_map(
-        val: Vec<(&QueryParameterWrapper, &QueryParameterWrapper)>,
-    ) -> QueryParameterWrapper {
-        QueryParameterWrapper {
-            parameter: CqlValue::Map(
-                val.iter()
-                    .map(|f| (f.0.parameter.clone(), f.1.parameter.clone()))
-                    .collect(),
-            ),
-        }
-    }
-
-    #[napi]
-    pub fn from_small_int(val: i32) -> napi::Result<QueryParameterWrapper> {
-        Ok(QueryParameterWrapper {
-            parameter: CqlValue::SmallInt(
-                val.try_into()
-                    .map_err(|_| js_error("Value must fit in i16 type to be small int"))?,
-            ),
-        })
-    }
-
-    #[napi]
-    pub fn from_local_time(val: &LocalTimeWrapper) -> QueryParameterWrapper {
-        QueryParameterWrapper {
-            parameter: CqlValue::Time(val.get_cql_time()),
-        }
-    }
-
-    #[napi]
-    pub fn from_tiny_int(val: i32) -> napi::Result<QueryParameterWrapper> {
-        Ok(QueryParameterWrapper {
-            parameter: CqlValue::TinyInt(
-                val.try_into()
-                    .map_err(|_| js_error("Value must fit in i16 type to be small int"))?,
-            ),
-        })
-    }
-
-    #[napi]
-    pub fn from_uuid(val: &UuidWrapper) -> QueryParameterWrapper {
-        QueryParameterWrapper {
-            parameter: CqlValue::Uuid(val.get_cql_uuid()),
-        }
-    }
-
-    #[napi]
-    pub fn from_tuple(val: Vec<Option<&QueryParameterWrapper>>) -> QueryParameterWrapper {
-        QueryParameterWrapper {
-            parameter: CqlValue::Tuple(
-                val.iter().map(|f| f.map(|e| e.parameter.clone())).collect(),
-            ),
-        }
-    }
-
-    #[napi]
-    pub fn from_time_uuid(val: &UuidWrapper) -> QueryParameterWrapper {
-        QueryParameterWrapper {
-            parameter: CqlValue::Timeuuid(CqlTimeuuid::from_bytes(val.get_cql_uuid().into_bytes())),
-        }
-    }
+    Ok(res)
 }
 
-impl MaybeUnsetQueryParameterWrapper {
-    /// Takes vector of QueryParameterWrapper references and turns it into vector of CqlValue
-    pub(crate) fn extract_parameters(
-        row: Vec<Option<&MaybeUnsetQueryParameterWrapper>>,
-    ) -> Vec<Option<MaybeUnset<CqlValue>>> {
-        row.iter()
-            .map(|e| e.as_ref().map(|v| v.parameter.clone()))
-            .collect()
+/// Convert element at pos position in elem Array into CqlValue, based on the provided type
+fn cql_value_from_napi_value(typ: &ComplexType, elem: &Array, pos: u32) -> napi::Result<CqlValue> {
+    /// Try to covert value at `pos` position in `elem` array into value of `statement_type` type.
+    macro_rules! get_element {
+        ($statement_type: ty) => {
+            elem.get::<$statement_type>(pos)?.ok_or(napi::Error::new(
+                Status::InvalidArg,
+                "Unexpected data when parsing parameters row".to_owned(),
+            ))?
+        };
     }
+    let value: CqlValue = match typ.base_type {
+        CqlType::Ascii => CqlValue::Ascii(get_element!(String)),
+        CqlType::Boolean => CqlValue::Boolean(get_element!(bool)),
+        CqlType::Blob => CqlValue::Blob(get_element!(Buffer).to_vec()),
+        CqlType::Counter => CqlValue::Counter(Counter(bigint_to_i64(
+            get_element!(BigInt),
+            "Value cast into counter type shouldn't overflow i64",
+        )?)),
+        CqlType::Decimal => todo!(),
+        CqlType::Date => CqlValue::Date(get_element!(&LocalDateWrapper).get_cql_date()),
+        CqlType::Double => CqlValue::Double(get_element!(f64)),
+        CqlType::Duration => CqlValue::Duration(get_element!(&DurationWrapper).get_cql_duration()),
+        CqlType::Float => CqlValue::Float(get_element!(f64) as f32),
+        CqlType::Int => CqlValue::Int(get_element!(i32)),
+        CqlType::BigInt => CqlValue::BigInt(bigint_to_i64(
+            get_element!(BigInt),
+            "Cannot fit value in CqlBigInt",
+        )?),
+        CqlType::Text => CqlValue::Text(get_element!(String)),
+        CqlType::Timestamp => CqlValue::Timestamp(CqlTimestamp(bigint_to_i64(
+            get_element!(BigInt),
+            "timestamp cannot overflow i64",
+        )?)),
+        CqlType::Inet => CqlValue::Inet(get_element!(&InetAddressWrapper).get_ip_addr()),
+        CqlType::List => CqlValue::List(cql_value_vec_from_array(
+            typ.support_type_1
+                .as_ref()
+                .expect("Expected support type for list"),
+            &get_element!(Array),
+        )?),
+        CqlType::Map => CqlValue::Map(cql_value_vec_from_map(typ, &get_element!(Array))?),
+        CqlType::Set => CqlValue::Set(cql_value_vec_from_array(
+            typ.support_type_1
+                .as_ref()
+                .expect("Expected support type for list"),
+            &get_element!(Array),
+        )?),
+        CqlType::UserDefinedType => todo!(),
+        CqlType::SmallInt => CqlValue::SmallInt(
+            get_element!(i32)
+                .try_into()
+                .map_err(|_| js_error("Value must fit in i16 type to be small int"))?,
+        ),
+        CqlType::TinyInt => CqlValue::TinyInt(
+            get_element!(i32)
+                .try_into()
+                .map_err(|_| js_error("Value must fit in i8 type to be tiny int"))?,
+        ),
+        CqlType::Time => CqlValue::Time(get_element!(&LocalTimeWrapper).get_cql_time()),
+        CqlType::Timeuuid => CqlValue::Timeuuid(CqlTimeuuid::from_bytes(
+            get_element!(&UuidWrapper).get_cql_uuid().into_bytes(),
+        )),
+        CqlType::Tuple => CqlValue::Tuple(cql_value_vec_from_tuple(typ, &get_element!(Array))?),
+        CqlType::Uuid => CqlValue::Uuid(get_element!(&UuidWrapper).get_cql_uuid()),
+        CqlType::Varint => todo!(),
+        CqlType::Unprovided => return Err(js_error("Expected type information for the value")),
+        CqlType::Empty => unreachable!("Should not receive Empty type here."),
+        CqlType::Custom => unreachable!("Should not receive Custom type here."),
+    };
+    Ok(value)
 }
 
-#[napi]
-impl MaybeUnsetQueryParameterWrapper {
-    #[napi]
-    pub fn from_non_null_non_unset_value(
-        val: &QueryParameterWrapper,
-    ) -> MaybeUnsetQueryParameterWrapper {
-        MaybeUnsetQueryParameterWrapper {
-            parameter: MaybeUnset::Set(val.parameter.clone()),
-        }
-    }
+impl FromNapiValue for ParameterWrapper {
+    /// # Safety
+    ///
+    /// Valid pointer to napi env must be provided
+    unsafe fn from_napi_value(
+        env: napi::sys::napi_env,
+        napi_val: napi::sys::napi_value,
+    ) -> napi::Result<Self> {
+        let parsing_error = || {
+            napi::Error::new(
+                Status::InvalidArg,
+                "Unexpected data when parsing parameters row".to_owned(),
+            )
+        };
 
-    #[napi]
-    pub fn unset() -> MaybeUnsetQueryParameterWrapper {
-        MaybeUnsetQueryParameterWrapper {
-            parameter: MaybeUnset::Unset,
-        }
+        // Caller of this function ensures a valid pointer to napi env is provided
+        let elem = unsafe { Array::from_napi_value(env, napi_val)? };
+        // If we received:
+        //   - 0 element array - null value was provided
+        //   - 1 element array - unset value was provided
+        //   - 2 element array - [type, value] was provided
+        let val = match elem.len() {
+            0 => None,
+            1 => Some(MaybeUnset::Unset),
+            2 => {
+                let typ = elem.get::<&ComplexType>(0)?.ok_or_else(parsing_error)?;
+                Some(MaybeUnset::Set(cql_value_from_napi_value(typ, &elem, 1)?))
+            }
+            _ => {
+                return Err(parsing_error());
+            }
+        };
+
+        Ok(ParameterWrapper { row: val })
     }
 }

--- a/src/result.rs
+++ b/src/result.rs
@@ -382,7 +382,7 @@ pub(crate) fn map_column_type_to_complex_type(typ: &ColumnType) -> ComplexType {
             other => unimplemented!("Missing implementation for CQL Collection type {:?}", other),
         },
         ColumnType::UserDefinedType { .. } => ComplexType::simple_type(CqlType::UserDefinedType),
-        ColumnType::Tuple(t) => ComplexType::from_tuple(t.as_slice()),
+        ColumnType::Tuple(t) => ComplexType::tuple_from_column_type(t.as_slice()),
         ColumnType::Vector {
             typ: _,
             dimensions: _,

--- a/src/tests/request_values_tests.rs
+++ b/src/tests/request_values_tests.rs
@@ -116,3 +116,21 @@ pub fn tests_from_value(test: String, value: ParameterWrapper) {
         v
     );
 }
+
+#[napi]
+pub fn tests_parameters_wrapper_unset(value: ParameterWrapper) {
+    match value.row {
+        Some(v) => match v {
+            scylla::value::MaybeUnset::Unset => (),
+            scylla::value::MaybeUnset::Set(_) => panic!("Expected unset value"),
+        },
+        None => panic!("Expected some value"),
+    }
+}
+
+#[napi]
+pub fn tests_parameters_wrapper_null(value: ParameterWrapper) {
+    if value.row.is_some() {
+        panic!("Expected none value")
+    }
+}

--- a/src/types/type_wrappers.rs
+++ b/src/types/type_wrappers.rs
@@ -30,6 +30,7 @@ pub enum CqlType {
     Uuid,
     Varint,
     Custom,
+    Unprovided,
 }
 
 /// The goal of this class is to have an enum, that can be type checked.
@@ -69,6 +70,51 @@ impl ComplexType {
         // Batch query to NAPI minimizes number of calls
         self.inner_types.clone()
     }
+
+    /// Create a new copy of the ComplexType, with first support type set to the provided type and the same base type
+    ///
+    /// Intended for filling types of the list / set values in case no support type was initially provided
+    #[napi]
+    pub fn remap_list_support_type(&self, new_subtype: &ComplexType) -> ComplexType {
+        ComplexType::one_support(self.base_type, Some(new_subtype.clone()))
+    }
+
+    /// Create a new copy of the ComplexType, with first and second support type set to the provided types and the same base type
+    ///
+    /// Intended for filling types of the map keys and value in case no support types were initially provided
+    #[napi]
+    pub fn remap_map_support_type(
+        &self,
+        key_new_subtype: &ComplexType,
+        val_new_subtype: &ComplexType,
+    ) -> ComplexType {
+        ComplexType::two_support(
+            self.base_type,
+            Some(key_new_subtype.clone()),
+            Some(val_new_subtype.clone()),
+        )
+    }
+
+    /// Create a new ComplexType for tuple with provided inner types.
+    #[napi]
+    pub fn remap_tuple_support_type(new_subtypes: Vec<Option<&ComplexType>>) -> ComplexType {
+        ComplexType::from_tuple(
+            new_subtypes
+                .into_iter()
+                // HACK:
+                // There is a chance, user doesn't provide a type for some tuple value.
+                // If this value is null or unset, we can still correctly handle that case.
+                // For this reason we set here Unprovided type, a type that will never be used in request.
+                // If we encounter Unprovided in parsing value, this means that insufficient type information was provided.
+                //
+                // This will be fixed at a later time, as it requires more investigation into how tuple works.
+                .map(|e| {
+                    e.unwrap_or(&ComplexType::simple_type(CqlType::Unprovided))
+                        .clone()
+                })
+                .collect(),
+        )
+    }
 }
 
 impl ComplexType {
@@ -96,15 +142,21 @@ impl ComplexType {
         }
     }
 
-    pub(crate) fn from_tuple(columns: &[ColumnType]) -> Self {
+    pub(crate) fn from_tuple(columns: Vec<ComplexType>) -> Self {
         ComplexType {
             base_type: CqlType::Tuple,
             support_type_1: None,
             support_type_2: None,
-            inner_types: columns
+            inner_types: columns,
+        }
+    }
+
+    pub(crate) fn tuple_from_column_type(columns: &[ColumnType]) -> Self {
+        ComplexType::from_tuple(
+            columns
                 .iter()
                 .map(|column| map_column_type_to_complex_type(column))
                 .collect(),
-        }
+        )
     }
 }

--- a/test/unit/query-parameter-tests.js
+++ b/test/unit/query-parameter-tests.js
@@ -9,6 +9,7 @@ const TimeUuid = require("../../lib/types/time-uuid");
 const Tuple = require("../../lib/types/tuple");
 const Uuid = require("../../lib/types/uuid");
 const Long = require("long");
+const { types } = require("../../main");
 
 const maxI64 = BigInt("9223372036854775807");
 
@@ -39,14 +40,44 @@ const testCases = [
     ["Uuid", Uuid.fromString("ffffffff-eeee-ffff-ffff-ffffffffffff")],
 ];
 
-describe("Should correctly convert some set values into Parameter wrapper", function () {
-    testCases.forEach((test) => {
-        it(test[0], function () {
-            let value = test[1];
-            let expectedType = rust.testsFromValueGetType(test[0]);
-            let converted = getWrapped(expectedType, value);
+describe("Should correctly convert ", function () {
+    describe("some set values into Parameter wrapper", function () {
+        testCases.forEach((test) => {
+            it(test[0], function () {
+                let value = test[1];
+                let expectedType = rust.testsFromValueGetType(test[0]);
+                let converted = getWrapped(expectedType, value);
+                // Assertion appears in rust code
+                rust.testsFromValue(test[0], converted);
+            });
+        });
+    });
+
+    describe("some unset value", function () {
+        it("with type", function () {
+            let someType = rust.testsFromValueGetType(testCases[0][0]);
+            let wrapped = getWrapped(someType, types.unset);
             // Assertion appears in rust code
-            rust.testsFromValue(test[0], converted);
+            rust.testsParametersWrapperUnset(wrapped);
+        });
+        it("without type", function () {
+            let wrapped = getWrapped(null, types.unset);
+            // Assertion appears in rust code
+            rust.testsParametersWrapperUnset(wrapped);
+        });
+    });
+
+    describe("none value", function () {
+        it("with type", function () {
+            let someType = rust.testsFromValueGetType(testCases[0][0]);
+            let wrapped = getWrapped(someType, null);
+            // Assertion appears in rust code
+            rust.testsParametersWrapperNull(wrapped);
+        });
+        it("without type", function () {
+            let wrapped = getWrapped(null, null);
+            // Assertion appears in rust code
+            rust.testsParametersWrapperNull(wrapped);
         });
     });
 });

--- a/test/unit/query-parameter-tests.js
+++ b/test/unit/query-parameter-tests.js
@@ -1,6 +1,5 @@
 "use strict";
 const rust = require("../../index");
-const assert = require("assert");
 const { getWrapped } = require("../../lib/types/cql-utils");
 const utils = require("../../lib/utils");
 const Duration = require("../../lib/types/duration");
@@ -40,7 +39,7 @@ const testCases = [
     ["Uuid", Uuid.fromString("ffffffff-eeee-ffff-ffff-ffffffffffff")],
 ];
 
-describe("Should correctly convert values into QueryParameterWrapper", function () {
+describe("Should correctly convert some set values into Parameter wrapper", function () {
     testCases.forEach((test) => {
         it(test[0], function () {
             let value = test[1];


### PR DESCRIPTION
Before, we created QueryParameterWrapper with from_... functions, and then cloning this object when executing query.

Now, with implementation of FromNapiValue trait, we pass parameters to queries directly, without any additional conversion steps. In order to correctly handle value types, each parameter is passed as a pair (type, value). Information about type is then used on the rust side to create correct CqlValue object.

This significantly improves performance for concurrent inserts benchmark, and slightly for plain inserts benchmark.

Concurrent inset. Around 30% improvement in time elapsed, 20% in task clock

After:

```bash
sudo perf stat node ./benchmark/logic/concurrent_insert.js scylladb-javascript-driver 1000000

 Performance counter stats for 'node ./benchmark/logic/concurrent_insert.js scylladb-javascript-driver 1000000':

         70,343.46 msec task-clock                       #    1.892 CPUs utilized             
         2,909,393      context-switches                 #   41.360 K/sec                     
            40,946      cpu-migrations                   #  582.087 /sec                      
           190,074      page-faults                      #    2.702 K/sec                     
   273,230,048,329      cycles                           #    3.884 GHz                       
    72,133,512,748      stalled-cycles-frontend          #   26.40% frontend cycles idle      
   205,423,999,244      instructions                     #    0.75  insn per cycle            
                                                  #    0.35  stalled cycles per insn   
    39,462,664,735      branches                         #  561.000 M/sec                     
     1,481,648,921      branch-misses                    #    3.75% of all branches           

      37.183329662 seconds time elapsed

      46.102799000 seconds user
      25.690728000 seconds sys
```

Before

```bash
sudo perf stat node ./benchmark/logic/concurrent_insert.js scylladb-javascript-driver 1000000

 Performance counter stats for 'node ./benchmark/logic/concurrent_insert.js scylladb-javascript-driver 1000000':

         86,873.69 msec task-clock                       #    1.633 CPUs utilized             
         3,221,740      context-switches                 #   37.085 K/sec                     
            48,446      cpu-migrations                   #  557.660 /sec                      
           190,596      page-faults                      #    2.194 K/sec                     
   344,373,066,097      cycles                           #    3.964 GHz                       
    87,340,988,626      stalled-cycles-frontend          #   25.36% frontend cycles idle      
   246,727,230,093      instructions                     #    0.72  insn per cycle            
                                                  #    0.35  stalled cycles per insn   
    47,143,750,188      branches                         #  542.670 M/sec                     
     1,750,876,479      branch-misses                    #    3.71% of all branches           

      53.200649700 seconds time elapsed

      60.397169000 seconds user
      28.058204000 seconds sys


```

Plain insert. Around 10% improvement in user time and number of instructions, 90% drop in page faults!

After:

```bash
sudo perf stat node ./benchmark/logic/insert.js scylladb-javascript-driver 300000

 Performance counter stats for 'node ./benchmark/logic/insert.js scylladb-javascript-driver 300000':

         30,435.03 msec task-clock                       #    0.839 CPUs utilized             
         2,126,428      context-switches                 #   69.868 K/sec                     
            19,269      cpu-migrations                   #  633.119 /sec                      
             8,034      page-faults                      #  263.972 /sec                      
   104,314,726,271      cycles                           #    3.427 GHz                       
    51,460,535,207      stalled-cycles-frontend          #   49.33% frontend cycles idle      
    91,254,504,996      instructions                     #    0.87  insn per cycle            
                                                  #    0.56  stalled cycles per insn   
    17,802,023,048      branches                         #  584.919 M/sec                     
     1,010,940,030      branch-misses                    #    5.68% of all branches           

      36.283305820 seconds time elapsed

      14.569449000 seconds user
      17.101418000 seconds sys
```

Before:

```bash
sudo perf stat node ./benchmark/logic/insert.js scylladb-javascript-driver 300000

 Performance counter stats for 'node ./benchmark/logic/insert.js scylladb-javascript-driver 300000':

         31,847.19 msec task-clock                       #    0.830 CPUs utilized             
         2,126,649      context-switches                 #   66.777 K/sec                     
            18,765      cpu-migrations                   #  589.220 /sec                      
            88,511      page-faults                      #    2.779 K/sec                     
   111,466,616,472      cycles                           #    3.500 GHz                       
    51,182,304,492      stalled-cycles-frontend          #   45.92% frontend cycles idle      
   100,318,097,101      instructions                     #    0.90  insn per cycle            
                                                  #    0.51  stalled cycles per insn   
    19,409,416,734      branches                         #  609.455 M/sec                     
     1,016,535,128      branch-misses                    #    5.24% of all branches           

      38.359245639 seconds time elapsed

      16.112863000 seconds user
      16.940505000 seconds sys
```
