### PR TITLE
Varint

### DIFF
--- a/docs/src/internal/parameter_wrapper.md
+++ b/docs/src/internal/parameter_wrapper.md
@@ -1,0 +1,25 @@
+# ParameterWrapper
+
+Parameter wrapper is used to pass parameters for all queries.
+It can pass any CQL Value, null and unset values.
+On the Rust side, the value is represented by:
+`Option<MaybeUnset<CqlValue>>`
+and on the JavaScript side it's represented by:
+`[ComplexType, Value]` with the null being: `[]` and unset: `[undefined]`.
+
+The conversion from the user provided values to accepted format is done in `types/cql-utils.js`.
+
+On the Rust side, `requests/parameter_wrappers.rs` is responsible for value conversion
+into format recognized by the Rust driver. It's done via the `FromNapiValue` trait.
+The specific format containing both type and value is necessary to create a correct CQL Value,
+without using [env](https://napi.rs/docs/compat-mode/concepts/env) in function.
+
+As driver allows values to be provided in multiple formats:
+
+- one of the predefined types,
+- as a string representation of the type,
+- as a pre-serialized byte array
+
+which are converted into predefined type, before passing it to the Rust.
+It's possible to do this conversion also on the Rust size
+(but it's necessary to check the performance impact of such change).

--- a/lib/new-utils.js
+++ b/lib/new-utils.js
@@ -1,6 +1,7 @@
 "use strict";
 const customErrors = require("./errors");
 const util = require("./utils");
+const Integer = require("./types/integer");
 
 const Long = require("long");
 
@@ -22,6 +23,22 @@ const errorTypeMap = {
 };
 
 const concatenationMark = "#";
+
+// BigInt constants
+const isBigIntSupported = typeof BigInt !== "undefined";
+const bigInt8 = isBigIntSupported ? BigInt(8) : null;
+const bigInt0 = isBigIntSupported ? BigInt(0) : null;
+const bigIntMinus1 = isBigIntSupported ? BigInt(-1) : null;
+const bigInt8BitsOn = isBigIntSupported ? BigInt(0xff) : null;
+
+// Buffer constants
+const buffers = {
+    int16Zero: util.allocBufferFromArray([0, 0]),
+    int32Zero: util.allocBufferFromArray([0, 0, 0, 0]),
+    int8Zero: util.allocBufferFromArray([0]),
+    int8One: util.allocBufferFromArray([1]),
+    int8MaxValue: util.allocBufferFromArray([0xff]),
+};
 
 /**
  * A wrapper function to map napi errors to Node.js errors or custom errors.
@@ -104,9 +121,117 @@ function arbitraryValueToBigInt(value) {
     );
 }
 
+/**
+ * Converts a value to a varint buffer.
+ * @param {Integer|Buffer|String|Number} value
+ * @returns {Buffer}
+ * @private
+ */
+function encodeVarint(value) {
+    if (typeof value === "number") {
+        value = Integer.fromNumber(value);
+    }
+    if (typeof value === "string") {
+        value = Integer.fromString(value);
+    }
+    let buf = null;
+    if (typeof value === "bigint") {
+        buf = encodeVarintFromBigInt(value);
+    }
+    if (value instanceof Buffer) {
+        buf = value;
+    }
+    if (value instanceof Integer) {
+        buf = Integer.toBuffer(value);
+    }
+    if (buf === null) {
+        throw new TypeError(
+            "Not a valid varint, expected Integer/Number/String/Buffer, obtained " +
+                util.inspect(value),
+        );
+    }
+    return buf;
+}
+
+/**
+ * Converts a BigInt to a varint buffer.
+ * @param {String|BigInt} value
+ * @returns {Buffer}
+ */
+function encodeVarintFromBigInt(value) {
+    if (typeof value === "string") {
+        // All numeric types are supported as strings for historical reasons
+        value = BigInt(value);
+    }
+
+    if (typeof value !== "bigint") {
+        throw new TypeError(
+            "Not a valid varint, expected BigInt, obtained " +
+                util.inspect(value),
+        );
+    }
+
+    if (value === bigInt0) {
+        return buffers.int8Zero;
+    } else if (value === bigIntMinus1) {
+        return buffers.int8MaxValue;
+    }
+
+    const parts = [];
+
+    if (value > bigInt0) {
+        while (value !== bigInt0) {
+            parts.unshift(Number(value & bigInt8BitsOn));
+            value = value >> bigInt8;
+        }
+
+        if (parts[0] > 0x7f) {
+            // Positive value needs a padding
+            parts.unshift(0);
+        }
+    } else {
+        while (value !== bigIntMinus1) {
+            parts.unshift(Number(value & bigInt8BitsOn));
+            value = value >> bigInt8;
+        }
+
+        if (parts[0] <= 0x7f) {
+            // Negative value needs a padding
+            parts.unshift(0xff);
+        }
+    }
+
+    return util.allocBufferFromArray(parts);
+}
+
+/**
+ * Converts a byte array to a BigInt
+ * @param {Buffer} bytes
+ * @returns {BigInt}
+ */
+function decodeVarintAsBigInt(bytes) {
+    let result = bigInt0;
+    if (bytes[0] <= 0x7f) {
+        for (let i = 0; i < bytes.length; i++) {
+            const b = BigInt(bytes[bytes.length - 1 - i]);
+            result = result | (b << BigInt(i * 8));
+        }
+    } else {
+        for (let i = 0; i < bytes.length; i++) {
+            const b = BigInt(bytes[bytes.length - 1 - i]);
+            result = result | ((~b & bigInt8BitsOn) << BigInt(i * 8));
+        }
+        result = ~result;
+    }
+
+    return result;
+}
+
 exports.throwNotSupported = throwNotSupported;
 exports.napiErrorHandler = napiErrorHandler;
 exports.throwNotSupported = throwNotSupported;
 exports.bigintToLong = bigintToLong;
 exports.longToBigint = longToBigint;
 exports.arbitraryValueToBigInt = arbitraryValueToBigInt;
+exports.encodeVarint = encodeVarint;
+exports.decodeVarintAsBigInt = decodeVarintAsBigInt;

--- a/lib/types/cql-utils.js
+++ b/lib/types/cql-utils.js
@@ -11,7 +11,7 @@ const LocalDate = require("./local-date");
 const LocalTime = require("./local-time");
 const InetAddress = require("./inet-address");
 const { guessType } = require("./type-guessing");
-const { arbitraryValueToBigInt } = require("../new-utils");
+const { arbitraryValueToBigInt, encodeVarint } = require("../new-utils");
 
 /**
  * Ensures the value isn't one of many ways to express null value
@@ -311,6 +311,9 @@ function wrapValueBasedOnType(type, value) {
                 );
             }
             value = value.getInternal();
+            break;
+        case rust.CqlType.Varint:
+            value = encodeVarint(value);
             break;
         default:
             // Or not yet implemented type

--- a/lib/types/cql-utils.js
+++ b/lib/types/cql-utils.js
@@ -43,7 +43,7 @@ function guessTypeChecked(value) {
  * Wraps each of the elements into given subtype
  * @param {Array} values
  * @param {rust.ComplexType} subtype
- * @returns {Array<rust.QueryParameterWrapper>}
+ * @returns {Array<rust.ComplexType|any[]>} Returns tuple: [rust.ComplexType, any[]]
  */
 function encodeListLike(values, subtype) {
     if (!Array.isArray(values))
@@ -60,19 +60,19 @@ function encodeListLike(values, subtype) {
             values[i],
             "A collection can't contain null or unset values",
         );
-        res.push(wrapValueBasedOnType(subtype, values[i]));
+        res.push(wrapValueBasedOnType(subtype, values[i])[1]);
     }
-    return res;
+    return [subtype, res];
 }
 
 /**
  * @param {*} value
  * @param {rust.ComplexType} parentType
- * @returns {Array<Array<rust.QueryParameterWrapper>>}
+ * @returns {Array<rust.ComplexType|any[][]>} Returns tuple: [rust.ComplexType, any[][]]
  */
 function encodeMap(value, parentType) {
-    const keySubtype = parentType.getFirstSupportType();
-    const valueSubtype = parentType.getSecondSupportType();
+    let keySubtype = parentType.getFirstSupportType();
+    let valueSubtype = parentType.getSecondSupportType();
 
     let res = [];
 
@@ -83,12 +83,25 @@ function encodeMap(value, parentType) {
         const val = value[key];
         ensureValue(val, "A collection can't contain null or unset values");
         ensureValue(key, "A collection can't contain null or unset values");
+        if (!keySubtype || !valueSubtype) {
+            if (valueSubtype || keySubtype) {
+                throw new Error(
+                    `Internal error: Invalid support types for map`,
+                );
+            }
+            keySubtype = guessTypeChecked(key);
+            valueSubtype = guessTypeChecked(val);
+            parentType = parentType.remapMapSupportType(
+                keySubtype,
+                valueSubtype,
+            );
+        }
         res.push([
-            wrapValueBasedOnType(keySubtype || guessTypeChecked(key), key),
-            wrapValueBasedOnType(valueSubtype || guessTypeChecked(val), val),
+            wrapValueBasedOnType(keySubtype, key)[1],
+            wrapValueBasedOnType(valueSubtype, val)[1],
         ]);
     }
-    return res;
+    return [parentType, res];
 }
 
 /**
@@ -102,86 +115,91 @@ function ensureNumber(value) {
 }
 
 /**
- * Encodes tuple into QueryParameterWrapper
+ * Wraps tuple into format recognized by ParameterWrapper
  * @param {types.Tuple} value
  * @param {rust.ComplexType} type
- * @returns {Array<rust.QueryParameterWrapper>}
+ * @returns {Array<rust.ComplexType|Array<any>>} Returns tuple: [rust.ComplexType, Array<any>]
  */
 function encodeTuple(value, type) {
     let res = [];
+    let newTypes = [];
     let types = type.getInnerTypes();
     for (let i = 0; i < types.length; i++) {
-        const element = value.get(i) !== undefined ? value.get(i) : null;
-        res.push(getWrapped(types[i], element));
+        const element = getWrapped(
+            types[i],
+            value.get(i) !== undefined ? value.get(i) : null,
+        );
+        newTypes.push(element[0]);
+        res.push(element[1]);
     }
-    return res;
+    return [rust.ComplexType.remapTupleSupportType(newTypes), res];
 }
 
 /**
- * Wrap value into MaybeUnsetQueryParameterWrapper based on the type
+ * Wraps value into format recognized by ParameterWrapper, based on the provided type
  * @param {rust.ComplexType} type
  * @param {*} value
- * @returns {rust.MaybeUnsetQueryParameterWrapper?}
+ * @returns {Array<rust.ComplexType|any>} Returns tuple: [rust.ComplexType, any] or []
  */
 function getWrapped(type, value) {
-    // Unsets were introduced in CQLv3, and the backend of the driver - Rust driver -
+    // Unset was introduced in CQLv3, and the backend of the driver - Rust driver -
     // works only with version >= 4 of CQL, so unset will always be supported.
     if (value === null) {
-        return null;
+        return [];
     } else if (value === types.unset) {
-        return rust.MaybeUnsetQueryParameterWrapper.unset();
+        return [undefined];
     }
-    return rust.MaybeUnsetQueryParameterWrapper.fromNonNullNonUnsetValue(
-        wrapValueBasedOnType(type, value),
-    );
+    return wrapValueBasedOnType(type, value);
 }
 
 /**
- * Wrap value, which is not Unset, into QueryParameterWrapper based on the type
+ * Wrap value, which is not Unset, into type and value pair,
+ * ensuring value is converted into expected form
  * @param {rust.ComplexType} type
  * @param {*} value
- * @returns {rust.QueryParameterWrapper}
+ * @returns {Array<rust.ComplexType|any>} Returns tuple: [rust.ComplexType, any]
  */
 function wrapValueBasedOnType(type, value) {
-    let encodedElement;
     let tmpElement;
     // To increase clarity of the error messages, in case value is of different type then expected,
     // when we call some methods on value variable, type is checked explicitly.
     // In other cases default Error will be thrown, which has message meaningful for the user.
     switch (type.baseType) {
+        // For these types, no action is required
         case rust.CqlType.Ascii:
-            return rust.QueryParameterWrapper.fromAscii(value);
-        case rust.CqlType.BigInt:
-            return rust.QueryParameterWrapper.fromBigint(
-                arbitraryValueToBigInt(value),
-            );
-        case rust.CqlType.Blob:
-            return rust.QueryParameterWrapper.fromBlob(value);
         case rust.CqlType.Boolean:
-            return rust.QueryParameterWrapper.fromBoolean(value);
+        case rust.CqlType.Blob:
+        case rust.CqlType.Decimal:
+        case rust.CqlType.Double:
+        case rust.CqlType.Empty:
+        case rust.CqlType.Float:
+        case rust.CqlType.Text:
+            break;
+        case rust.CqlType.BigInt:
+            value = arbitraryValueToBigInt(value);
+            break;
         case rust.CqlType.Counter:
-            return rust.QueryParameterWrapper.fromCounter(BigInt(value));
+            value = BigInt(value);
+            break;
         case rust.CqlType.Date:
             if (!(value instanceof LocalDate))
                 throw new TypeError(
                     "Expected LocalDate type to parse into Cql Date",
                 );
-            return rust.QueryParameterWrapper.fromLocalDate(
-                value.getInternal(),
-            );
-        case rust.CqlType.Double:
-            return rust.QueryParameterWrapper.fromDouble(value);
+            value = value.getInternal();
+            break;
         case rust.CqlType.Duration:
             if (!(value instanceof Duration))
                 throw new TypeError(
                     "Expected Duration type to parse into Cql Duration",
                 );
-            return rust.QueryParameterWrapper.fromDuration(value.getInternal());
-        case rust.CqlType.Float:
-            return rust.QueryParameterWrapper.fromFloat(value);
+            value = value.getInternal();
+            break;
         case rust.CqlType.Int:
+        case rust.CqlType.SmallInt:
+        case rust.CqlType.TinyInt:
             ensureNumber(value);
-            return rust.QueryParameterWrapper.fromInt(value);
+            break;
         case rust.CqlType.Set:
             // TODO:
             // This is part of the datastax logic for encoding set.
@@ -196,10 +214,11 @@ function wrapValueBasedOnType(type, value) {
                 });
                 return this.encodeList(arr, subtype);
             } */
-            encodedElement = encodeListLike(value, type.getFirstSupportType());
-            return rust.QueryParameterWrapper.fromSet(encodedElement);
-        case rust.CqlType.Text:
-            return rust.QueryParameterWrapper.fromText(value);
+            value = encodeListLike(value, type.getFirstSupportType());
+            if (!type.getFirstSupportType())
+                type = type.remapListSupportType(value[0]);
+            value = value[1];
+            break;
         case rust.CqlType.Timestamp:
             tmpElement = value;
             if (typeof value === "string") {
@@ -212,8 +231,8 @@ function wrapValueBasedOnType(type, value) {
                     throw new TypeError("Invalid date: " + tmpElement);
                 }
             }
-
-            return rust.QueryParameterWrapper.fromTimestamp(BigInt(value));
+            value = BigInt(value);
+            break;
         case rust.CqlType.Inet:
             // Other forms of providing InetAddress are kept as parity with old driver
             if (typeof value === "string") {
@@ -227,10 +246,14 @@ function wrapValueBasedOnType(type, value) {
                     "Expected InetAddress type to parse into Cql Inet",
                 );
             }
-            return rust.QueryParameterWrapper.fromInet(value.getInternal());
+            value = value.getInternal();
+            break;
         case rust.CqlType.List:
-            encodedElement = encodeListLike(value, type.getFirstSupportType());
-            return rust.QueryParameterWrapper.fromList(encodedElement);
+            value = encodeListLike(value, type.getFirstSupportType());
+            if (!type.getFirstSupportType())
+                type = type.remapListSupportType(value[0]);
+            value = value[1];
+            break;
         case rust.CqlType.Map:
             // TODO:
             // This is part of the datastax logic for encoding map.
@@ -242,11 +265,10 @@ function wrapValueBasedOnType(type, value) {
                 // Use Map#forEach() method to iterate
                 value.forEach(addItem);
             } */
-            encodedElement = encodeMap(value, type);
-            return rust.QueryParameterWrapper.fromMap(encodedElement);
-        case rust.CqlType.SmallInt:
-            ensureNumber(value);
-            return rust.QueryParameterWrapper.fromSmallInt(value);
+            value = encodeMap(value, type);
+            type = value[0];
+            value = value[1];
+            break;
         case rust.CqlType.Time:
             // Other forms of providing LocalTime are kept as parity with old driver
             if (typeof value == "string") {
@@ -258,12 +280,8 @@ function wrapValueBasedOnType(type, value) {
                 );
             }
 
-            return rust.QueryParameterWrapper.fromLocalTime(
-                value.getInternal(),
-            );
-        case rust.CqlType.TinyInt:
-            ensureNumber(value);
-            return rust.QueryParameterWrapper.fromTinyInt(value);
+            value = value.getInternal();
+            break;
         case rust.CqlType.Uuid:
             // Other forms of providing UUID are kept as parity with old driver
             if (typeof value === "string") {
@@ -275,10 +293,13 @@ function wrapValueBasedOnType(type, value) {
                     "Expected UUID type to parse into Cql Uuid",
                 );
             }
-            return rust.QueryParameterWrapper.fromUuid(value.getInternal());
+            value = value.getInternal();
+            break;
         case rust.CqlType.Tuple:
-            encodedElement = encodeTuple(value, type);
-            return rust.QueryParameterWrapper.fromTuple(encodedElement);
+            value = encodeTuple(value, type);
+            type = value[0];
+            value = value[1];
+            break;
         case rust.CqlType.Timeuuid:
             // Other forms of providing TimeUUID are kept as parity with old driver
             if (typeof value === "string") {
@@ -289,26 +310,28 @@ function wrapValueBasedOnType(type, value) {
                     "Expected Time UUID type to parse into Cql Uuid",
                 );
             }
-            return rust.QueryParameterWrapper.fromTimeUuid(value.getInternal());
+            value = value.getInternal();
+            break;
         default:
             // Or not yet implemented type
             throw new ReferenceError(
                 `[INTERNAL DRIVER ERROR] Unknown type: ${type}`,
             );
     }
