### PR TITLE
[WIP] Introduce temporary logging

### DIFF
--- a/.github/test.sh
+++ b/.github/test.sh
@@ -2,4 +2,11 @@ ccm create test8625732647544266 -v 3.11.4
 ccm populate -n 1:0
 timeout 120 ccm start --wait-for-binary-proto 
 echo $?
+echo "Above is a code from the first run"
+ccm remove 
+ccm create test1436203882558078 -v 3.11.4
+ccm populate -n 3:0
+timeout 120 ccm start --wait-for-binary-proto
+echo $?
+echo "Above is a code from the second run"
 echo "Done"

--- a/.github/test.sh
+++ b/.github/test.sh
@@ -1,8 +1,8 @@
 ccm create test8625732647544266 -v 3.11.4
 ccm populate -n 1:0
-set -e
-timeout 120 ccm start --wait-for-binary-proto 
-echo $?
+# set -e
+timeout 60 ccm start --wait-for-binary-proto 
+# echo $?
 # echo "Above is a code from the first run"
 # ccm remove 
 # ccm create test1436203882558078 -v 3.11.4

--- a/.github/test.sh
+++ b/.github/test.sh
@@ -2,7 +2,8 @@ ccm create test8625732647544266 -v 3.11.4
 ccm populate -n 1:0
 # set -e
 timeout 60 ccm start --wait-for-binary-proto 
-# echo $?
+# echo "TEst"
+echo $?
 # echo "Above is a code from the first run"
 # ccm remove 
 # ccm create test1436203882558078 -v 3.11.4

--- a/.github/test.sh
+++ b/.github/test.sh
@@ -1,12 +1,13 @@
 ccm create test8625732647544266 -v 3.11.4
 ccm populate -n 1:0
+set -e
 timeout 120 ccm start --wait-for-binary-proto 
 echo $?
-echo "Above is a code from the first run"
-ccm remove 
-ccm create test1436203882558078 -v 3.11.4
-ccm populate -n 3:0
-timeout 120 ccm start --wait-for-binary-proto
-echo $?
-echo "Above is a code from the second run"
-echo "Done"
+# echo "Above is a code from the first run"
+# ccm remove 
+# ccm create test1436203882558078 -v 3.11.4
+# ccm populate -n 3:0
+# timeout 120 ccm start --wait-for-binary-proto
+# echo $?
+# echo "Above is a code from the second run"
+# echo "Done"

--- a/.github/test.sh
+++ b/.github/test.sh
@@ -1,0 +1,5 @@
+ccm create test8625732647544266 -v 3.11.4
+ccm populate -n 1:0
+timeout 120 ccm start --wait-for-binary-proto 
+echo $?
+echo "Done"

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -59,8 +59,9 @@ jobs:
           pip install --user https://github.com/scylladb/scylla-ccm/archive/master.zip
       - name: Run ccm test
         run: bash .github/test.sh
-      - name: Build
-        run: ${{ matrix.settings.build }}
-        shell: bash
-      - name: Run integration tests
-        run: npm run integration
+      - name: Breakpoint if tests failed
+        if: failure()
+        uses: namespacelabs/breakpoint-action@v0
+        with:
+          duration: 90m
+          authorized-users: adespawn

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -57,9 +57,5 @@ jobs:
           wget https://github.com/datastax/simulacron/releases/download/0.12.0/simulacron-standalone-0.12.0.jar -O ~/simulacron.jar
           pip install --user --upgrade psutil
           pip install --user https://github.com/scylladb/scylla-ccm/archive/master.zip
-      - name: Build
-        run: ${{ matrix.settings.build }}
-        shell: bash
-      - name: Run integration tests
-        run: npm run integration
-          
+      - name: Run ccm test
+        run: bash .github/test.sh

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -59,3 +59,8 @@ jobs:
           pip install --user https://github.com/scylladb/scylla-ccm/archive/master.zip
       - name: Run ccm test
         run: bash .github/test.sh
