### PR TITLE
Update the Host

### DIFF
--- a/lib/host.js
+++ b/lib/host.js
@@ -2,7 +2,6 @@
 
 const events = require("events");
 
-const utils = require("./utils");
 const { throwNotSupported } = require("./new-utils");
 const _rust = require("../index");
 
@@ -80,6 +79,8 @@ class Host extends events.EventEmitter {
     }
 
     /**
+     * This endpoint is not yet implemented, and its usage will throw an error
+     *
      * Determines if the node is UP now (seen as UP by the driver).
      * @returns {boolean}
      */
@@ -88,6 +89,8 @@ class Host extends events.EventEmitter {
     }
 
     /**
+     * This endpoint is not yet implemented, and its usage will throw an error
+     *
      * Determines if the host can be considered as UP.
      * Deprecated: Use {@link Host#isUp()} instead.
      * @returns {boolean}
@@ -97,18 +100,24 @@ class Host extends events.EventEmitter {
     }
 
     /**
+     * This endpoint is not yet implemented, and its usage will throw an error
+     *
      * Returns an array containing the Cassandra Version as an Array of Numbers having the major version in the first
      * position.
      * @returns {Array.<Number>}
      */
     getCassandraVersion() {
-        if (!this.cassandraVersion) {
-            return utils.emptyArray;
-        }
-        return this.cassandraVersion
-            .split("-")[0]
-            .split(".")
-            .map((x) => parseInt(x, 10));
+        // We never set the version when creating object from Rust,
+        // so we will explicitly throw an error, when someone attempts to get the version
+        // to avoid any confusion
+        throw new Error(`TODO: Not implemented`);
+        // if (!this.cassandraVersion) {
+        //     return utils.emptyArray;
+        // }
+        // return this.cassandraVersion
+        //     .split("-")[0]
+        //     .split(".")
+        //     .map((x) => parseInt(x, 10));
     }
 
     /**
@@ -198,6 +207,7 @@ class HostMap extends events.EventEmitter {
      * Removes an item from the map.
      * @param {String} key The key of the host
      * @fires HostMap#remove
+     * @deprecated Editing underlying connections will not be supported in this driver
      */
     remove(key) {
         const value = this._items.get(key);
@@ -224,6 +234,7 @@ class HostMap extends events.EventEmitter {
      * Removes multiple hosts from the map.
      * @param {Array.<String>} keys
      * @fires HostMap#remove
+     * @deprecated Editing underlying connections will not be supported in this driver
      */
     removeMultiple(keys) {
         // Clear value cache
@@ -258,6 +269,7 @@ class HostMap extends events.EventEmitter {
      * @param {Host} value The host to be added
      * @fires HostMap#remove
      * @fires HostMap#add
+     * @deprecated Editing underlying connections will not be supported in this driver
      */
     set(key, value) {
         // Clear values cache
@@ -301,6 +313,7 @@ class HostMap extends events.EventEmitter {
      *
      * Removes all items from the map.
      * @returns {Array.<Host>} The previous items
+     * @deprecated Editing underlying connections will not be supported in this driver
      */
     clear() {
         const previousItems = this.values();
@@ -344,7 +357,7 @@ class HostMap extends events.EventEmitter {
         const hostMap = new HostMap();
 
         for (const hostWrapper of hostsList) {
-            hostMap.set(hostWrapper.address, Host.fromRust(hostWrapper));
+            hostMap._items.set(hostWrapper.address, Host.fromRust(hostWrapper));
         }
 
         return hostMap;


### PR DESCRIPTION
Updates the Host class to better reflect the current state of support in the driver. This includes deprecating the edit endpoints of the HostMap class (hosts are read only in the Rust driver), and better indication for the not yet implemented endpoints.