+    return [type, value];
 }
 
 /**
- * Parses array of params into rust objects according to preparedStatement expected types
- * Throws ResponseError when received different amount of parameters than expected
+ * Parses array of params into expected format according to preparedStatement expected types
  *
  * If `allowGuessing` is true, then for each missing field of `expectedTypes`, this function will try to guess a type.
  * If the type cannot be guessed, error will be thrown.
- * Field is missing if it is null, undefined (or if the `expectedTypes` list is to short)
+ * Field is missing if it is null, undefined or if the `expectedTypes` list is too short
  * @param {Array<rust.ComplexType | null>} expectedTypes List of expected types.
  * @param {Array<any>} params
  * @param {boolean} [allowGuessing]
- * @returns {Array<rust.QueryParameterWrapper>}
+ * @returns {Array<rust.ComplexType|any>} Returns tuple: [rust.ComplexType, any] or []
+ * @throws ResponseError when received different amount of parameters than expected
  */
 function parseParams(expectedTypes, params, allowGuessing) {
     if (expectedTypes.length == 0 && !params) return [];
@@ -327,8 +350,10 @@ function parseParams(expectedTypes, params, allowGuessing) {
             params[i] = null;
         }
 
-        if (params[i] === null) {
-            res.push(null);
+        // undefined as null depends on encodingOptions.useUndefinedAsUnset option
+        // TODO: Add support for this option
+        if (params[i] === null || params[i] === undefined) {
+            res.push([]);
             continue;
         }
 

--- a/lib/types/results-wrapper.js
+++ b/lib/types/results-wrapper.js
@@ -7,7 +7,7 @@ const Duration = require("./duration");
 const LocalTime = require("./local-time");
 const InetAddress = require("./inet-address");
 const LocalDate = require("./local-date");
-const { bigintToLong } = require("../new-utils");
+const { bigintToLong, decodeVarintAsBigInt } = require("../new-utils");
 const Row = require("./row");
 const Tuple = require("./tuple");
 
@@ -76,6 +76,8 @@ function getCqlObject(field) {
                         e === null ? undefined : getCqlObject(e),
                     ),
                 );
+            case rust.CqlType.Varint:
+                return decodeVarintAsBigInt(value);
             default:
                 throw new Error("Unexpected type");
         }

