### PR TITLE
Split benchmark into separate package

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -26,6 +26,8 @@ jobs:
       - name: Build
         run: ${{ matrix.settings.build }}
         shell: bash
+      - name: Build rust benchmarks
+        run: cargo build -p benchmark
       - name: Install benchmarks dependencies
         run: |
           cd benchmark

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,9 @@ openssl = "0.10.70"
 [lints.rust]
 unsafe-op-in-unsafe-fn = "warn"
 
+[workspace]
+members = ["benchmark"]
+
 [build-dependencies]
 napi-build = "2.1.5"
 
@@ -32,22 +35,3 @@ strip = "symbols"
 [profile.dev]
 panic = "abort"
 
-[[bin]]
-name = "select_benchmark"
-path = "benchmark/logic_rust/select.rs"
-
-[[bin]]
-name = "insert_benchmark"
-path = "benchmark/logic_rust/insert.rs"
-
-[[bin]]
-name = "concurrent_insert_benchmark"
-path = "benchmark/logic_rust/concurrent_insert.rs"
-
-[[bin]]
-name = "concurrent_select_benchmark"
-path = "benchmark/logic_rust/concurrent_select.rs"
-
-[[bin]]
-name = "batch_benchmark"
-path = "benchmark/logic_rust/batch.rs"

--- a/benchmark/Cargo.toml
+++ b/benchmark/Cargo.toml
@@ -1,0 +1,30 @@
+[package]
+edition = "2024"
+name = "benchmark"
+version = "0.0.0"
+
+[dependencies]
+scylla = { version = "1.4.0", features = [] }
+tokio = { version = "1.34", features = ["full"] }
+uuid = "1"
+futures = "0.3"
+
+[[bin]]
+name = "select_benchmark"
+path = "logic_rust/select.rs"
+
+[[bin]]
+name = "insert_benchmark"
+path = "logic_rust/insert.rs"
+
+[[bin]]
+name = "concurrent_insert_benchmark"
+path = "logic_rust/concurrent_insert.rs"
+
+[[bin]]
+name = "concurrent_select_benchmark"
+path = "logic_rust/concurrent_select.rs"
+
+[[bin]]
+name = "batch_benchmark"
+path = "logic_rust/batch.rs"


### PR DESCRIPTION
This allows to avoid building benchmarks with npm run build, and allows to build it with cargo build -p benchmark.

This allows to save CI time for tasks that do need benchmarks