### PR TITLE
Add MacOS to integration tests CI

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -15,7 +15,7 @@ env:
     branches:
       - '**'
 jobs:
-  build-and-run-tests:
+  linux-integration-tests:
     strategy:
       fail-fast: false
       matrix:
@@ -52,3 +52,53 @@ jobs:
           CCM_IS_SCYLLA: "true"
           CCM_PATH: "./scylla-ccm"
         run: npm run integration
+  macos-integration-tests:
+    strategy:
+      fail-fast: false
+      matrix:
+        settings:
+          - host: macos-15-intel
+            target: x86_64-apple-darwin
+            build: npm run build -- --target x86_64-apple-darwin
+    name: Build and run integration tests - ${{ matrix.settings.target }} - node@20
+    runs-on: ${{ matrix.settings.host }}
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/setup
+        with:
+          host: ${{ matrix.settings.host }}
+          target: ${{ matrix.settings.target }}
+      - uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '8'
+      - name: Install ccm
+        # We need a copy of the repo for the ssl tests.
+        # When installing ccm as a package, we do not save the certificates, 
+        # that are present in the ./ssl directory
+        run: |
+          git clone https://github.com/scylladb/scylla-ccm.git
+          python3 -m venv ./venv
+          source ./venv/bin/activate
+          pip install https://github.com/adespawn/scylla-ccm/archive/macos-proper-fix.zip
+      - name: Enable interfaces
+        # We need to manually enable the interfaces on macos
+        # https://github.com/scylladb/scylla-ccm?tab=readme-ov-file#requirements
+        run: |
+          sudo ifconfig lo0 alias 127.0.0.2 up
+          sudo ifconfig lo0 alias 127.0.0.3 up
+          sudo ifconfig lo0 alias 127.0.0.4 up
+          sudo ifconfig lo0 alias 127.0.0.5 up
+          sudo ifconfig lo0 alias 127.0.0.6 up
+      - name: Build
+        run: ${{ matrix.settings.build }}
+        shell: bash
+      - name: Run integration tests on cassandra
+        env:
+          CUSTOM_JAVA_HOME: __USE_JAVA_IN_PATH__ 
+          CCM_IS_SCYLLA: "false"
+          CCM_PATH: "./scylla-ccm"
+        run: |
+          source ./venv/bin/activate 
+          npm run integration

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
   "napi": {
     "binary-name": "scylladb-driver-alpha",
     "targets": [
-      "x86_64-unknown-linux-gnu"
+      "x86_64-unknown-linux-gnu",
+      "x86_64-apple-darwin"
     ]
   },
   "repository": {


### PR DESCRIPTION
This adds a new part of the CI workflow to run integration tests on
intel MacOS with Cassandra CCM.

Why not ScyllaDB? It's not supported on MacOS.

What about https://github.com/scylladb/nodejs-rs-driver/issues/244?
If this appears to be a problem, we can move this test to extended
CI, where it will not hurt us so much to have a flaky test
(especially if this is a decently rare chance to fail).

What about M chips (arm)?
The Java source we use for CCM does not support JAVA 8 on this platform.
Using Java 11 causes CI to fail (ccm just never starts the nodes).
(See: https://github.com/scylladb/nodejs-rs-driver/actions/runs/21636604746/job/62363768675).

At some point I may try to search for a different Java provider,
that does support this architecture. For now we limit ourselves
to intel Macs only.

Progress towards: #50 #292 