### PR TITLE
CI: attempt to fix ccm permission errors

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -55,9 +55,8 @@ jobs:
       - name: Install ccm and get simulacron
         run: |
           wget https://github.com/datastax/simulacron/releases/download/0.12.0/simulacron-standalone-0.12.0.jar -O ~/simulacron.jar
-          pip install psutil
-          sudo pip install --upgrade psutil
-          pip install https://github.com/scylladb/scylla-ccm/archive/master.zip
+          pip install --user --upgrade psutil
+          pip install --user https://github.com/scylladb/scylla-ccm/archive/master.zip
       - name: Build
         run: ${{ matrix.settings.build }}
         shell: bash


### PR DESCRIPTION
This patch attempts to fix CCM-related permission errors in the CI by using `pip install` with the `--user` flag. As the permission error seems to appear in a flaky way, we'll see if this helped only after a few more CI runs with this open/merged.