### PR TITLE
Update pageState parsing

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -267,12 +267,9 @@ class Client extends events.EventEmitter {
             const execOptions = this.createOptions(options);
             if (execOptions.isPaged()) {
                 return promiseUtils.optionalCallback(
-                    this.#rustyPaged(
-                        query,
-                        params,
-                        execOptions,
-                        execOptions.getPageState(),
-                    ).then((e) => e[1]),
+                    this.#rustyPaged(query, params, execOptions).then(
+                        (e) => e[1],
+                    ),
                     callback,
                 );
             }
@@ -513,6 +510,17 @@ class Client extends events.EventEmitter {
 
         if (pageState instanceof Buffer) {
             pageState = rust.PagingStateWrapper.fromBuffer(pageState);
+        } else if (pageState == undefined) {
+            // Take the page state option into account only when we don't pass it explicitly (it's done only in eachRow)
+            if (execOptions.getPageState() instanceof Buffer) {
+                pageState = rust.PagingStateWrapper.fromBuffer(
+                    execOptions.getPageState(),
+                );
+            } else if (typeof execOptions.pageState === "string") {
+                pageState = rust.PagingStateWrapper.fromBuffer(
+                    Buffer.from(execOptions.getPageState(), "hex"),
+                );
+            }
         }
         const rustOptions = queryOptions.queryOptionsIntoWrapper(execOptions);
         let result;

--- a/test/integration/supported/client-each-row-tests.js
+++ b/test/integration/supported/client-each-row-tests.js
@@ -544,9 +544,7 @@ describe("Client", function () {
                 }
             },
         );
-        // TODO: Fix this test
-        // Lack of support for pageState and fetchSize
-        /* vit("2.0", "should use pageState and fetchSize", function (done) {
+        vit("2.0", "should use pageState and fetchSize", function (done) {
             const client = newInstance({
                 keyspace: setupInfo.keyspace,
                 queryOptions: { consistency: types.consistencies.quorum },
@@ -621,10 +619,8 @@ describe("Client", function () {
                 ],
                 done,
             );
-        }); */
-        // TODO: Fix this test
-        // No support for pagingState variable
-        /* vit("2.0", "should expose result.nextPage() method", function (done) {
+        });
+        vit("2.0", "should expose result.nextPage() method", function (done) {
             const client = newInstance({
                 keyspace: setupInfo.keyspace,
                 queryOptions: { consistency: types.consistencies.quorum },
@@ -709,7 +705,7 @@ describe("Client", function () {
                 ],
                 done,
             );
-        }); */
+        });
         vit(
             "2.0",
             "should not expose result.nextPage() method when no more rows",


### PR DESCRIPTION
Before, the pageState exec option was not taken into account, when executing eachRow endpoint. This PR modifies that endpoint, so it's possible to start executing eachRow from some defined state.

Behavior of other endpoints remains unchanged