### PR TITLE
Update cargo toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ napi-build = "2.1.5"
 
 [profile.release]
 lto = true
-strip = "symbols"
+panic = "abort"
 
 [profile.dev]
 panic = "abort"


### PR DESCRIPTION
This updates two things in the cargo.toml:
1. Panic mode in release mode. See #47 for motivation of this change.
2. Remove strip flag from the release mode. Why: This flag was part of the napi auto-generated template. The binary built without this flag is about ~15% bigger (4.4MB -> 5MB). This increase allows a better collection of crash logs (as we obtain full stack trace) during panics that are meant to indicate driver bugs.

This change also matches the rust drier (which does not strip symbols)

Fixes: #47 