--- a/src/requests/parameter_wrappers.rs
+++ b/src/requests/parameter_wrappers.rs
@@ -2,7 +2,7 @@ use napi::{
     bindgen_prelude::{Array, BigInt, Buffer, FromNapiValue, Undefined},
     Status,
 };
-use scylla::value::{Counter, CqlTimestamp, CqlTimeuuid, CqlValue, MaybeUnset};
+use scylla::value::{Counter, CqlTimestamp, CqlTimeuuid, CqlValue, CqlVarint, MaybeUnset};
 
 use crate::{
     types::{
@@ -151,7 +151,9 @@ fn cql_value_from_napi_value(typ: &ComplexType, elem: &Array, pos: u32) -> napi:
         )),
         CqlType::Tuple => CqlValue::Tuple(cql_value_vec_from_tuple(typ, &get_element!(Array))?),
         CqlType::Uuid => CqlValue::Uuid(get_element!(&UuidWrapper).get_cql_uuid()),
-        CqlType::Varint => todo!(),
+        CqlType::Varint => CqlValue::Varint(CqlVarint::from_signed_bytes_be(
+            get_element!(Buffer).to_vec(),
+        )),
         CqlType::Unprovided => return Err(js_error("Expected type information for the value")),
         CqlType::Empty => unreachable!("Should not receive Empty type here."),
         CqlType::Custom => unreachable!("Should not receive Custom type here."),

