### PR TITLE
UUID raw performance

### DIFF
--- a/lib/types/uuid.js
+++ b/lib/types/uuid.js
@@ -2,7 +2,6 @@
 
 const crypto = require("crypto");
 const utils = require("../utils");
-const rust = require("../../index");
 
 /** @module types */
 
@@ -19,10 +18,10 @@ class Uuid {
         /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
     /**
-     * @type {rust.UuidWrapper}
+     * @type {Buffer}
      * @private
      */
-    #internal;
+    #raw;
 
     /**
      * Creates a new instance of Uuid based on a Buffer
@@ -34,7 +33,7 @@ class Uuid {
                 "You must provide a buffer containing 16 bytes",
             );
         }
-        this.#internal = rust.UuidWrapper.new(buffer);
+        this.#raw = buffer;
     }
 
     /**
@@ -43,7 +42,7 @@ class Uuid {
      * @type Buffer
      */
     get buffer() {
-        return this.#internal.getBuffer();
+        return this.#raw;
     }
 
     set buffer(_) {
@@ -94,7 +93,7 @@ class Uuid {
      * @returns {Buffer}
      */
     getBuffer() {
-        return this.#internal.getBuffer();
+        return this.buffer;
     }
 
     /**
@@ -150,7 +149,7 @@ class Uuid {
      * @returns {rust.UuidWrapper}
      */
     getInternal() {
-        return this.#internal;
+        return this.#raw;
     }
 }
 


### PR DESCRIPTION
UUID but faster

Update UUID and TimeUUID to use raw buffers, instead of rust wrappers
for storing internal state.


Before

```bash
sudo perf stat /node ./benchmark/logic/concurrent_insert.js scylladb-javascript-driver 1000000
 

 Performance counter stats for '/node ./benchmark/logic/concurrent_insert.js scylladb-javascript-driver 1000000':

         64,301.95 msec task-clock                       #    2.155 CPUs utilized             
         1,973,780      context-switches                 #   30.695 K/sec                     
            69,319      cpu-migrations                   #    1.078 K/sec                     
           214,866      page-faults                      #    3.342 K/sec                     
   250,045,258,686      cycles                           #    3.889 GHz                       
    87,874,976,377      stalled-cycles-frontend          #   35.14% frontend cycles idle      
   178,385,613,402      instructions                     #    0.71  insn per cycle            
                                                  #    0.49  stalled cycles per insn   
    34,667,445,111      branches                         #  539.135 M/sec                     
     1,500,348,161      branch-misses                    #    4.33% of all branches           

      29.844681006 seconds time elapsed

      41.757460000 seconds user
      23.734114000 seconds sys
```

```bash
sudo perf stat /node ./benchmark/logic/concurrent_select.js scylladb-javascript-driver 800000 

 Performance counter stats for '/node ./benchmark/logic/concurrent_select.js scylladb-javascript-driver 800000':

        130,085.53 msec task-clock                       #    1.508 CPUs utilized             
         1,559,307      context-switches                 #   11.987 K/sec                     
           655,066      cpu-migrations                   #    5.036 K/sec                     
            88,447      page-faults                      #  679.914 /sec                      
   511,028,701,841      cycles                           #    3.928 GHz                       
   164,154,500,997      stalled-cycles-frontend          #   32.12% frontend cycles idle      
   363,009,682,488      instructions                     #    0.71  insn per cycle            
                                                  #    0.45  stalled cycles per insn   
    68,120,755,034      branches                         #  523.661 M/sec                     
     1,877,879,648      branch-misses                    #    2.76% of all branches           

      86.250729951 seconds time elapsed

     104.076497000 seconds user
      27.284663000 seconds sys
```

After

concurrent_insert: 10 - 20% improvement between all stats

```bash
sudo perf stat /node ./benchmark/logic/concurrent_insert.js scylladb-javascript-driver 1000000

 Performance counter stats for '/node ./benchmark/logic/concurrent_insert.js scylladb-javascript-driver 1000000':

         57,361.99 msec task-clock                       #    2.350 CPUs utilized             
         1,740,308      context-switches                 #   30.339 K/sec                     
            72,572      cpu-migrations                   #    1.265 K/sec                     
           220,962      page-faults                      #    3.852 K/sec                     
   217,680,601,181      cycles                           #    3.795 GHz                       
    84,739,011,158      stalled-cycles-frontend          #   38.93% frontend cycles idle      
   167,922,616,789      instructions                     #    0.77  insn per cycle            
                                                  #    0.50  stalled cycles per insn   
    32,689,712,275      branches                         #  569.885 M/sec                     
     1,461,994,475      branch-misses                    #    4.47% of all branches           

      24.407353210 seconds time elapsed

      35.343360000 seconds user
      23.097567000 seconds sys
```

concurrent_select: 20 - 25% improvement between all stats

```bash
sudo perf stat /node ./benchmark/logic/concurrent_select.js scylladb-javascript-driver 800000

 Performance counter stats for '/node ./benchmark/logic/concurrent_select.js scylladb-javascript-driver 800000':

        102,973.71 msec task-clock                       #    1.598 CPUs utilized             
         1,339,061      context-switches                 #   13.004 K/sec                     
           504,613      cpu-migrations                   #    4.900 K/sec                     
           132,858      page-faults                      #    1.290 K/sec                     
   396,294,756,327      cycles                           #    3.849 GHz                       
   139,406,693,262      stalled-cycles-frontend          #   35.18% frontend cycles idle      
   295,268,487,607      instructions                     #    0.75  insn per cycle            
                                                  #    0.47  stalled cycles per insn   
    56,054,780,474      branches                         #  544.360 M/sec                     
     1,667,803,584      branch-misses                    #    2.98% of all branches           

      64.432062083 seconds time elapsed

      79.389064000 seconds user
      24.640962000 seconds sys
```
