### PR TITLE
Fix async iterators

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -592,7 +592,20 @@ class Client extends events.EventEmitter {
         }
         // result[0] - information about page state
         // result[1] - object representing result itself
-        result[1] = new ResultSet(result[1], result[0]);
+        let resultSet = new ResultSet(result[1], result[0]);
+        if (result[0].hasNextPage()) {
+            resultSet.nextPageAsync = async (pageState) => {
+                return (
+                    await this.#rustyPaged(
+                        query,
+                        params,
+                        execOptions,
+                        pageState,
+                    )
+                )[1];
+            };
+        }
+        result[1] = resultSet;
         return result;
     }
 

--- a/test/integration/supported/paging-tests.js
+++ b/test/integration/supported/paging-tests.js
@@ -85,9 +85,7 @@ module.exports = function (keyspace, prepare) {
         });
 
         if (Symbol.asyncIterator) {
-            // No support for async iterator
-            // TODO: Fix those tests
-            /* it("should retrieve the following pages with async iterator", async () => {
+            it("should retrieve the following pages with async iterator", async () => {
                 // Use a small fetch size for testing, usually should be in the hundreds or thousands
                 const fetchSize = 11;
                 const rs = await client.execute(query, [keyA], {
@@ -135,7 +133,7 @@ module.exports = function (keyspace, prepare) {
                     rows1.map((row) => row["id2"]),
                     rows2.map((row) => row["id2"]),
                 );
-            }); */
+            });
 
             it("should return the first page when only there is a single result page", async () => {
                 const rs = await client.execute(query, [keyB], {


### PR DESCRIPTION
Before this commit, we didn't set the nextPageAsync in the result set. This commit creates this filed in the result set,
in the client.#rustyPaged endpoint.


While this wasn't tracked in the issue, this PR adds support for nextPageAsync field, as well as async iterators over Result sets (`resultSet asyc iterator` from feature status)