### PR TITLE
Reduce complex type usage

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -16,7 +16,11 @@ const ExecOptions = require("./execution-options");
 const promiseUtils = require("./promise-utils");
 const rust = require("../index");
 const ResultSet = require("./types/result-set.js");
-const { parseParams, convertHints } = require("./types/cql-utils.js");
+const {
+    parseParams,
+    minimalParseParams,
+    convertHints,
+} = require("./types/cql-utils.js");
 const queryOptions = require("./query-options.js");
 const { PreparedCache } = require("./cache.js");
 
@@ -342,13 +346,9 @@ class Client extends events.EventEmitter {
                     query instanceof rust.PreparedStatementWrapper
                         ? query
                         : await this.rustClient.prepareStatement(query);
-                let parsedParams = parseParams(
-                    statement.getExpectedTypes(),
-                    params,
-                );
+                let parsedParams = minimalParseParams(params);
                 result = await this.rustClient.executePreparedUnpaged(
-                    statement,
-                    parsedParams,
+                    [statement, parsedParams],
                     rustOptions,
                 );
             } else {
@@ -525,13 +525,9 @@ class Client extends events.EventEmitter {
         if (execOptions.isPrepared()) {
             // Execute prepared statement, as requested by the user
             const statement = await this.rustClient.prepareStatement(query);
-            let parsedParams = parseParams(
-                statement.getExpectedTypes(),
-                params,
-            );
+            let parsedParams = minimalParseParams(params);
             result = await this.rustClient.executeSinglePage(
-                statement,
-                parsedParams,
+                [statement, parsedParams],
                 rustOptions,
                 pageState,
             );

--- a/lib/types/cql-utils.js
+++ b/lib/types/cql-utils.js
@@ -325,6 +325,47 @@ function wrapValueBasedOnType(type, value) {
     return [type, value];
 }
 
+function wrapValueLight(value) {
+    switch (true) {
+        // For these types, no action is required
+        case value instanceof Uuid:
+        case rust.CqlType.Uuid:
+            value = value.getInternal();
+            break;
+
+        default:
+            break;
+        // // Or not yet implemented type
+        // throw new ReferenceError(
+        //     `[INTERNAL DRIVER ERROR] Unknown type: ${type}`,
+        // );
+    }
+    return value;
+}
+
+function minimalParseParams(params) {
+    if (!params) return [];
+    let res = [];
+    for (let i = 0; i < params.length; i++) {
+        if (params[i] === types.unset) {
+            // Rust driver works only with version >= 4 of CQL [Source?], so unset will always be supported.
+            // Currently we don't support unset values and we treat them as NULL values.
+            // TODO: Fix this
+            params[i] = null;
+        }
+
+        // undefined as null depends on encodingOptions.useUndefinedAsUnset option
+        // TODO: Add support for this option
+        if (params[i] === null || params[i] === undefined) {
+            res.push([]);
+            continue;
+        }
+
+        res.push(wrapValueLight(params[i]));
+    }
+    return res;
+}
+
 /**
  * Parses array of params into expected format according to preparedStatement expected types
  *
@@ -421,8 +462,8 @@ function rustConvertHint(object) {
 }
 
 module.exports.parseParams = parseParams;
+module.exports.minimalParseParams = minimalParseParams;
 module.exports.convertHints = convertHints;
 module.exports.rustConvertHint = rustConvertHint;
-
 // For unit test usage
 module.exports.getWrapped = getWrapped;

--- a/src/tests/request_values_tests.rs
+++ b/src/tests/request_values_tests.rs
@@ -104,7 +104,7 @@ pub fn tests_from_value(test: String, value: ParameterWrapper) {
         _ => CqlValue::Empty,
     };
     assert_eq!(
-        match value.row {
+        match value.value {
             Some(v) => {
                 match v {
                     scylla::value::MaybeUnset::Unset => panic!("Expected set value"),
@@ -119,7 +119,7 @@ pub fn tests_from_value(test: String, value: ParameterWrapper) {
 
 #[napi]
 pub fn tests_parameters_wrapper_unset(value: ParameterWrapper) {
-    match value.row {
+    match value.value {
         Some(v) => match v {
             scylla::value::MaybeUnset::Unset => (),
             scylla::value::MaybeUnset::Set(_) => panic!("Expected unset value"),
@@ -130,7 +130,7 @@ pub fn tests_parameters_wrapper_unset(value: ParameterWrapper) {
 
 #[napi]
 pub fn tests_parameters_wrapper_null(value: ParameterWrapper) {
-    if value.row.is_some() {
+    if value.value.is_some() {
         panic!("Expected none value")
     }
 }


### PR DESCRIPTION
This is a very early draft. Currently works only for some basic types, and UUID.

This PR attempts to reduce usage of Compex type, by shifting parameters preparing (from all accepted formats) onto rust side and as a result, reducing the need for the JS side to know expected types.

30% improvement for time elapsed and 20% for task clock


Before:

```bash
sudo perf stat node ./benchmark/logic/concurrent_insert.js scylladb-javascript-driver 2000000

 Performance counter stats for 'node ./benchmark/logic/concurrent_insert.js scylladb-javascript-driver 2000000':

        118,291.96 msec task-clock                       #    2.380 CPUs utilized             
         3,706,295      context-switches                 #   31.332 K/sec                     
           206,323      cpu-migrations                   #    1.744 K/sec                     
           428,074      page-faults                      #    3.619 K/sec                     
   459,702,397,261      cycles                           #    3.886 GHz                       
   183,584,434,064      stalled-cycles-frontend          #   39.94% frontend cycles idle      
   335,176,259,143      instructions                     #    0.73  insn per cycle            
                                                  #    0.55  stalled cycles per insn   
    65,323,848,951      branches                         #  552.226 M/sec                     
     3,100,074,370      branch-misses                    #    4.75% of all branches           

      49.711533158 seconds time elapsed

      72.887237000 seconds user
      47.781235000 seconds sys
```

After:

```bash
sudo perf stat node ./benchmark/logic/concurrent_insert.js scylladb-javascript-driver 2000000

 Performance counter stats for 'node ./benchmark/logic/concurrent_insert.js scylladb-javascript-driver 2000000':

         97,353.41 msec task-clock                       #    2.836 CPUs utilized             
         2,361,289      context-switches                 #   24.255 K/sec                     
           275,625      cpu-migrations                   #    2.831 K/sec                     
           422,072      page-faults                      #    4.335 K/sec                     
   372,492,719,364      cycles                           #    3.826 GHz                       
   169,074,225,002      stalled-cycles-frontend          #   45.39% frontend cycles idle      
   263,664,151,995      instructions                     #    0.71  insn per cycle            
                                                  #    0.64  stalled cycles per insn   
    51,895,019,049      branches                         #  533.058 M/sec                     
     2,752,008,302      branch-misses                    #    5.30% of all branches           

      34.321760331 seconds time elapsed

      57.348979000 seconds user
      41.203228000 seconds sys




```