--- a/src/result.rs
+++ b/src/result.rs
@@ -332,7 +332,11 @@ impl ToNapiValue for CqlValueWrapper {
             ),
 
             CqlValue::Uuid(val) => UuidWrapper::to_napi_value(env, UuidWrapper::from_cql_uuid(val)),
-            CqlValue::Varint(_) => todo!(),
+            CqlValue::Varint(val) => add_type_to_napi_obj(
+                env,
+                Buffer::to_napi_value(env, Buffer::from(val.as_signed_bytes_be_slice())),
+                CqlType::Varint,
+            ),
             other => unimplemented!("Missing implementation for CQL value {:?}", other),
         }
     }

--- a/src/result.rs
+++ b/src/result.rs
@@ -382,7 +382,7 @@ pub(crate) fn map_column_type_to_complex_type(typ: &ColumnType) -> ComplexType {
             other => unimplemented!("Missing implementation for CQL Collection type {:?}", other),
         },
         ColumnType::UserDefinedType { .. } => ComplexType::simple_type(CqlType::UserDefinedType),
-        ColumnType::Tuple(t) => ComplexType::from_tuple(t.as_slice()),
+        ColumnType::Tuple(t) => ComplexType::tuple_from_column_type(t.as_slice()),
         ColumnType::Vector {
             typ: _,
             dimensions: _,

--- a/src/tests/request_values_tests.rs
+++ b/src/tests/request_values_tests.rs
@@ -116,3 +116,21 @@ pub fn tests_from_value(test: String, value: ParameterWrapper) {
         v
     );
 }
