### PR TITLE
Remove the host map edit endpoints

### DIFF
--- a/lib/host.js
+++ b/lib/host.js
@@ -147,7 +147,6 @@ class Host extends events.EventEmitter {
  * It creates an internal copy when adding or removing, making it safe to iterate using the values()
  * method within async operations.
  * @extends events.EventEmitter
- * @constructor
  */
 class HostMap extends events.EventEmitter {
     constructor() {
@@ -200,97 +199,24 @@ class HostMap extends events.EventEmitter {
     }
 
     /**
-     * # WARNING:
-     * Editing host map does not affect the connection to the database.
-     * You only edit the local copy of the connected hosts.
-     *
-     * Removes an item from the map.
-     * @param {String} key The key of the host
-     * @fires HostMap#remove
-     * @deprecated Editing underlying connections will not be supported in this driver
+     * @deprecated Not supported by the driver. Usage will throw an error.
      */
-    remove(key) {
-        const value = this._items.get(key);
-        if (value === undefined) {
-            return;
-        }
-
-        // Clear cache
-        this._values = null;
-
-        // Copy the values
-        const copy = new Map(this._items);
-        copy.delete(key);
-
-        this._items = copy;
-        this.emit("remove", value);
+    remove() {
+        throwNotSupported("HostMap.remove");
     }
 
     /**
-     * # WARNING:
-     * Editing host map does not affect the connection to the database.
-     * You only edit the local copy of the connected hosts.
-     *
-     * Removes multiple hosts from the map.
-     * @param {Array.<String>} keys
-     * @fires HostMap#remove
-     * @deprecated Editing underlying connections will not be supported in this driver
+     * @deprecated Not supported by the driver. Usage will throw an error.
      */
-    removeMultiple(keys) {
-        // Clear value cache
-        this._values = null;
-
-        // Copy the values
-        const copy = new Map(this._items);
-        const removedHosts = [];
-
-        for (const key of keys) {
-            const h = copy.get(key);
-
-            if (!h) {
-                continue;
-            }
-
-            removedHosts.push(h);
-            copy.delete(key);
-        }
-
-        this._items = copy;
-        removedHosts.forEach((h) => this.emit("remove", h));
+    removeMultiple() {
+        throwNotSupported("HostMap.removeMultiple");
     }
 
     /**
-     * # WARNING:
-     * Editing host map does not affect the connection to the database.
-     * You only edit the local copy of the connected hosts.
-     *
-     * Adds a new item to the map.
-     * @param {String} key The key of the host
-     * @param {Host} value The host to be added
-     * @fires HostMap#remove
-     * @fires HostMap#add
-     * @deprecated Editing underlying connections will not be supported in this driver
+     * @deprecated Not supported by the driver. Usage will throw an error.
      */
-    set(key, value) {
-        // Clear values cache
-        this._values = null;
-
-        const originalValue = this._items.get(key);
-        if (originalValue) {
-            // The internal structure does not change
-            this._items.set(key, value);
-            // emit a remove followed by a add
-            this.emit("remove", originalValue);
-            this.emit("add", value);
-            return;
-        }
-
-        // Copy the values
-        const copy = new Map(this._items);
-        copy.set(key, value);
-        this._items = copy;
-        this.emit("add", value);
-        return value;
+    set() {
+        throwNotSupported("HostMap.set");
     }
 
     /**
@@ -307,27 +233,10 @@ class HostMap extends events.EventEmitter {
     }
 
     /**
-     * # WARNING:
-     * Editing host map does not affect the connection to the database.
-     * You only edit the local copy of the connected hosts.
-     *
-     * Removes all items from the map.
-     * @returns {Array.<Host>} The previous items
-     * @deprecated Editing underlying connections will not be supported in this driver
+     * @deprecated Not supported by the driver. Usage will throw an error.
      */
     clear() {
-        const previousItems = this.values();
-
-        // Clear cache
-        this._values = null;
-
-        // Clear items
-        this._items = new Map();
-
-        // Emit events
-        previousItems.forEach((h) => this.emit("remove", h));
-
-        return previousItems;
+        throwNotSupported("HostMap.clear");
     }
 
     inspect() {


### PR DESCRIPTION
Fully removes the HostMap edit endpoints. See the discussion in #269 for the motivation for this change.