### PR TITLE
Remove encoder from API

### DIFF
--- a/main.js
+++ b/main.js
@@ -33,7 +33,6 @@ const Metadata = require("./lib/metadata");
 exports.metadata = {
   Metadata: Metadata,
 };
-exports.Encoder = require("./lib/encoder");
 exports.geometry = require("./lib/geometry");
 exports.datastax = require("./lib/datastax");
 /**

--- a/test/unit-not-supported/basic-tests.js
+++ b/test/unit-not-supported/basic-tests.js
@@ -692,9 +692,6 @@ describe("exports", function () {
             api.metadata.Metadata,
             require("../../lib/metadata"),
         );
-        assert.ok(api.Encoder);
-        assert.strictEqual(typeof api.Encoder, "function");
-        assert.strictEqual(api.Encoder, require("../../lib/encoder"));
         assert.ok(api.defaultOptions());
         assert.strictEqual(api.tracker, require("../../lib/tracker"));
         assert.strictEqual(typeof api.tracker.RequestTracker, "function");


### PR DESCRIPTION
It turns out, encoder was exposed only in the JS version of the library. There was no typescript support for encoder. This fixes #274