### PR TITLE
Add checks for error messages in integration tests

### DIFF
--- a/lib/types/protocol-version.js
+++ b/lib/types/protocol-version.js
@@ -41,15 +41,6 @@ const protocolVersion = {
     minSupported: 0x01,
 
     /**
-     * Determines whether the protocol version is a DSE-specific protocol version.
-     * @param {Number} version
-     * @returns {Boolean}
-     * @ignore
-     */
-    isDse: function (version) {
-        return version >= this.dseV1 && version <= this.dseV2;
-    },
-    /**
      * Returns true if the protocol version represents a version of Cassandra
      * supported by this driver, false otherwise
      * @param {Number} version
@@ -66,7 +57,7 @@ const protocolVersion = {
      * @ignore
      */
     isSupported: function (version) {
-        return this.isDse(version) || this.isSupportedCassandra(version);
+        return this.isSupportedCassandra(version);
     },
 
     /**
@@ -123,7 +114,7 @@ const protocolVersion = {
      * @ignore
      */
     supportsContinuousPaging: function (version) {
-        return this.isDse(version);
+        return false;
     },
     /**
      * Determines whether the protocol supports paging state and serial consistency parameters in QUERY and EXECUTE
@@ -196,7 +187,7 @@ const protocolVersion = {
      * @ignore
      */
     uses4BytesQueryFlags: function (version) {
-        return this.isDse(version);
+        return false;
     },
     /**
      * Startup responses using protocol v4+ can be a SERVER_ERROR wrapping a ProtocolException, this method returns true

--- a/test/integration/broken/metadata-tests.js
+++ b/test/integration/broken/metadata-tests.js
@@ -14,11 +14,7 @@ describe("metadata @SERVER_API", function () {
 
     const yaml = [];
 
-    if (helper.isDseGreaterThan("6")) {
-        yaml.push("cdc_enabled:true");
-    }
-
-    if (!helper.isDse() && helper.isCassandraGreaterThan("4.0")) {
+    if (helper.isCassandraGreaterThan("4.0")) {
         yaml.push("enable_materialized_views:true");
     }
 
@@ -794,20 +790,8 @@ describe("metadata @SERVER_API", function () {
                     );
                 }
 
-                if (helper.isDseGreaterThan("6")) {
-                    queries.push(
-                        "CREATE TABLE tbl_cdc_true (a int PRIMARY KEY, b text) WITH cdc=TRUE",
-                        "CREATE TABLE tbl_cdc_false (a int PRIMARY KEY, b text) WITH cdc=FALSE",
-                        "CREATE TABLE tbl_nodesync_true (a int PRIMARY KEY, b text) WITH nodesync={'enabled': 'true', 'deadline_target_sec': '86400'}",
-                        "CREATE TABLE tbl_nodesync_false (a int PRIMARY KEY, b text) WITH nodesync={'enabled': 'false'}",
-                    );
-                }
-
-                if (
-                    !helper.isCassandraGreaterThan("4.0") &&
-                    !helper.isDseGreaterThan("6.0")
-                ) {
-                    // COMPACT STORAGE is not supported by DSE 6.0 / C* 4.0.
+                if (!helper.isCassandraGreaterThan("4.0")) {
+                    // COMPACT STORAGE is not supported by C* 4.0.
                     queries.push(
                         "CREATE TABLE tbl5 (id1 uuid, id2 timeuuid, text1 text, PRIMARY KEY (id1, id2)) WITH COMPACT STORAGE",
                         "CREATE TABLE tbl6 (id uuid, text1 text, text2 text, PRIMARY KEY (id)) WITH COMPACT STORAGE",
@@ -1032,10 +1016,7 @@ describe("metadata @SERVER_API", function () {
                 });
             });
             it("should retrieve the metadata of a compact storaged table", function (done) {
-                if (
-                    helper.isCassandraGreaterThan("4.0") ||
-                    helper.isDseGreaterThan("6")
-                ) {
+                if (helper.isCassandraGreaterThan("4.0")) {
                     this.skip();
                 }
 
@@ -1076,10 +1057,7 @@ describe("metadata @SERVER_API", function () {
                 });
             });
             it("should retrieve the metadata of a compact storaged table with clustering key", function (done) {
-                if (
-                    helper.isCassandraGreaterThan("4.0") ||
-                    helper.isDseGreaterThan("6")
-                ) {
+                if (helper.isCassandraGreaterThan("4.0")) {
                     this.skip();
                 }
 
@@ -1940,10 +1918,6 @@ describe("metadata @SERVER_API", function () {
                             table.compression.constructor,
                             Object,
                         );
-
-                        if (helper.isDseGreaterThan("5.0")) {
-                            assert.isString(table.compression.class);
-                        }
                     }));
 
                 vit(
@@ -1986,11 +1960,6 @@ describe("metadata @SERVER_API", function () {
                     "CREATE TABLE ks_view_meta.scores (user TEXT, game TEXT, year INT, month INT, day INT, score INT, PRIMARY KEY (user, game, year, month, day))",
                     "CREATE MATERIALIZED VIEW ks_view_meta.dailyhigh AS SELECT game, year, month, score, user, day FROM scores WHERE game IS NOT NULL AND year IS NOT NULL AND month IS NOT NULL AND day IS NOT NULL AND score IS NOT NULL AND user IS NOT NULL PRIMARY KEY ((game, year, month, day), score, user) WITH CLUSTERING ORDER BY (score DESC, user ASC)",
                 ];
-                if (helper.isDseGreaterThan("6")) {
-                    queries.push(
-                        "CREATE MATERIALIZED VIEW ks_view_meta.dailyhigh_nodesync AS SELECT game, year, month, score, user, day FROM scores WHERE game IS NOT NULL AND year IS NOT NULL AND month IS NOT NULL AND day IS NOT NULL AND score IS NOT NULL AND user IS NOT NULL PRIMARY KEY ((game, year, month, day), score, user) WITH CLUSTERING ORDER BY (score DESC, user ASC) AND nodesync = { 'enabled': 'true', 'deadline_target_sec': '86400'}",
-                    );
-                }
                 utils.eachSeries(
                     queries,
                     client.execute.bind(client),

--- a/test/integration/broken/udf-tests.js
+++ b/test/integration/broken/udf-tests.js
@@ -26,15 +26,6 @@ vdescribe("2.2", "Metadata @SERVER_API", function () {
             "CREATE AGGREGATE ks_udf.sum(int) SFUNC plus STYPE int INITCOND 1",
             "CREATE AGGREGATE ks_udf.sum(bigint) SFUNC plus STYPE bigint INITCOND 2",
         ];
-        if (helper.isDseGreaterThan("6")) {
-            queries.push(
-                "CREATE FUNCTION ks_udf.deterministic(dividend int, divisor int) CALLED ON NULL INPUT RETURNS int DETERMINISTIC LANGUAGE java AS 'return dividend / divisor;'",
-                "CREATE FUNCTION ks_udf.monotonic(dividend int, divisor int) CALLED ON NULL INPUT RETURNS int MONOTONIC LANGUAGE java AS 'return dividend / divisor;'",
-                "CREATE FUNCTION ks_udf.md(dividend int, divisor int) CALLED ON NULL INPUT RETURNS int DETERMINISTIC MONOTONIC LANGUAGE java AS 'return dividend / divisor;'",
-                "CREATE FUNCTION ks_udf.monotonic_on(dividend int, divisor int) CALLED ON NULL INPUT RETURNS int MONOTONIC ON dividend LANGUAGE java AS 'return dividend / divisor;'",
-                "CREATE AGGREGATE ks_udf.deta(int) SFUNC plus STYPE int INITCOND 0 DETERMINISTIC;",
-            );
-        }
         utils.eachSeries(
             queries,
             client.execute.bind(client),

--- a/test/integration/supported/client-batch-tests.js
+++ b/test/integration/supported/client-batch-tests.js
@@ -1073,9 +1073,6 @@ describe("Client @SERVER_API", function () {
         // Would require error throwing refactor
         // TODO: Fix this test
         it("should not use keyspace if set on options for lower protocol versions", function () {
-            if (helper.isDseGreaterThan("6.0")) {
-                return this.skip();
-            }
             const client = newInstance({});
             const insertQuery =
                 "INSERT INTO %s (id, time, double_sample) VALUES (?, ?, ?)";

--- a/test/integration/supported/client-batch-tests.js
+++ b/test/integration/supported/client-batch-tests.js
@@ -166,7 +166,13 @@ describe("Client @SERVER_API", function () {
                 const client = newInstance();
                 client.batch(["INSERT WILL FAIL"], function (err) {
                     assert.ok(err);
-                    // Would require correct error throwing
+                    assert.ok(
+                        err.message.includes(
+                            "Preparation failed on every connection from the selected pool.",
+                        ),
+                    );
+                    assert.ok(err.message.includes("syntax error"));
+                    // Would require error throwing refactor
                     // TODO: fix this test
                     /* assert.ok(err instanceof errors.ResponseError); */
                     done();
@@ -211,9 +217,8 @@ describe("Client @SERVER_API", function () {
                         );
                     })
                     .catch(function (err) {
-                        // should be an Argument Error
                         assert.ok(err);
-                        // Would require correct error throwing
+                        // Would require error throwing refactor
                         // TODO: Fix this test
                         /* if (
                             !(err instanceof errors.ArgumentError) &&
@@ -224,6 +229,19 @@ describe("Client @SERVER_API", function () {
                                     method.toString(),
                             );
                         } */
+                        if (
+                            !(err instanceof errors.ArgumentError) &&
+                            // TODO: This should be ResponseError.
+                            // For now we just check the message to make sure it's the proper error
+                            !err.message.includes(
+                                "Preparation failed on every connection from the selected pool.",
+                            )
+                        ) {
+                            throw new Error(
+                                "Expected ArgumentError or ResponseError for method " +
+                                    method.toString(),
+                            );
+                        }
                     });
             });
             setImmediate(client.shutdown.bind(client));