+
+#[napi]
+pub fn tests_parameters_wrapper_unset(value: ParameterWrapper) {
+    match value.row {
+        Some(v) => match v {
+            scylla::value::MaybeUnset::Unset => (),
+            scylla::value::MaybeUnset::Set(_) => panic!("Expected unset value"),
+        },
+        None => panic!("Expected some value"),
+    }
+}
+
+#[napi]
+pub fn tests_parameters_wrapper_null(value: ParameterWrapper) {
+    if value.row.is_some() {
+        panic!("Expected none value")
+    }
+}

--- a/src/tests/request_values_tests.rs
+++ b/src/tests/request_values_tests.rs
@@ -1,6 +1,6 @@
 use scylla::{
     cluster::metadata::{ColumnType, NativeType},
-    value::CqlTime,
+    value::{CqlTime, CqlVarint},
 };
 use std::{
     net::{IpAddr, Ipv4Addr},
@@ -48,6 +48,7 @@ pub fn tests_from_value_get_type(test: String) -> ComplexType {
             ])
         }
         "Uuid" => (CqlType::Uuid, None, None),
+        "Varint" => (CqlType::Varint, None, None),
         _ => (CqlType::Empty, None, None),
     };
     ComplexType::two_support(
@@ -101,6 +102,10 @@ pub fn tests_from_value(test: String, value: ParameterWrapper) {
             None,
         ]),
         "Uuid" => CqlValue::Uuid(uuid!("ffffffff-eeee-ffff-ffff-ffffffffffff")),
