### PR TITLE
UUID result

### DIFF
--- a/lib/types/results-wrapper.js
+++ b/lib/types/results-wrapper.js
@@ -32,10 +32,6 @@ function getCqlObject(field) {
             return LocalDate.fromRust(field);
         case field instanceof rust.DurationWrapper:
             return Duration.fromRust(field);
-        case field instanceof rust.TimeUuidWrapper:
-            return TimeUuid.fromRust(field);
-        case field instanceof rust.UuidWrapper:
-            return Uuid.fromRust(field);
         case field instanceof rust.InetAddressWrapper:
             return InetAddress.fromRust(field);
         case field instanceof rust.LocalTimeWrapper:
@@ -70,12 +66,16 @@ function getCqlObject(field) {
                     );
                 }
                 return res;
+            case rust.CqlType.Timeuuid:
+                return TimeUuid.fromRust(value);
             case rust.CqlType.Tuple:
                 return Tuple.fromArray(
                     value.map((e) =>
                         e === null ? undefined : getCqlObject(e),
                     ),
                 );
+            case rust.CqlType.Uuid:
+                return Uuid.fromRust(value);
             default:
                 throw new Error("Unexpected type");
         }

--- a/lib/types/results-wrapper.js
+++ b/lib/types/results-wrapper.js
@@ -16,9 +16,8 @@ const Tuple = require("./tuple");
  *
  * This function accepts the following kinds of arguments:
  *   1. `Value` ->  When can correctly handle the value based on the type;
- *   2. `[Type, Value]` ->  In case of ambiguity, rust side provides tuple of (CqlType, Value);
- *   3. `Array` -> Tuple in JS is represented as an array so we need to distinguish between the previous case
- *      and a case where the array is provided as value. We determine it based on the type of the first value.
+ *   2. `[Type, Value]` ->  In case of ambiguity, rust side provides tuple of (CqlType, Value).
+ *      Specifically, array based types will always be returned in this form.
  *
  * See rust.CqlValueWrapper, for more information
  * @param {rust.CqlValueWrapper} field
@@ -39,15 +38,9 @@ function getCqlObject(field) {
     }
 
     if (Array.isArray(field)) {
-        // Check if the returned value is in (Type, Value) format
-        if (!(field.length === 2 && field[0] instanceof rust.CqlTypeClass)) {
-            // If not, returned value represents array. We need to map each element of the array
-            return field.map((value) => getCqlObject(value));
-        }
-
         let res;
         let value = field[1];
-        switch (field[0].typ) {
+        switch (field[0]) {
             case rust.CqlType.BigInt:
                 return bigintToLong(value);
             case rust.CqlType.Counter:
@@ -76,6 +69,9 @@ function getCqlObject(field) {
                 );
             case rust.CqlType.Uuid:
                 return Uuid.fromRust(value);
+            case rust.CqlType.Set:
+            case rust.CqlType.List:
+                return value.map((v) => getCqlObject(v));
             default:
                 throw new Error("Unexpected type");
         }

--- a/lib/types/time-uuid.js
+++ b/lib/types/time-uuid.js
@@ -265,7 +265,7 @@ class TimeUuid extends Uuid {
      * @returns {TimeUuid}
      */
     static fromRust(buffer) {
-        const uuid = new Uuid(buffer.getBuffer());
+        const uuid = new Uuid(buffer);
         return TimeUuid.fromString(uuid.toString());
     }
 }

--- a/lib/types/uuid.js
+++ b/lib/types/uuid.js
@@ -137,11 +137,11 @@ class Uuid {
 
     /**
      * @package
-     * @param {rust.UuidWrapper} buffer
+     * @param {Buffer} buffer
      * @returns {Uuid}
      */
     static fromRust(buffer) {
-        return new Uuid(buffer.getBuffer());
+        return new Uuid(buffer);
     }
 
     /**

--- a/src/result.rs
+++ b/src/result.rs
@@ -3,7 +3,6 @@ use std::sync::Arc;
 use crate::{
     types::{
         local_date::LocalDateWrapper,
-        time_uuid::TimeUuidWrapper,
         type_wrappers::{ComplexType, CqlType, CqlTypeClass},
         uuid::UuidWrapper,
     },
@@ -310,9 +309,11 @@ impl ToNapiValue for CqlValueWrapper {
             CqlValue::Time(val) => {
                 LocalTimeWrapper::to_napi_value(env, LocalTimeWrapper::from_cql_time(val))
             }
-            CqlValue::Timeuuid(val) => {
-                TimeUuidWrapper::to_napi_value(env, TimeUuidWrapper::from_cql_time_uuid(val))
-            }
+            CqlValue::Timeuuid(val) => add_type_to_napi_obj(
+                env,
+                Buffer::to_napi_value(env, Buffer::from(val.as_bytes().as_slice())),
+                CqlType::Timeuuid,
+            ),
             CqlValue::Tuple(val) => add_type_to_napi_obj(
                 env,
                 Vec::to_napi_value(
@@ -331,7 +332,11 @@ impl ToNapiValue for CqlValueWrapper {
                 CqlType::Tuple,
             ),
 
-            CqlValue::Uuid(val) => UuidWrapper::to_napi_value(env, UuidWrapper::from_cql_uuid(val)),
+            CqlValue::Uuid(val) => add_type_to_napi_obj(
+                env,
+                Buffer::to_napi_value(env, Buffer::from(val.as_bytes().as_slice())),
+                CqlType::Uuid,
+            ),
             CqlValue::Varint(_) => todo!(),
             other => unimplemented!("Missing implementation for CQL value {:?}", other),
         }

--- a/src/types/type_wrappers.rs
+++ b/src/types/type_wrappers.rs
@@ -33,14 +33,6 @@ pub enum CqlType {
     Unprovided,
 }
 
-/// The goal of this class is to have an enum, that can be type checked.
-/// By default, it's not possible to check in JS if value is of given enum type.
-/// For this reason we create a class containing just an enum.
-#[napi]
-pub struct CqlTypeClass {
-    pub typ: CqlType,
-}
-
 /// Keeps whole CQL type, including support types.
 /// It has similar information to [scylla::frame::response::result::ColumnType],
 /// but can be passes to NAPI-RS


### PR DESCRIPTION
Update UUID, so that we return raw bytes instead of object wrapper.

Removes CqlTypeClass, to reduce the overhead from it's type.
This means, that array will be treated as ambiguous types in result wrapping.