### PR TITLE
Update CI triggers

### DIFF
--- a/.github/workflows/check-docs.yml
+++ b/.github/workflows/check-docs.yml
@@ -2,7 +2,11 @@ name: Compile js-doc and build mdBook
 
 on:
   push:
-
+    branches:
+      - "**"
+  pull_request:
+    branches:
+      - '**'
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -6,6 +6,9 @@ env:
   push:
     branches:
       - "**"
+  pull_request:
+    branches:
+      - '**'
 jobs:
   check-code-quality:
     runs-on: ubuntu-latest

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -8,6 +8,9 @@ env:
   push:
     branches:
       - "**"
+  pull_request:
+    branches:
+      - '**'
 jobs:
   build-and-run-examples:
     strategy:

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -11,6 +11,9 @@ env:
   push:
     branches:
       - "**"
+  pull_request:
+    branches:
+      - '**'
 jobs:
   build-and-run-tests:
     strategy:

--- a/.github/workflows/typescript-tests.yml
+++ b/.github/workflows/typescript-tests.yml
@@ -5,6 +5,9 @@ env:
   push:
     branches:
       - "**"
+  pull_request:
+    branches:
+      - '**'
 jobs:
   build-and-run-tests:
     strategy:

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -8,6 +8,9 @@ env:
   push:
     branches:
       - "**"
+  pull_request:
+    branches:
+      - '**'
 jobs:
   build-and-run-tests:
     strategy:


### PR DESCRIPTION
Update CI triggers, so they run also on pull requests. Because until now we worked directly on the main repo, this was not necessary.