+        "Varint" => CqlValue::Varint(CqlVarint::from_signed_bytes_be_slice(&[
+            10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10,
+            10, 10, 10, 10, 10, 10, 10, 10, 10, 10,
+        ])),
         _ => CqlValue::Empty,
     };
     assert_eq!(

--- a/src/tests/result_tests.rs
+++ b/src/tests/result_tests.rs
@@ -1,4 +1,6 @@
-use scylla::value::{Counter, CqlDate, CqlDuration, CqlTime, CqlTimestamp, CqlTimeuuid, CqlValue};
+use scylla::value::{
+    Counter, CqlDate, CqlDuration, CqlTime, CqlTimestamp, CqlTimeuuid, CqlValue, CqlVarint,
+};
 use std::{
     net::{IpAddr, Ipv4Addr},
     str::FromStr,
@@ -180,5 +182,15 @@ pub fn tests_get_cql_wrapper_time() -> CqlValueWrapper {
 /// Test function returning sample CqlValueWrapper with Inet type
 pub fn tests_get_cql_wrapper_inet() -> CqlValueWrapper {
     let element = CqlValue::Inet(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)));
+    CqlValueWrapper { inner: element }
+}
+
+#[napi]
+/// Test function returning sample CqlValueWrapper with Varint type
+pub fn tests_get_cql_wrapper_varint() -> CqlValueWrapper {
+    let element = CqlValue::Varint(CqlVarint::from_signed_bytes_be_slice(&[
+        10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10,
+        10, 10, 10, 10, 10, 10, 10, 10, 10,
+    ]));
     CqlValueWrapper { inner: element }
 }

--- a/test/unit/cql-value-wrapper-tests.js
+++ b/test/unit/cql-value-wrapper-tests.js
@@ -245,4 +245,20 @@ describe("Cql value wrapper", function () {
         let expectedInet = InetAddress.fromString("127.0.0.1");
         assert.strictEqual(value.equals(expectedInet), true);
     });
+
+    it("should get varint type correctly from napi", function () {
+        let element = rust.testsGetCqlWrapperVarint();
+        let value = getCqlObject(element);
+        /* Corresponding value: 
+        let element = CqlValue::Varint(CqlVarint::from_signed_bytes_be_slice(&[
+            10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10,
+            10, 10, 10, 10, 10, 10, 10, 10, 10,
+        ])) */
+        assert.strictEqual(
+            BigInt(
+                "4540866244600635114649842549360310111892940575123159374096375843447573711370",
+            ),
+            value,
+        );
+    });
 });