+      - name: Build
+        run: ${{ matrix.settings.build }}
+        shell: bash
+      - name: Run integration tests
+        run: npm run integration

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -57,11 +57,16 @@ jobs:
           wget https://github.com/datastax/simulacron/releases/download/0.12.0/simulacron-standalone-0.12.0.jar -O ~/simulacron.jar
           pip install --user --upgrade psutil
           pip install --user https://github.com/scylladb/scylla-ccm/archive/master.zip
-      # - name: Run ccm test
-      #   run: bash .github/test.sh
-      - name: Breakpoint if tests failed
-        # if: failure()
-        uses: namespacelabs/breakpoint-action@v0
-        with:
-          duration: 90m
-          authorized-users: adespawn
+      - name: Run ccm test
+        run: bash .github/test.sh
+      - name: Build
+        run: ${{ matrix.settings.build }}
+        shell: bash
+      - name: Run integration tests
+        run: npm run integration
+      # - name: Breakpoint if tests failed
+      #   # if: failure()
+      #   uses: namespacelabs/breakpoint-action@v0
+      #   with:
+      #     duration: 90m
+      #     authorized-users: adespawn

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -57,10 +57,10 @@ jobs:
           wget https://github.com/datastax/simulacron/releases/download/0.12.0/simulacron-standalone-0.12.0.jar -O ~/simulacron.jar
           pip install --user --upgrade psutil
           pip install --user https://github.com/scylladb/scylla-ccm/archive/master.zip
-      - name: Run ccm test
-        run: bash .github/test.sh
+      # - name: Run ccm test
+      #   run: bash .github/test.sh
       - name: Breakpoint if tests failed
-        if: failure()
+        # if: failure()
         uses: namespacelabs/breakpoint-action@v0
         with:
           duration: 90m

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "unit": "./node_modules/.bin/mocha test/unit -t 5000 --recursive",
     "unit-not-supported": "./node_modules/.bin/mocha test/unit-not-supported -t 5000 --recursive",
     "examples": "node ./examples/runner.js",
-    "integration": "./node_modules/.bin/mocha test/integration/supported --recursive",
+    "integration": "./node_modules/.bin/mocha test/integration/supported --recursive --exit",
     "prettier": "npx prettier \"{lib,examples,test}/**/*.js\" --write",
     "full-clippy": "cargo clippy --all-targets --all-features -- -D warnings",
     "pre-push": "npm run prettier && cargo fmt && npm run full-clippy && napi build --platform && npm run eslint-fix",