@@ -677,9 +695,7 @@ describe("Client @SERVER_API", function () {
             );
         }); */
 
-        // Would require correct error throwing
-        // TODO: Fix this test
-        /* vit(
+        vit(
             "2.0",
             "should callback in error when the one of the queries contains syntax error",
             function (done) {
@@ -715,14 +731,18 @@ describe("Client @SERVER_API", function () {
                             queries,
                             { prepare: true },
                             function (err) {
-                                helper.assertInstanceOf(
+                                // Would require error throwing refactor
+                                // TODO: Fix this test
+                                assert.ok(err);
+                                assert.ok(err.message.includes("syntax error"));
+                                /* helper.assertInstanceOf(
                                     err,
                                     errors.ResponseError,
                                 );
                                 assert.strictEqual(
                                     err.code,
                                     types.responseErrorCodes.syntaxError,
-                                );
+                                ); */
                                 next();
                             },
                         );
@@ -730,7 +750,7 @@ describe("Client @SERVER_API", function () {
                     done,
                 );
             },
-        ); */
+        );
         vit(
             "2.0",
             "should callback in error when the type does not match",
@@ -756,8 +776,13 @@ describe("Client @SERVER_API", function () {
                             queries,
                             { prepare: true },
                             function (err) {
-                                // Would require correct error throwing
+                                // Would require error throwing refactor
                                 // TODO: Fix this test
+                                assert.ok(
+                                    err.message.includes(
+                                        "Failed to convert napi value Object into rust type",
+                                    ),
+                                );
                                 assert.strictEqual(isNativeError(err), true);
                                 /* helper.assertInstanceOf(err, TypeError); */
                                 next();
@@ -1045,9 +1070,9 @@ describe("Client @SERVER_API", function () {
                 });
             },
         );
-        // Would require correct error throwing
+        // Would require error throwing refactor
         // TODO: Fix this test
-        /* it("should not use keyspace if set on options for lower protocol versions", function () {
+        it("should not use keyspace if set on options for lower protocol versions", function () {
             if (helper.isDseGreaterThan("6.0")) {
                 return this.skip();
             }
@@ -1073,10 +1098,16 @@ describe("Client @SERVER_API", function () {
                     throw new Error("should have failed");
                 })
                 .catch(function (err) {
-                    helper.assertInstanceOf(err, errors.ResponseError);
+                    assert.ok(err);
+                    assert.ok(
+                        err.message.includes(
+                            "Preparation failed on every connection from the selected pool.",
+                        ),
+                    );
+                    // helper.assertInstanceOf(err, errors.ResponseError);
                     return client.shutdown();
                 });
-        }); */
+        });
     });
 });
 

