### PR TITLE
UUID generateRandom

### DIFF
--- a/benchmark/logic/concurrent_insert.js
+++ b/benchmark/logic/concurrent_insert.js
@@ -8,6 +8,7 @@ const assert = require("assert");
 
 const client = new cassandra.Client(utils.getClientArgs());
 const iterCnt = parseInt(process.argv[3]);
+const uuidGenerator = utils.getRandomUUID(process.argv[2], cassandra.types.Uuid);
 
 async.series(
     [
@@ -20,7 +21,7 @@ async.series(
                 for (let i = 0; i < steps; i++) {
                     allParameters.push({
                         query: 'INSERT INTO benchmarks.basic (id, val) VALUES (?, ?)',
-                        params: [cassandra.types.Uuid.random(), 10]
+                        params: [uuidGenerator(), 10]
                     });
                 }
                 try {

--- a/benchmark/logic/concurrent_select.js
+++ b/benchmark/logic/concurrent_select.js
@@ -7,6 +7,7 @@ const { exit } = require("process");
 
 const client = new cassandra.Client(utils.getClientArgs());
 const iterCnt = parseInt(process.argv[3]);
+const uuidGenerator = utils.getRandomUUID(process.argv[2], cassandra.types.Uuid);
 
 async.series(
     [
@@ -17,7 +18,7 @@ async.series(
             let query =
                 "INSERT INTO benchmarks.basic (id, val) VALUES (?, ?)";
             for (let i = 0; i < 10; i++) {
-                let id = cassandra.types.Uuid.random();
+                let id = uuidGenerator();
                 try {
                     await client.execute(query, [id, 100], { prepare: true, collectResults: true });
                 } catch (err) {

--- a/benchmark/logic/insert.js
+++ b/benchmark/logic/insert.js
@@ -7,6 +7,7 @@ const { exit } = require("process");
 
 const client = new cassandra.Client(utils.getClientArgs());
 const iterCnt = parseInt(process.argv[3]);
+const uuidGenerator = utils.getRandomUUID(process.argv[2], cassandra.types.Uuid);
 
 async.series(
     [
@@ -15,7 +16,7 @@ async.series(
         },
         async function insert(next) {
             for (let i = 0; i < iterCnt; i++) {
-                const id = cassandra.types.Uuid.random();
+                const id = uuidGenerator();
                 const query =
                     "INSERT INTO benchmarks.basic (id, val) VALUES (?, ?)";
                 try {

--- a/benchmark/logic/select.js
+++ b/benchmark/logic/select.js
@@ -7,6 +7,7 @@ const { exit } = require("process");
 
 const client = new cassandra.Client(utils.getClientArgs());
 const iterCnt = parseInt(process.argv[3]);
+const uuidGenerator = utils.getRandomUUID(process.argv[2], cassandra.types.Uuid);
 
 async.series(
     [
@@ -17,7 +18,7 @@ async.series(
             let query =
                 "INSERT INTO benchmarks.basic (id, val) VALUES (?, ?)";
             for (let i = 0; i < 10; i++) {
-                let id = cassandra.types.Uuid.random();
+                let id = uuidGenerator();
                 try {
                     await client.execute(query, [id, 100], { prepare: true });
                 } catch (err) {

--- a/benchmark/logic/utils.js
+++ b/benchmark/logic/utils.js
@@ -49,10 +49,27 @@ async function repeatCapped(callback, n) {
         const finalStep = Math.min(n, (rep + 1) * singleStepCount);
         await callback(finalStep - rep * singleStepCount);
     }
-    
+
+}
+
+/**
+ * Create a function generating random UUID, based on the driver used.
+ * 
+ * For the new driver use generateRandom, and for other use random()
+ * @param {string} driver 
+ * @param {Uuid} UUID 
+ * @returns {Function}
+ */
+function getRandomUUID(driver, UUID) {
+    if (driver == "scylladb-javascript-driver") {
+        return () => UUID.generateRandom;
+    }
+    return () => UUID.random();
+
 }
 
 exports.tableSchemaBasic = tableSchemaBasic;
 exports.getClientArgs = getClientArgs;
 exports.prepareDatabase = prepareDatabase;
 exports.repeatCapped = repeatCapped;
+exports.getRandomUUID = getRandomUUID;

--- a/examples/DataStax/concurrent-executions/execute-concurrent-array.js
+++ b/examples/DataStax/concurrent-executions/execute-concurrent-array.js
@@ -25,7 +25,8 @@ async function example() {
 
     // Use an Array with 10000 different values
     const values = Array.from(new Array(10000).keys()).map((x) => [
-        Uuid.random(),
+        // We can use generateRandom, as we are not reading the values of the generated UUID
+        Uuid.generateRandom,
         x.toString(),
     ]);
 

--- a/examples/DataStax/concurrent-executions/execute-in-loop.js
+++ b/examples/DataStax/concurrent-executions/execute-in-loop.js
@@ -53,7 +53,8 @@ async function executeOneAtATime(info) {
     const options = { prepare: true, isIdempotent: true };
 
     while (info.counter++ < info.totalLength) {
-        const params = [Uuid.random(), `Value for ${info.counter}`];
+        // We can use generateRandom, as we are not reading the values of the generated UUID
+        const params = [Uuid.generateRandom, `Value for ${info.counter}`];
         await client.execute(query, params, options);
     }
 }

--- a/lib/types/cql-utils.js
+++ b/lib/types/cql-utils.js
@@ -292,12 +292,15 @@ function wrapValueBasedOnType(type, value) {
                 value = Uuid.fromString(value);
             }
 
-            if (!(value instanceof Uuid)) {
+            if (value === Uuid.generateRandom) {
+                value = Buffer.alloc(0);
+            } else if (!(value instanceof Uuid)) {
                 throw new TypeError(
                     "Expected UUID type to parse into Cql Uuid",
                 );
+            } else {
+                value = value.getInternal();
             }
-            value = value.getInternal();
             break;
         case rust.CqlType.Tuple:
             value = encodeTuple(value, type);

--- a/lib/types/index.d.ts
+++ b/lib/types/index.d.ts
@@ -407,6 +407,8 @@ export namespace types {
 
     static fromString(value: string): Uuid;
 
+    static generateRandom: object;
+
     static random(callback: ValueCallback<Uuid>): void;
 
     static random(): Uuid;

--- a/lib/types/type-guessing.js
+++ b/lib/types/type-guessing.js
@@ -1,5 +1,6 @@
 const { errors } = require("../errors");
 const types = require("./index");
+const Uuid = require("./uuid");
 const typeValues = types.dataTypes;
 const Long = types.Long;
 const Integer = types.Integer;
@@ -45,6 +46,8 @@ function guessType(value) {
     } else if (value instanceof BigDecimal) {
         code = typeValues.decimal;
     } else if (value instanceof types.Uuid) {
+        code = typeValues.uuid;
+    } else if (value === Uuid.generateRandom) {
         code = typeValues.uuid;
     } else if (value instanceof types.InetAddress) {
         code = typeValues.inet;

--- a/lib/types/uuid.js
+++ b/lib/types/uuid.js
@@ -18,6 +18,16 @@ class Uuid {
         /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
     /**
+     * When providing `generateRandom` as a query parameter,
+     * each time a new random UUID will be generated.
+     *
+     *  While using `generateRandom` is faster than `random`,
+     *  it's not possible to retrieve a value of such UUID,
+     *  or use the same UUID in multiple places.
+     */
+    static generateRandom = Object.freeze({ randomUuid: true });
+
+    /**
      * @type {Buffer}
      * @private
      */

--- a/src/tests/request_values_tests.rs
+++ b/src/tests/request_values_tests.rs
@@ -1,6 +1,6 @@
 use scylla::{
     cluster::metadata::{ColumnType, NativeType},
-    value::CqlTime,
+    value::{CqlTime, MaybeUnset},
 };
 use std::{
     net::{IpAddr, Ipv4Addr},
@@ -10,6 +10,7 @@ use std::{
 use crate::{
     requests::parameter_wrappers::ParameterWrapper,
     types::type_wrappers::{ComplexType, CqlType},
+    utils::js_error,
 };
 
 use scylla::value::{Counter, CqlDuration, CqlTimestamp, CqlTimeuuid, CqlValue};
@@ -132,5 +133,22 @@ pub fn tests_parameters_wrapper_unset(value: ParameterWrapper) {
 pub fn tests_parameters_wrapper_null(value: ParameterWrapper) {
     if value.row.is_some() {
         panic!("Expected none value")
+    }
+}
+
+#[napi]
+pub fn tests_uuid_generate_random(
+    value1: ParameterWrapper,
+    value2: ParameterWrapper,
+) -> napi::Result<()> {
+    match (value1.row, value2.row) {
+        (Some(MaybeUnset::Set(v1)), Some(MaybeUnset::Set(v2))) => {
+            if v1 == v2 {
+                Err(js_error("Expected UUID to differ"))
+            } else {
+                Ok(())
+            }
+        }
+        _ => Err(js_error("Expected values to be UUID")),
     }
 }

--- a/test/unit/type-guessing-tests.js
+++ b/test/unit/type-guessing-tests.js
@@ -53,6 +53,11 @@ describe("Encoder.guessDataType()", function () {
             "Guess type for a UUID value failed",
         );
         assertGuessed(
+            types.Uuid.generateRandom,
+            rust.CqlType.Uuid,
+            "Guess type for a UUID generateRandom",
+        );
+        assertGuessed(
             types.TimeUuid.now(),
             rust.CqlType.Uuid,
             "Guess type for a TimeUuid value failed",

--- a/test/unit/uuid-type-tests.js
+++ b/test/unit/uuid-type-tests.js
@@ -5,6 +5,8 @@ const helper = require("../test-helper");
 const utils = require("../../lib/utils");
 const Uuid = require("../../lib/types").Uuid;
 const TimeUuid = require("../../lib/types").TimeUuid;
+const rust = require("../../index");
+const { getWrapped } = require("../../lib/types/cql-utils");
 
 describe("Uuid", function () {
     describe("constructor", function () {
@@ -232,6 +234,22 @@ describe("Uuid", function () {
                     done();
                 },
             );
+        });
+    });
+
+    describe("generateRandom", function () {
+        it("should generate random UUIDs", function () {
+            let uuid1 = getWrapped(
+                rust.testsFromValueGetType("Uuid"),
+                Uuid.generateRandom,
+            );
+            let uuid2 = getWrapped(
+                rust.testsFromValueGetType("Uuid"),
+                Uuid.generateRandom,
+            );
+            // Assertion on the rust side
+            rust.testsUuidGenerateRandom(uuid1, uuid2);
+            rust.testsUuidGenerateRandom(uuid1, uuid1);
         });
     });
 


### PR DESCRIPTION
Extend the UUID API to add UUID.generateRandom static value.

When providing `generateRandom` as a query parameter,
each time a new random UUID will be generated.

While using `generateRandom` is faster than `random`,
it's not possible to retrieve a value of such UUID,
or use the same UUID in multiple places.