### PR TITLE
Remove multilingual option for md book

### DIFF
--- a/docs/book.toml
+++ b/docs/book.toml
@@ -1,7 +1,6 @@
 [book]
 authors = []
 language = "en"
-multilingual = false
 src = "src"
 title = "ScyllaDB JavaScript Driver"
 


### PR DESCRIPTION
With the release of md book 0.5.0 multilingual option was removed. This commit removes this option, as keeping it causes the build to fail. See: https://github.com/rust-lang/mdBook/blob/master/CHANGELOG.md#config-changes