### PR TITLE
Enable eslint "no-prototype-builtins" directive

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -28,10 +28,6 @@ export default [
       //Check if there is a space at the beginning of a comment
       "spaced-comment": "error",
 
-      // This will be deleted after everything is switched from prototypes to classes
-      // TODO: FIX
-      "no-prototype-builtins": "off",
-
       // Check if variable names are in camelCase
       // Disabled in some of the tests because they are inserting values into the database
       "camelcase": "error",

--- a/lib/encoder.js
+++ b/lib/encoder.js
@@ -111,19 +111,196 @@ const zeroLengthTypesSupported = new Set([
 
 /**
  * Serializes and deserializes to and from a CQL type and a Javascript Type.
- * @param {Number} protocolVersion
- * @param {ClientOptions} options
- * @constructor
  */
-function Encoder(protocolVersion, options) {
-    this.encodingOptions = options.encoding || utils.emptyObject;
-    defineInstanceMembers.call(this);
-    this.setProtocolVersion(protocolVersion);
-    setEncoders.call(this);
-    if (this.encodingOptions.copyBuffer) {
-        this.handleBuffer = handleBufferCopy;
-    } else {
-        this.handleBuffer = handleBufferRef;
+class Encoder {
+    /**
+     * @param {Number} protocolVersion
+     * @param {ClientOptions} options
+     */
+    constructor(protocolVersion, options) {
+        this.encodingOptions = options.encoding || utils.emptyObject;
+        defineInstanceMembers.call(this);
+        this.setProtocolVersion(protocolVersion);
+        setEncoders.call(this);
+        if (this.encodingOptions.copyBuffer) {
+            this.handleBuffer = handleBufferCopy;
+        } else {
+            this.handleBuffer = handleBufferRef;
+        }
+    }
+    /**
+     * Try to guess the Cassandra type to be stored, based on the javascript value type
+     * @param value
+     * @returns {{code: number, info: object}|null}
+     * @ignore
+     * @internal
+     */
+    static guessDataType(value) {
+        let code = null;
+        let info = null;
+        const esTypeName = typeof value;
+        if (esTypeName === "number") {
+            code = dataTypes.double;
+        } else if (esTypeName === "string") {
+            code = dataTypes.text;
+            if (value.length === 36 && uuidRegex.test(value)) {
+                code = dataTypes.uuid;
+            }
+        } else if (esTypeName === "boolean") {
+            code = dataTypes.boolean;
+        } else if (value instanceof Buffer) {
+            code = dataTypes.blob;
+        } else if (value instanceof Date) {
+            code = dataTypes.timestamp;
+        } else if (value instanceof Long) {
+            code = dataTypes.bigint;
+        } else if (value instanceof Integer) {
+            code = dataTypes.varint;
+        } else if (value instanceof BigDecimal) {
+            code = dataTypes.decimal;
+        } else if (value instanceof types.Uuid) {
+            code = dataTypes.uuid;
+        } else if (value instanceof types.InetAddress) {
+            code = dataTypes.inet;
+        } else if (value instanceof types.Tuple) {
+            code = dataTypes.tuple;
+        } else if (value instanceof types.LocalDate) {
+            code = dataTypes.date;
+        } else if (value instanceof types.LocalTime) {
+            code = dataTypes.time;
+        } else if (value instanceof types.Duration) {
+            code = dataTypes.custom;
+            info = customTypeNames.duration;
+        }
+
+        // Map JS TypedArrays onto vectors
+        else if (Encoder.isTypedArray(value)) {
+            code = dataTypes.custom;
+            // TODO: another area that we have to generalize if we ever need to support vector subtypes other than float
+            info = buildParameterizedCustomType(customTypeNames.vector, [
+                singleTypeNamesByDataType[dataTypes.float],
+                value.length,
+            ]);
+        } else if (Array.isArray(value)) {
+            code = dataTypes.list;
+        } else if (value instanceof DateRange) {
+            throwNotSupported("encoding DateRange");
+        }
+
+        if (code === null) {
+            return null;
+        }
+        return { code: code, info: info };
+    }
+    static isTypedArray(arg) {
+        // The TypedArray superclass isn't available directly so to detect an instance of a TypedArray
+        // subclass we have to access the prototype of a concrete instance.  There's nothing magical about
+        // Uint8Array here; we could just as easily use any of the other TypedArray subclasses.
+        return arg instanceof Object.getPrototypeOf(Uint8Array);
+    }
+    /**
+     * Decodes Cassandra bytes into Javascript values.
+     *
+     * This is part of an <b>experimental</b> API, this can be changed future releases.
+     * @param {Buffer} buffer Raw buffer to be decoded.
+     * @param {Object} type An object containing the data type `code` and `info`.
+     * @param {Number} type.code Type code.
+     * @param {Object} [type.info] Additional information on the type for complex / nested types.
+     */
+    decode(buffer, type) {
+        if (
+            buffer === null ||
+            (buffer.length === 0 && !zeroLengthTypesSupported.has(type.code))
+        ) {
+            return null;
+        }
+
+        const decoder = this.decoders[type.code];
+
+        if (!decoder) {
+            throw new Error("Unknown data type: " + type.code);
+        }
+
+        return decoder.call(this, buffer, type.info);
+    }
+    /**
+     * Encodes Javascript types into Buffer according to the Cassandra protocol.
+     *
+     * This is part of an <b>experimental</b> API, this can be changed future releases.
+     * @param {*} value The value to be converted.
+     * @param {{code: number, info: *|Object}|String|Number} [typeInfo] The type information.
+     *
+     * It can be either a:
+     * - A `String` representing the data type.
+     * - A `Number` with one of the values of {@link module:types~dataTypes dataTypes}.
+     * - An `Object` containing the `type.code` as one of the values of
+     *   {@link module:types~dataTypes dataTypes} and `type.info`.
+     * @returns {Buffer}
+     * @throws {TypeError} When there is an encoding error
+     */
+    encode(value, typeInfo) {
+        if (value === undefined) {
+            value =
+                this.encodingOptions.useUndefinedAsUnset &&
+                this.protocolVersion >= 4
+                    ? types.unset
+                    : null;
+        }
+
+        if (value === types.unset) {
+            if (!types.protocolVersion.supportsUnset(this.protocolVersion)) {
+                throw new TypeError(
+                    "Unset value can not be used for this version of Cassandra, protocol version: " +
+                        this.protocolVersion,
+                );
+            }
+
+            return value;
+        }
+
+        if (value === null || value instanceof Buffer) {
+            return value;
+        }
+
+        /** @type {{code: Number, info: object}} */
+        let type = {
+            code: null,
+            info: null,
+        };
+
+        if (typeInfo) {
+            if (typeof typeInfo === "number") {
+                type.code = typeInfo;
+            } else if (typeof typeInfo === "string") {
+                type = dataTypes.getByName(typeInfo);
+            }
+            if (typeof typeInfo.code === "number") {
+                type.code = typeInfo.code;
+                type.info = typeInfo.info;
+            }
+            if (typeof type.code !== "number") {
+                throw new TypeError(
+                    "Type information not valid, only String and Number values are valid hints",
+                );
+            }
+        } else {
+            // Lets guess
+            type = Encoder.guessDataType(value);
+            if (!type) {
+                throw new TypeError(
+                    "Target data type could not be guessed, you should use prepared statements for accurate type mapping. Value: " +
+                        util.inspect(value),
+                );
+            }
+        }
+
+        const encoder = this.encoders[type.code];
+
+        if (!encoder) {
+            throw new Error("Type not supported " + type.code);
+        }
+
+        return encoder.call(this, value, type.info);
     }
 }
 
@@ -1779,176 +1956,6 @@ function setEncoders() {
 }
 
 /**
- * Decodes Cassandra bytes into Javascript values.
- *
- * This is part of an <b>experimental</b> API, this can be changed future releases.
- * @param {Buffer} buffer Raw buffer to be decoded.
- * @param {Object} type An object containing the data type `code` and `info`.
- * @param {Number} type.code Type code.
- * @param {Object} [type.info] Additional information on the type for complex / nested types.
- */
-Encoder.prototype.decode = function (buffer, type) {
-    if (
-        buffer === null ||
-        (buffer.length === 0 && !zeroLengthTypesSupported.has(type.code))
-    ) {
-        return null;
-    }
-
-    const decoder = this.decoders[type.code];
-
-    if (!decoder) {
-        throw new Error("Unknown data type: " + type.code);
-    }
-
-    return decoder.call(this, buffer, type.info);
-};
-
-/**
- * Encodes Javascript types into Buffer according to the Cassandra protocol.
- *
- * This is part of an <b>experimental</b> API, this can be changed future releases.
- * @param {*} value The value to be converted.
- * @param {{code: number, info: *|Object}|String|Number} [typeInfo] The type information.
- *
- * It can be either a:
- * - A `String` representing the data type.
- * - A `Number` with one of the values of {@link module:types~dataTypes dataTypes}.
- * - An `Object` containing the `type.code` as one of the values of
- *   {@link module:types~dataTypes dataTypes} and `type.info`.
- * @returns {Buffer}
- * @throws {TypeError} When there is an encoding error
- */
-Encoder.prototype.encode = function (value, typeInfo) {
-    if (value === undefined) {
-        value =
-            this.encodingOptions.useUndefinedAsUnset &&
-            this.protocolVersion >= 4
-                ? types.unset
-                : null;
-    }
-
-    if (value === types.unset) {
-        if (!types.protocolVersion.supportsUnset(this.protocolVersion)) {
-            throw new TypeError(
-                "Unset value can not be used for this version of Cassandra, protocol version: " +
-                    this.protocolVersion,
-            );
-        }
-
-        return value;
-    }
-
-    if (value === null || value instanceof Buffer) {
-        return value;
-    }
-
-    /** @type {{code: Number, info: object}} */
-    let type = {
-        code: null,
-        info: null,
-    };
-
-    if (typeInfo) {
-        if (typeof typeInfo === "number") {
-            type.code = typeInfo;
-        } else if (typeof typeInfo === "string") {
-            type = dataTypes.getByName(typeInfo);
-        }
-        if (typeof typeInfo.code === "number") {
-            type.code = typeInfo.code;
-            type.info = typeInfo.info;
-        }
-        if (typeof type.code !== "number") {
-            throw new TypeError(
-                "Type information not valid, only String and Number values are valid hints",
-            );
-        }
-    } else {
-        // Lets guess
-        type = Encoder.guessDataType(value);
-        if (!type) {
-            throw new TypeError(
-                "Target data type could not be guessed, you should use prepared statements for accurate type mapping. Value: " +
-                    util.inspect(value),
-            );
-        }
-    }
-
-    const encoder = this.encoders[type.code];
-
-    if (!encoder) {
-        throw new Error("Type not supported " + type.code);
-    }
-
-    return encoder.call(this, value, type.info);
-};
-
-/**
- * Try to guess the Cassandra type to be stored, based on the javascript value type
- * @param value
- * @returns {{code: number, info: object}|null}
- * @ignore
- * @internal
- */
-Encoder.guessDataType = function (value) {
-    let code = null;
-    let info = null;
-    const esTypeName = typeof value;
-    if (esTypeName === "number") {
-        code = dataTypes.double;
-    } else if (esTypeName === "string") {
-        code = dataTypes.text;
-        if (value.length === 36 && uuidRegex.test(value)) {
-            code = dataTypes.uuid;
-        }
-    } else if (esTypeName === "boolean") {
-        code = dataTypes.boolean;
-    } else if (value instanceof Buffer) {
-        code = dataTypes.blob;
-    } else if (value instanceof Date) {
-        code = dataTypes.timestamp;
-    } else if (value instanceof Long) {
-        code = dataTypes.bigint;
-    } else if (value instanceof Integer) {
-        code = dataTypes.varint;
-    } else if (value instanceof BigDecimal) {
-        code = dataTypes.decimal;
-    } else if (value instanceof types.Uuid) {
-        code = dataTypes.uuid;
-    } else if (value instanceof types.InetAddress) {
-        code = dataTypes.inet;
-    } else if (value instanceof types.Tuple) {
-        code = dataTypes.tuple;
-    } else if (value instanceof types.LocalDate) {
-        code = dataTypes.date;
-    } else if (value instanceof types.LocalTime) {
-        code = dataTypes.time;
-    } else if (value instanceof types.Duration) {
-        code = dataTypes.custom;
-        info = customTypeNames.duration;
-    }
-    // Map JS TypedArrays onto vectors
-    else if (Encoder.isTypedArray(value)) {
-        code = dataTypes.custom;
-        // TODO: another area that we have to generalize if we ever need to support vector subtypes other than float
-        info = buildParameterizedCustomType(customTypeNames.vector, [
-            singleTypeNamesByDataType[dataTypes.float],
-            value.length,
-        ]);
-    } else if (Array.isArray(value)) {
-        code = dataTypes.list;
-    } else if (value instanceof DateRange) {
-        throwNotSupported("encoding DateRange");
-    }
-
-    if (code === null) {
-        return null;
-    }
-    return { code: code, info: info };
-};
-
-/**
  * Gets a buffer containing with the bytes (BE) representing the collection length for protocol v2 and below
  * @param {Buffer|Number} value
  * @returns {Buffer}
@@ -2112,11 +2119,5 @@ function invertObject(obj) {
     }
     return rv;
 }
-Encoder.isTypedArray = function (arg) {
-    // The TypedArray superclass isn't available directly so to detect an instance of a TypedArray
-    // subclass we have to access the prototype of a concrete instance.  There's nothing magical about
-    // Uint8Array here; we could just as easily use any of the other TypedArray subclasses.
-    return arg instanceof Object.getPrototypeOf(Uint8Array);
-};
 
 module.exports = Encoder;

--- a/lib/encoder.js
+++ b/lib/encoder.js
@@ -1091,7 +1091,7 @@ function defineInstanceMembers() {
         } else {
             // Use object
             for (const key in value) {
-                if (!value.hasOwnProperty(key)) {
+                if (!Object.prototype.hasOwnProperty.call(value, key)) {
                     continue;
                 }
                 const val = value[key];
@@ -1194,8 +1194,8 @@ function defineInstanceMembers() {
             // Perform client-side validation iff we were actually supplied with meaningful type info.  In practice
             // this will only occur when using prepared statements.
             if (
-                params.hasOwnProperty("subtype") &&
-                params.hasOwnProperty("dimensions")
+                Object.prototype.hasOwnProperty.call(params, "subtype") &&
+                Object.prototype.hasOwnProperty.call(params, "dimensions")
             ) {
                 const subtype = params["subtype"];
                 const dimensions = params["dimensions"];
@@ -2113,7 +2113,7 @@ function buildParameterizedCustomType(customTypeName, args) {
 function invertObject(obj) {
     const rv = {};
     for (const k in obj) {
-        if (obj.hasOwnProperty(k)) {
+        if (Object.prototype.hasOwnProperty.call(obj, k)) {
             rv[obj[k]] = k;
         }
     }

--- a/lib/metadata/schema-parser.js
+++ b/lib/metadata/schema-parser.js
@@ -780,7 +780,10 @@ class SchemaParserV2 extends SchemaParser {
             strategy = replication["class"];
             strategyOptions = {};
             for (const key in replication) {
-                if (!replication.hasOwnProperty(key) || key === "class") {
+                if (
+                    !Object.prototype.hasOwnProperty.call(replication, key) ||
+                    key === "class"
+                ) {
                     continue;
                 }
                 strategyOptions[key] = replication[key];
@@ -1189,7 +1192,7 @@ function getTokenToReplicaMapper(strategy, strategyOptions) {
     return function noStrategy(tokenizer, ring, primaryReplicas) {
         const replicas = {};
         for (const key in primaryReplicas) {
-            if (!primaryReplicas.hasOwnProperty(key)) {
+            if (!Object.prototype.hasOwnProperty.call(primaryReplicas, key)) {
                 continue;
             }
             replicas[key] = [primaryReplicas[key]];

--- a/lib/types/cql-utils.js
+++ b/lib/types/cql-utils.js
@@ -77,7 +77,7 @@ function encodeMap(value, parentType) {
     let res = [];
 
     for (const key in value) {
-        if (!value.hasOwnProperty(key)) {
+        if (!Object.prototype.hasOwnProperty.call(value, key)) {
             continue;
         }
         const val = value[key];

--- a/lib/types/index.js
+++ b/lib/types/index.js
@@ -175,7 +175,7 @@ const dataTypes = {
 const _dataTypesByCode = (function () {
     const result = {};
     for (const key in dataTypes) {
-        if (!dataTypes.hasOwnProperty(key)) {
+        if (!Object.prototype.hasOwnProperty.call(dataTypes, key)) {
             continue;
         }
         const val = dataTypes[key];

--- a/lib/types/row.js
+++ b/lib/types/row.js
@@ -64,7 +64,7 @@ class Row {
      */
     forEach(callback) {
         for (const columnName in this) {
-            if (!this.hasOwnProperty(columnName)) {
+            if (!Object.prototype.hasOwnProperty.call(this, columnName)) {
                 continue;
             }
             callback(this[columnName], columnName);

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -195,7 +195,7 @@ function deepExtend(target) {
     const sources = Array.prototype.slice.call(arguments, 1);
     sources.forEach(function (source) {
         for (const prop in source) {
-            if (!source.hasOwnProperty(prop)) {
+            if (!Object.prototype.hasOwnProperty.call(source, prop)) {
                 continue;
             }
             const targetProp = target[prop];
@@ -356,7 +356,7 @@ function adaptNamedParamsPrepared(params, columns) {
     for (let i = 0; i < columns.length; i++) {
         const name = columns[i].name;
 
-        if (!params.hasOwnProperty(name)) {
+        if (!Object.prototype.hasOwnProperty.call(params, name)) {
             throw new errors.ArgumentError(`Parameter "${name}" not defined`);
         }
         paramsArray[i] = params[name];

--- a/test/unit-not-supported/encoder-tests.js
+++ b/test/unit-not-supported/encoder-tests.js
@@ -2060,7 +2060,9 @@ describe("encoder", function () {
 
     describe("prototype", function () {
         it("should only expose encode() and decode() functions", function () {
-            const keys = Object.keys(Encoder.prototype);
+            const keys = Object.getOwnPropertyNames(Encoder.prototype).filter(
+                (k) => k !== "constructor",
+            );
             assert.deepStrictEqual(keys, ["decode", "encode"]);
             keys.forEach(function (k) {
                 assert.strictEqual(typeof Encoder.prototype[k], "function");


### PR DESCRIPTION
The "no-prototype-builtins" directive was switched off because of errors, this PR edits the use of `hasOwnProperty()` calls and switches on this rule.