--- a/test/unit/query-parameter-tests.js
+++ b/test/unit/query-parameter-tests.js
@@ -9,6 +9,7 @@ const TimeUuid = require("../../lib/types/time-uuid");
 const Tuple = require("../../lib/types/tuple");
 const Uuid = require("../../lib/types/uuid");
 const Long = require("long");
+const { types } = require("../../main");
 
 const maxI64 = BigInt("9223372036854775807");
 
@@ -39,14 +40,44 @@ const testCases = [
     ["Uuid", Uuid.fromString("ffffffff-eeee-ffff-ffff-ffffffffffff")],
 ];
 
-describe("Should correctly convert some set values into Parameter wrapper", function () {
-    testCases.forEach((test) => {
-        it(test[0], function () {
-            let value = test[1];
-            let expectedType = rust.testsFromValueGetType(test[0]);
-            let converted = getWrapped(expectedType, value);
+describe("Should correctly convert ", function () {
+    describe("some set values into Parameter wrapper", function () {
+        testCases.forEach((test) => {
+            it(test[0], function () {
+                let value = test[1];
+                let expectedType = rust.testsFromValueGetType(test[0]);
+                let converted = getWrapped(expectedType, value);
+                // Assertion appears in rust code
+                rust.testsFromValue(test[0], converted);
+            });
+        });
+    });
+
+    describe("some unset value", function () {
+        it("with type", function () {
+            let someType = rust.testsFromValueGetType(testCases[0][0]);
+            let wrapped = getWrapped(someType, types.unset);
             // Assertion appears in rust code
-            rust.testsFromValue(test[0], converted);
+            rust.testsParametersWrapperUnset(wrapped);
+        });
+        it("without type", function () {
+            let wrapped = getWrapped(null, types.unset);
+            // Assertion appears in rust code
+            rust.testsParametersWrapperUnset(wrapped);
+        });
+    });
+
+    describe("none value", function () {
+        it("with type", function () {
+            let someType = rust.testsFromValueGetType(testCases[0][0]);
+            let wrapped = getWrapped(someType, null);
+            // Assertion appears in rust code
+            rust.testsParametersWrapperNull(wrapped);
+        });
+        it("without type", function () {
+            let wrapped = getWrapped(null, null);
+            // Assertion appears in rust code
+            rust.testsParametersWrapperNull(wrapped);
         });
     });
 });

--- a/test/unit/query-parameter-tests.js
+++ b/test/unit/query-parameter-tests.js
@@ -9,6 +9,7 @@ const TimeUuid = require("../../lib/types/time-uuid");
 const Tuple = require("../../lib/types/tuple");
 const Uuid = require("../../lib/types/uuid");
 const Long = require("long");
+const Integer = require("../../lib/types/integer");
 const { types } = require("../../main");
 
 const maxI64 = BigInt("9223372036854775807");
@@ -38,6 +39,19 @@ const testCases = [
     ["Timeuuid", TimeUuid.fromString("8e14e760-7fa8-11eb-bc66-000000000001")],
     ["Tuple", new Tuple("First", new Tuple(1, 2), null)],
     ["Uuid", Uuid.fromString("ffffffff-eeee-ffff-ffff-ffffffffffff")],
+    [
+        "Varint",
+        Integer.fromString(
+            "4540866244600635114649842549360310111892940575123159374096375843447573711370",
+            10,
+        ),
+    ],
+    [
+        "Varint",
+        BigInt(
+            "4540866244600635114649842549360310111892940575123159374096375843447573711370",
+        ),
+    ],
 ];
 
 describe("Should correctly convert ", function () {

--- a/test/unit/query-parameter-tests.js
+++ b/test/unit/query-parameter-tests.js
@@ -1,6 +1,5 @@
 "use strict";
 const rust = require("../../index");
-const assert = require("assert");
 const { getWrapped } = require("../../lib/types/cql-utils");
 const utils = require("../../lib/utils");
 const Duration = require("../../lib/types/duration");
@@ -40,7 +39,7 @@ const testCases = [
     ["Uuid", Uuid.fromString("ffffffff-eeee-ffff-ffff-ffffffffffff")],
 ];
 
-describe("Should correctly convert values into QueryParameterWrapper", function () {
+describe("Should correctly convert some set values into Parameter wrapper", function () {
     testCases.forEach((test) => {
         it(test[0], function () {
             let value = test[1];


### PR DESCRIPTION
Varint can be either Integer or BigInt depending on ClientOptions.
Added ClientOptions "pass-through" for `getWrapped` and `getCqlObject` functions in order that to work.