### PR TITLE
Remove datacenter from benchmarks, examples and docs

### DIFF
--- a/benchmark/logic/utils.js
+++ b/benchmark/logic/utils.js
@@ -3,7 +3,6 @@
 function getClientArgs() {
     return {
         contactPoints: [process.env.SCYLLA_URI ?? "172.17.0.2:9042"],
-        localDataCenter: process.env.DATACENTER ?? "datacenter1",
     };
 }
 

--- a/examples/DataStax/util.js
+++ b/examples/DataStax/util.js
@@ -1,7 +1,6 @@
 function getClientArgs() {
     return {
         contactPoints: [process.env.SCYLLA_URI ?? "172.17.0.2:9042"],
-        localDataCenter: process.env.DATACENTER ?? "datacenter1",
     };
 }
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -31,7 +31,6 @@ const { PreparedCache } = require("./cache.js");
  * @example <caption>Creating a new client instance</caption>
  * const client = new Client({
  *   contactPoints: ['10.0.1.101', '10.0.1.102'],
- *   localDataCenter: 'datacenter1'
  * });
  * @example <caption>Executing a query</caption>
  * const result = await client.connect();


### PR DESCRIPTION
We currently do not support this field -- meaning it had no effect in those situations.