--- a/test/integration/supported/client-batch-tests.js
+++ b/test/integration/supported/client-batch-tests.js
@@ -17,6 +17,9 @@ describe("Client @SERVER_API", function () {
         const table1 = `${keyspace}.${helper.getRandomName("tblA")}`;
         const table2 = `${keyspace}.${helper.getRandomName("tblB")}`;
         before(function (done) {
+            // This is a temporary logging for catching timeouts
+            console.log(`Running before test`);
+
             const client = newInstance();
             utils.series(
                 [
@@ -39,6 +42,9 @@ describe("Client @SERVER_API", function () {
                 ],
                 done,
             );
+
+            // This is a temporary logging for catching timeouts
+            console.log(`Finishing before test`);
         });
         after(helper.ccmHelper.remove);
         vit(
@@ -566,6 +572,9 @@ describe("Client @SERVER_API", function () {
         const table1 = keyspace + "." + table1Short;
         const table2 = keyspace + "." + helper.getRandomName("tblB");
         before(function (done) {
+            // This is a temporary logging for catching timeouts
+            console.log(`Running before test`);
+
             const client = newInstance();
             const createTableCql =
                 "CREATE TABLE %s (" +
@@ -601,6 +610,9 @@ describe("Client @SERVER_API", function () {
                 ],
                 done,
             );
+
+            // This is a temporary logging for catching timeouts
+            console.log(`Finishing before test`);
         });
         after(helper.ccmHelper.remove);
         // No support for varint

--- a/test/integration/supported/client-stream-tests.js
+++ b/test/integration/supported/client-stream-tests.js
@@ -12,7 +12,13 @@ const errors = require("../../../lib/errors.js");
 describe("Client", function () {
     this.timeout(120000);
     describe("#stream(query, params, {prepare: 0})", function () {
-        before(helper.ccmHelper.start(1));
+        before(function () {
+            // This is a temporary logging for catching timeouts
+            console.log(`Running before test`);
+            helper.ccmHelper.start(1);
+            // This is a temporary logging for catching timeouts
+            console.log(`Finishing before test`);
+        });
         after(helper.ccmHelper.remove);
         it("should emit end when no rows", function (done) {
             const client = newInstance();
@@ -135,6 +141,8 @@ describe("Client", function () {
         const commonKs = helper.getRandomName("ks");
         const commonTable = commonKs + "." + helper.getRandomName("table");
         before(function (done) {
+            // This is a temporary logging for catching timeouts
+            console.log(`Running before test`);
             const client = newInstance();
             utils.series(
                 [
@@ -154,6 +162,8 @@ describe("Client", function () {
                 ],
                 done,
             );
+            // This is a temporary logging for catching timeouts
+            console.log(`Finishing before test`);
         });
         after(helper.ccmHelper.remove);
         it("should prepare and emit end when no rows", function (done) {

--- a/test/test-helper.js
+++ b/test/test-helper.js
@@ -1361,7 +1361,7 @@ helper.ccm.spawn = function (processName, params, callback) {
     p.stderr.setEncoding("utf8");
 
     // This is a temporary logging for catching timeouts
-    console.log(`Running ${processName} ${params.join(" ")}`);
+    console.log(`Running ${processName} ${params.join(" ")} at ${Date.now()}`);
 
     p.stdout.on("data", function (data) {
         stdoutArray.push(data);
@@ -1377,7 +1377,7 @@ helper.ccm.spawn = function (processName, params, callback) {
             return;
         }
         // This is a temporary logging for catching timeouts
-        console.log(`Closing ${processName} ${params.join(" ")}`);
+        console.log(`Closing ${processName} ${params.join(" ")} at ${Date.now()}`);
 
         const info = { code: code, stdout: stdoutArray, stderr: stderrArray };
         let err = null;

--- a/test/test-helper.js
+++ b/test/test-helper.js
@@ -1337,6 +1337,12 @@ helper.ccm.exec = function (params, callback) {
     helper.ccm.spawn("ccm", params, callback);
 };
 
+/**
+ *
+ * @param {string} processName
+ * @param {Array<string>} params
+ * @param {function} callback
+ */
 helper.ccm.spawn = function (processName, params, callback) {
     if (!callback) {
         callback = function () {};
@@ -1353,6 +1359,10 @@ helper.ccm.spawn = function (processName, params, callback) {
     let closing = 0;
     p.stdout.setEncoding("utf8");
     p.stderr.setEncoding("utf8");
+
+    // This is a temporary logging for catching timeouts
+    console.log(`Running ${processName} ${params.join(" ")}`);
+
     p.stdout.on("data", function (data) {
         stdoutArray.push(data);
     });
@@ -1366,6 +1376,9 @@ helper.ccm.spawn = function (processName, params, callback) {
             // avoid calling multiple times
             return;
         }
+        // This is a temporary logging for catching timeouts
+        console.log(`Closing ${processName} ${params.join(" ")}`);
+
         const info = { code: code, stdout: stdoutArray, stderr: stderrArray };
         let err = null;
         if (code !== 0) {


### PR DESCRIPTION
Introduce temporary logging in integration tests, around the before step. The goal of this commit is to narrow down the cause of occasional timeouts in "before" step on CI (those timeouts mentioned in #148).