### PR TITLE
Lazy column retrieving

### DIFF
--- a/lib/types/result-set.js
+++ b/lib/types/result-set.js
@@ -16,6 +16,20 @@ const asyncIteratorSymbol = Symbol.asyncIterator || "@@asyncIterator";
 
 class ResultSet {
     /**
+     * Object representing Rust result wrapper.
+     * This value is used for the fields that are retrieved lazily.
+     * @type {rust.QueryResultWrapper}
+     */
+    #rustResult;
+
+    /**
+     * Cache for columns vale.
+     * This field is filled, only when user requests it's value.
+     * @type {Array.<{name, type}>?}
+     */
+    #columns;
+
+    /**
      * @param {rust.QueryResultWrapper} result
      * @param {rust.PagingStateResponseWrapper} [pagingState]
      */
@@ -29,14 +43,14 @@ class ResultSet {
 
             this.rows = result.rows;
             this.rowLength = this.rows ? this.rows.length : result.rowLength;
-            this.columns = null;
+            this.#columns = null;
             this.pageState = null;
             this.nextPage = undefined;
             this.nextPageAsync = undefined;
             const meta = result.meta;
 
             if (meta) {
-                this.columns = meta.columns;
+                this.#columns = meta.columns;
 
                 if (meta.pageState) {
                     this.pageState = meta.pageState.toString("hex");
@@ -64,12 +78,8 @@ class ResultSet {
          */
         this.rowLength = this.rows ? this.rows.length : 0;
 
-        /**
-         * Gets the columns returned in this ResultSet.
-         * @type {Array.<{name, type}>}
-         * @default null
-         */
-        this.columns = resultsWrapper.getColumnsMetadata(result);
+        this.#rustResult = result;
+        this.#columns = null;
 
         /**
          * A string token representing the current page state of query. It can be used in the following executions to
@@ -144,6 +154,22 @@ class ResultSet {
          * @type {Function}
          */
         this.nextPageAsync = undefined;
+    }
+
+    /**
+     * Gets the columns returned in this ResultSet.
+     * @type {Array.<{name, type}>}
+     * @readonly
+     */
+    get columns() {
+        if (!this.#columns) {
+            this.#columns = resultsWrapper.getColumnsMetadata(this.#rustResult);
+        }
+        return this.#columns;
+    }
+
+    set columns(_) {
+        throw new SyntaxError("ResultSet is read-only");
     }
 
     /**


### PR DESCRIPTION
Result set has many fields that are rarely used by user. This includes columns field. With this change,
value of this field is retrieved only when the user attempts to read it, improving performance in other situations,
without impacting it when the value is read.

There are other fields that can be retrieved laisy, that can be redone in future PRs.  

Improves performance by ~10% in concurrent select benchmark.

Before:

```bash
sudo perf stat node ./benchmark/logic/concurrent_select.js scylladb-javascript-driver 800000

 Performance counter stats for 'node ./benchmark/logic/concurrent_select.js scylladb-javascript-driver 800000':

        120,292.15 msec task-clock                       #    1.562 CPUs utilized             
         1,493,029      context-switches                 #   12.412 K/sec                     
           618,900      cpu-migrations                   #    5.145 K/sec                     
            86,487      page-faults                      #  718.975 /sec                      
   443,756,830,288      cycles                           #    3.689 GHz                       
   158,398,518,698      stalled-cycles-frontend          #   35.69% frontend cycles idle      
   388,279,703,814      instructions                     #    0.87  insn per cycle            
                                                  #    0.41  stalled cycles per insn   
    72,697,073,045      branches                         #  604.338 M/sec                     
     1,817,829,570      branch-misses                    #    2.50% of all branches           

      76.995354123 seconds time elapsed

      94.338877000 seconds user
      27.235754000 seconds sys
```

```bash
sudo perf stat node ./benchmark/logic/concurrent_select.js scylladb-javascript-driver 800000

 Performance counter stats for 'node ./benchmark/logic/concurrent_select.js scylladb-javascript-driver 800000':

        107,673.28 msec task-clock                       #    1.592 CPUs utilized             
         1,428,367      context-switches                 #   13.266 K/sec                     
           562,923      cpu-migrations                   #    5.228 K/sec                     
            83,753      page-faults                      #  777.844 /sec                      
   418,684,624,472      cycles                           #    3.888 GHz                       
   152,095,137,311      stalled-cycles-frontend          #   36.33% frontend cycles idle      
   361,447,211,877      instructions                     #    0.86  insn per cycle            
                                                  #    0.42  stalled cycles per insn   
    67,717,291,717      branches                         #  628.915 M/sec                     
     1,735,270,888      branch-misses                    #    2.56% of all branches           

      67.630013642 seconds time elapsed

      84.216164000 seconds user
      24.651219000 seconds sys
```