--- a/test/integration/supported/client-execute-prepared-tests.js
+++ b/test/integration/supported/client-execute-prepared-tests.js
@@ -68,7 +68,7 @@ describe("Client @SERVER_API", function () {
             const query = "SELECT WILL FAIL";
             client.execute(query, ["system"], { prepare: 1 }, function (err) {
                 assert.ok(err);
-                // Would require correct Error throwing
+                // Would require error throwing refactor
                 // TODO: fix this test
                 helper.assertInstanceOf(err, Error);
                 /* assert.strictEqual(
@@ -76,6 +76,12 @@ describe("Client @SERVER_API", function () {
                     types.responseErrorCodes.syntaxError,
                 );
                 assert.strictEqual(err.query, query); */
+                assert.ok(
+                    err.message.includes(
+                        "Preparation failed on every connection from the selected pool.",
+                    ),
+                );
+                assert.ok(err.message.includes("syntax error"));
                 done();
             });
         });
@@ -123,10 +129,7 @@ describe("Client @SERVER_API", function () {
                             params,
                             { prepare: true },
                             (err) => {
-                                // Would require correct error throwing
-                                // TODO: fix this test
-                                helper.assertInstanceOf(err, Error);
-                                // helper.assertInstanceOf(err, TypeError);
+                                helper.assertInstanceOf(err, TypeError);
                                 next();
                             },
                         ),
@@ -146,10 +149,7 @@ describe("Client @SERVER_API", function () {
                             params,
                             { prepare: true },
                             (err) => {
-                                // Would require correct error throwing
-                                // TODO: fix this test
-                                helper.assertInstanceOf(err, Error);
-                                // helper.assertInstanceOf(err, TypeError);
+                                helper.assertInstanceOf(err, TypeError);
                                 next();
                             },
                         ),
@@ -249,7 +249,7 @@ describe("Client @SERVER_API", function () {
                                     { prepare: 1 },
                                     function (err) {
                                         helper.assertInstanceOf(err, Error);
-                                        // Would require correct Error throwing
+                                        // Would require error throwing refactor
                                         // TODO: fix this test
                                         /* helper.assertInstanceOf(
                                             err,
@@ -259,6 +259,16 @@ describe("Client @SERVER_API", function () {
                                             err.code,
                                             types.responseErrorCodes.invalid,
                                         ); */
+                                        assert.ok(
+                                            err.message.includes(
+                                                "Preparation failed on every connection from the selected pool.",
+                                            ),
+                                        );
+                                        assert.ok(
+                                            err.message.includes(
+                                                "The query is syntactically correct but invalid",
+                                            ),
+                                        );
                                         next();
                                     },
                                 );
@@ -276,7 +286,7 @@ describe("Client @SERVER_API", function () {
                                     { prepare: 1 },
                                     function (err) {
                                         helper.assertInstanceOf(err, Error);
-                                        // Would require correct Error throwing
+                                        // Would require error throwing refactor
                                         // TODO: fix this test
                                         /* helper.assertInstanceOf(
                                             err,
@@ -286,6 +296,16 @@ describe("Client @SERVER_API", function () {
                                             err.code,
                                             types.responseErrorCodes.invalid,
                                         ); */
+                                        assert.ok(
+                                            err.message.includes(
+                                                "Preparation failed on every connection from the selected pool.",
+                                            ),
+                                        );
+                                        assert.ok(
+                                            err.message.includes(
+                                                "The query is syntactically correct but invalid",
+                                            ),
+                                        );
                                         next();
                                     },
                                 );
@@ -1328,9 +1348,15 @@ describe("Client @SERVER_API", function () {
 
             function validateResponseError(callback) {
                 return (err) => {
-                    // Would require full error throwing
+                    // Would require error throwing refactor
                     // TODO: fix this test
                     helper.assertInstanceOf(err, Error);
+                    assert.ok(
+                        err instanceof errors.ResponseError ||
+                            err.message.includes(
+                                "The query is syntactically correct but invalid",
+                            ),
+                    );
                     /* helper.assertInstanceOf(err, errors.ResponseError);
                     assert.strictEqual(
                         err.code,

--- a/test/integration/supported/client-execute-tests.js
+++ b/test/integration/supported/client-execute-tests.js
@@ -38,27 +38,29 @@ describe("Client @SERVER_API", function () {
             });
         });
 
-        // Would require correct error throwing
+        // Would require error throwing refactor
         // TODO: Fix this test
-        /* it("should callback with syntax error", function (done) {
+        it("should callback with syntax error", function (done) {
             const client = setupInfo.client;
             client.connect(function (err) {
                 assert.ifError(err);
                 const query = "SELECT WILL FAIL";
                 client.execute(query, function (err, result) {
                     assert.ok(err);
-                    assert.strictEqual(
-                        err.code,
-                        types.responseErrorCodes.syntaxError,
-                    );
-                    assert.strictEqual(err.query, query);
+                    assert.ok(err instanceof Error);
+                    assert.ok(err.message.includes("syntax error"));
+                    // assert.strictEqual(
+                    //     err.code,
+                    //     types.responseErrorCodes.syntaxError,
+                    // );
+                    // assert.strictEqual(err.query, query);
                     assert.equal(result, null);
                     done();
                 });
             });
-        }); */
+        });
 
-        // Would require correct error conversion
+        // Would require error throwing refactor
         // TODO: Fix this test
         context("with incorrect query parameters", () => {
             const client = setupInfo.client;
@@ -73,8 +75,12 @@ describe("Client @SERVER_API", function () {
                     ],
                     (params, next) =>
                         client.execute(query, params, (err) => {
-                            // TODO: Ensure correct error is thrown
                             helper.assertInstanceOf(err, Error);
+                            assert.ok(
+                                err.message.includes(
+                                    "Failed to serialize query parameters",
+                                ),
+                            );
                             /* helper.assertInstanceOf(err, errors.ResponseError);
                             assert.strictEqual(
                                 err.code,
@@ -86,7 +92,7 @@ describe("Client @SERVER_API", function () {
                 );
             });
 
-            // Would require correct error throwing
+            // Would require error throwing refactor
             // TODO: Fix this test
             it("should callback with error when the parameter types do not match", (done) => {
                 utils.eachSeries(
@@ -96,8 +102,12 @@ describe("Client @SERVER_API", function () {
                     ],
                     (params, next) =>
                         client.execute(query, params, (err) => {
-                            // TODO: Ensure correct error is thrown
                             helper.assertInstanceOf(err, Error);
+                            assert.ok(
+                                err.message.includes(
+                                    "Failed to serialize query parameters",
+                                ),
+                            );
                             /* helper.assertInstanceOf(err, errors.ResponseError);
                             assert.strictEqual(
                                 err.code,
@@ -117,9 +127,7 @@ describe("Client @SERVER_API", function () {
                     ],
                     (params, next) =>
                         client.execute(query, params, (err) => {
-                            // TODO: Ensure correct error is thrown
-                            helper.assertInstanceOf(err, Error);
-                            /* helper.assertInstanceOf(err, TypeError); */
+                            helper.assertInstanceOf(err, TypeError);
                             next();
                         }),
                     done,
@@ -508,12 +516,17 @@ describe("Client @SERVER_API", function () {
                                 { hints: [[]] },
                                 function (err) {
                                     helper.assertInstanceOf(err, Error);
-                                    // Would require correct error throwing
+                                    // Would require error throwing refactor
                                     // TODO: Fix this test
                                     /* helper.assertNotInstanceOf(
                                         err,
                                         errors.NoHostAvailableError,
                                     ); */
+                                    assert.ok(
+                                        err.message.includes(
+                                            "Type information not valid",
+                                        ),
+                                    );
                                     next();
                                 },
                             );
@@ -525,12 +538,17 @@ describe("Client @SERVER_API", function () {
                                 { hints: ["zzz", "mmmm"] },
                                 function (err) {
                                     helper.assertInstanceOf(err, Error);
-                                    // Would require correct error throwing
+                                    // Would require error throwing refactor
                                     // TODO: Fix this test
                                     /* helper.assertNotInstanceOf(
                                         err,
                                         errors.NoHostAvailableError,
                                     ); */
+                                    assert.ok(
+                                        err.message.includes(
+                                            "Data type with name zzz not valid",
+                                        ),
+                                    );
                                     next();
                                 },
                             );
@@ -2073,8 +2091,8 @@ describe("Client @SERVER_API", function () {
                         });
                 },
             );
-            // Would require correct error throwing
-            /* it("should reject the promise when there is a syntax error", function () {
+            // Would require error throwing refactor
+            it("should reject the promise when there is a syntax error", function () {
                 const client = setupInfo.client;
                 return client
                     .connect()
@@ -2085,9 +2103,14 @@ describe("Client @SERVER_API", function () {
                         throw new Error("should have been rejected");
                     })
                     .catch(function (err) {
-                        helper.assertInstanceOf(err, errors.ResponseError);
+                        assert.ok(
+                            err.message.includes(
+                                "The submitted query has a syntax error",
+                            ),
+                        );
+                        // helper.assertInstanceOf(err, errors.ResponseError);
                     });
-            }); */
+            });
         });
         vdescribe("2.0", "with lightweight transactions", function () {
             const client = setupInfo.client;

--- a/test/integration/supported/client-execute-tests.js
+++ b/test/integration/supported/client-execute-tests.js
@@ -2173,9 +2173,6 @@ describe("Client @SERVER_API", function () {
         // No support for keyspace
         // TODO: Fix this test
         /* it("should not use keyspace if set on options for lower protocol versions", function () {
-            if (helper.isDseGreaterThan("6.0")) {
-                return this.skip();
-            }
             const client = setupInfo.client;
             return client
                 .execute("select * from local", null, { keyspace: "system" })

--- a/test/integration/supported/client-stream-tests.js
+++ b/test/integration/supported/client-stream-tests.js
@@ -85,8 +85,13 @@ describe("Client", function () {
                 .on("error", function (err) {
                     assert.ok(err, "It should yield an error");
                     // TODO: Fix this test
-                    // Would require correct error throwing
+                    // Would require error throwing refactor
                     /* helper.assertInstanceOf(err, errors.ResponseError); */
+                    assert.ok(
+                        err.message.includes(
+                            "The submitted query has a syntax error",
+                        ),
+                    );
                     errorCalled = true;
                 });
         });
@@ -331,11 +336,16 @@ describe("Client", function () {
                 .on("error", function (err) {
                     assert.ok(err);
                     // TODO: Fix this test
-                    // Would require correct error throwing
+                    // Would require error throwing refactor
                     /* assert.ok(
                         err instanceof TypeError,
                         "Error should be an instance of TypeError",
                     ); */
+                    assert.ok(
+                        err.message.includes(
+                            "Failed to convert JavaScript value `Object {}` into rust type `String`",
+                        ),
+                    );
                     errCalled = true;
                 })
                 .on("readable", function () {

--- a/test/test-helper.js
+++ b/test/test-helper.js
@@ -453,25 +453,6 @@ const helper = {
     },
 
     /**
-     * Determines if the current server is a DSE instance *AND* version is greater than or equals to the version provided
-     * @param {String} version The version in string format, dot separated.
-     * @returns {Boolean}
-     */
-    isDseGreaterThan: function (version) {
-        const serverInfo = this.getServerInfo();
-        if (!serverInfo.isDse) {
-            return false;
-        }
-
-        return helper.versionCompare(serverInfo.version, version);
-    },
-
-    /** Determines if the current server is a DSE instance. */
-    isDse: function () {
-        return this.getServerInfo().isDse;
-    },
-
-    /**
      * Determines if the current C* or DSE instance version is greater than or equals to the C* version provided
      * @param {String} version The version in string format, dot separated.
      * @returns {Boolean}
@@ -1258,10 +1239,6 @@ helper.ccm.bootstrapNode = function (options, callback) {
 helper.ccm.decommissionNode = function (nodeIndex, callback) {
     helper.trace("decommissioning node", nodeIndex);
     const args = ["node" + nodeIndex, "decommission"];
-    // Special case for C* 3.12+, DSE 5.1+, force decommission (see CASSANDRA-12510)
-    if (helper.isDseGreaterThan("5.1")) {
-        args.push("--force");
-    }
     helper.ccm.exec(args, callback);
 };
 


### PR DESCRIPTION
Enable some previously disabled tests and add additional checks for the error messages to prevent unexpected changes.