### PR TITLE
Named parameters

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -176,8 +176,9 @@ class Client extends events.EventEmitter {
      */
     async prepareStatement(statement) {
         let expectedTypes = await this.rustClient.prepareStatement(statement);
-        let types = expectedTypes.map((t) => convertComplexType(t));
-        return new PreparedInfo(types, statement);
+        let types = expectedTypes.map((t) => convertComplexType(t[0]));
+        let boundParamNames = expectedTypes.map((t) => t[1].toLowerCase());
+        return new PreparedInfo(types, statement, boundParamNames);
     }
 
     /**
@@ -322,7 +323,7 @@ class Client extends events.EventEmitter {
     /**
      * Wrapper for executing queries by rust driver
      * @param {string | PreparedInfo} query
-     * @param {Array} params
+     * @param {Array | Object} params
      * @param {ExecutionOptions} execOptions
      * @returns {Promise<ResultSet>}
      * @package
@@ -350,6 +351,10 @@ class Client extends events.EventEmitter {
                 prepared = await this.prepareStatement(query);
             } else {
                 prepared = query;
+            }
+
+            if (withNamedParameters) {
+                params = utils.adaptNamedParamsPrepared(params, prepared);
             }
 
             let encoded = encodeParams(prepared.types, params, this.#encoder);
@@ -500,7 +505,7 @@ class Client extends events.EventEmitter {
     /**
      * Execute a single page of query
      * @param {string} query
-     * @param {Array} params
+     * @param {Array | Object} params
      * @param {ExecutionOptions} execOptions
      * @param {rust.PagingStateWrapper|Buffer} [pageState]
      * @returns {Promise<Array<rust.PagingStateResponseWrapper, ResultSet>>} should be Promise<[rust.PagingStateResponseWrapper, ResultSet]>
@@ -542,6 +547,10 @@ class Client extends events.EventEmitter {
                 prepared = await this.prepareStatement(query);
             } else {
                 prepared = query;
+            }
+
+            if (withNamedParameters) {
+                params = utils.adaptNamedParamsPrepared(params, prepared);
             }
 
             let encoded = encodeParams(prepared.types, params, this.#encoder);
@@ -729,6 +738,10 @@ class Client extends events.EventEmitter {
                 }
                 types = prepared.types;
                 statement = prepared.statement;
+
+                if (isNamedParameters(params, execOptions)) {
+                    params = utils.adaptNamedParamsPrepared(params, prepared);
+                }
             } else {
                 types = hints[i] || [];
             }

--- a/lib/client.js
+++ b/lib/client.js
@@ -3,7 +3,11 @@
 
 const events = require("events");
 const util = require("util");
-const { throwNotSupported, PreparedInfo } = require("./new-utils.js");
+const {
+    throwNotSupported,
+    isNamedParameters,
+    PreparedInfo,
+} = require("./new-utils.js");
 
 const utils = require("./utils.js");
 const errors = require("./errors.js");
@@ -324,18 +328,7 @@ class Client extends events.EventEmitter {
      * @package
      */
     async rustyExecute(query, params, execOptions) {
-        if (
-            // !execOptions.isPrepared() &&
-            params &&
-            !Array.isArray(params)
-            // && !types.protocolVersion.supportsNamedParameters(version)
-        ) {
-            throw new Error(`TODO: Implement any support for named parameters`);
-            // // Only Cassandra 2.1 and above supports named parameters
-            // throw new errors.ArgumentError(
-            //   "Named parameters for simple statements are not supported, use prepare flag",
-            // );
-        }
+        let withNamedParameters = isNamedParameters(params, execOptions);
 
         if (!this.connected) {
             // TODO: Check this logic and decide if it's needed. Probably do it while implementing (better) connection
@@ -514,18 +507,7 @@ class Client extends events.EventEmitter {
      * @private
      */
     async #rustyPaged(query, params, execOptions, pageState) {
-        if (
-            !execOptions.isPrepared() &&
-            params &&
-            !Array.isArray(params)
-            // && !types.protocolVersion.supportsNamedParameters(version)
-        ) {
-            throw new Error(`TODO: Implement any support for named parameters`);
-            // // Only Cassandra 2.1 and above supports named parameters
-            // throw new errors.ArgumentError(
-            //   "Named parameters for simple statements are not supported, use prepare flag",
-            // );
-        }
+        let withNamedParameters = isNamedParameters(params, execOptions);
 
         if (!this.connected) {
             // TODO: Check this logic and decide if it's needed. Probably do it while implementing (better) connection

--- a/lib/client.js
+++ b/lib/client.js
@@ -167,14 +167,14 @@ class Client extends events.EventEmitter {
 
     /**
      * Manually prepare query into prepared statement
-     * @param {string} query
+     * @param {string} statement
      * @returns {Promise<list<Object | string>>}
      * Returns a tuple of type object (the format expected by the encoder) and prepared statement wrapper
      * @package
      */
-    async prepareQuery(query) {
-        let expectedTypes = await this.rustClient.prepareStatement(query);
-        let res = [expectedTypes.map((t) => convertComplexType(t)), query];
+    async prepareStatement(statement) {
+        let expectedTypes = await this.rustClient.prepareStatement(statement);
+        let res = [expectedTypes.map((t) => convertComplexType(t)), statement];
         return res;
     }
 
@@ -258,7 +258,7 @@ class Client extends events.EventEmitter {
      *
      * It returns a `Promise` when a `callback` is not provided.
      *
-     * @param {string} query The query to execute.
+     * @param {string} statement The query to execute.
      * @param {Array|Object} [params] Array of parameter values or an associative array (object) containing parameter names
      * as keys and its value.
      * @param {QueryOptions} [options] The query options for the execution.
@@ -352,7 +352,7 @@ class Client extends events.EventEmitter {
             // If the statement is already prepared, skip the preparation process
             // Otherwise call Rust part to prepare a statement
             if (typeof query === "string") {
-                query = await this.prepareQuery(query);
+                query = await this.prepareStatement(query);
             }
 
             /**
@@ -408,7 +408,7 @@ class Client extends events.EventEmitter {
      *
      * The query can be prepared (recommended) or not depending on the [prepare]{@linkcode QueryOptions} flag.
      *
-     * @param {string} query The query to execute
+     * @param {string} statement The query to execute
      * @param {Array|Object} [params] Array of parameter values or an associative array (object) containing parameter names
      * as keys and its value.
      * @param {QueryOptions} [options] The query options.
@@ -511,7 +511,7 @@ class Client extends events.EventEmitter {
 
     /**
      * Execute a single page of query
-     * @param {string} query
+     * @param {string} statement
      * @param {Array} params
      * @param {ExecutionOptions} execOptions
      * @param {rust.PagingStateWrapper|Buffer} [pageState]
@@ -558,7 +558,7 @@ class Client extends events.EventEmitter {
             // If the statement is already prepared, skip the preparation process
             // Otherwise call Rust part to prepare a statement
             if (typeof query === "string") {
-                query = await this.prepareQuery(query);
+                query = await this.prepareStatement(query);
             }
 
             /**
@@ -629,7 +629,7 @@ class Client extends events.EventEmitter {
      * The query can be prepared (recommended) or not depending on {@link QueryOptions}.prepare flag. Retries on multiple
      * hosts if needed.
      *
-     * @param {string} query The query to prepare and execute.
+     * @param {string} statement The query to prepare and execute.
      * @param {Array|Object} [params] Array of parameter values or an associative array (object) containing parameter names
      * as keys and its value
      * @param {QueryOptions} [options] The query options.
@@ -750,7 +750,7 @@ class Client extends events.EventEmitter {
             if (shouldBePrepared) {
                 let prepared = preparedCache.getElement(statement);
                 if (!prepared) {
-                    prepared = await this.prepareQuery(statement);
+                    prepared = await this.prepareStatement(statement);
                     preparedCache.storeElement(statement, prepared);
                 }
                 types = prepared[0];

--- a/lib/client.js
+++ b/lib/client.js
@@ -3,7 +3,7 @@
 
 const events = require("events");
 const util = require("util");
-const { throwNotSupported } = require("./new-utils.js");
+const { throwNotSupported, PreparedInfo } = require("./new-utils.js");
 
 const utils = require("./utils.js");
 const errors = require("./errors.js");
@@ -166,16 +166,14 @@ class Client extends events.EventEmitter {
     }
 
     /**
-     * Manually prepare query into prepared statement
+     * Manually prepare query into prepared statement.
      * @param {string} statement
-     * @returns {Promise<list<Object | string>>}
-     * Returns a tuple of type object (the format expected by the encoder) and prepared statement wrapper
-     * @package
+     * @returns {Promise<PreparedInfo>}
      */
     async prepareStatement(statement) {
         let expectedTypes = await this.rustClient.prepareStatement(statement);
-        let res = [expectedTypes.map((t) => convertComplexType(t)), statement];
-        return res;
+        let types = expectedTypes.map((t) => convertComplexType(t));
+        return new PreparedInfo(types, statement);
     }
 
     /**
@@ -258,7 +256,7 @@ class Client extends events.EventEmitter {
      *
      * It returns a `Promise` when a `callback` is not provided.
      *
-     * @param {string} statement The query to execute.
+     * @param {string} query The query to execute.
      * @param {Array|Object} [params] Array of parameter values or an associative array (object) containing parameter names
      * as keys and its value.
      * @param {QueryOptions} [options] The query options for the execution.
@@ -319,7 +317,7 @@ class Client extends events.EventEmitter {
 
     /**
      * Wrapper for executing queries by rust driver
-     * @param {string | list<Object | string>} query
+     * @param {string | PreparedInfo} query
      * @param {Array} params
      * @param {ExecutionOptions} execOptions
      * @returns {Promise<ResultSet>}
@@ -349,26 +347,23 @@ class Client extends events.EventEmitter {
         let result;
 
         if (execOptions.isPrepared()) {
+            /**
+             * @type {PreparedInfo}
+             */
+            let prepared;
             // If the statement is already prepared, skip the preparation process
             // Otherwise call Rust part to prepare a statement
             if (typeof query === "string") {
-                query = await this.prepareStatement(query);
+                prepared = await this.prepareStatement(query);
+            } else {
+                prepared = query;
             }
 
-            /**
-             * @type {string}
-             */
-            let statement = query[1];
-            /**
-             * @type {Object}
-             */
-            let expectedTypes = query[0];
-
-            let encoded = encodeParams(expectedTypes, params, this.#encoder);
+            let encoded = encodeParams(prepared.types, params, this.#encoder);
 
             // Execute query
             result = await this.rustClient.executePreparedUnpagedEncoded(
-                statement,
+                prepared.statement,
                 encoded,
                 rustOptions,
             );
@@ -408,7 +403,7 @@ class Client extends events.EventEmitter {
      *
      * The query can be prepared (recommended) or not depending on the [prepare]{@linkcode QueryOptions} flag.
      *
-     * @param {string} statement The query to execute
+     * @param {string} query The query to execute
      * @param {Array|Object} [params] Array of parameter values or an associative array (object) containing parameter names
      * as keys and its value.
      * @param {QueryOptions} [options] The query options.
@@ -511,7 +506,7 @@ class Client extends events.EventEmitter {
 
     /**
      * Execute a single page of query
-     * @param {string} statement
+     * @param {string} query
      * @param {Array} params
      * @param {ExecutionOptions} execOptions
      * @param {rust.PagingStateWrapper|Buffer} [pageState]
@@ -555,26 +550,23 @@ class Client extends events.EventEmitter {
         const rustOptions = execOptions.getRustOptions();
         let result;
         if (execOptions.isPrepared()) {
+            /**
+             * @type {PreparedInfo}
+             */
+            let prepared;
             // If the statement is already prepared, skip the preparation process
             // Otherwise call Rust part to prepare a statement
             if (typeof query === "string") {
-                query = await this.prepareStatement(query);
+                prepared = await this.prepareStatement(query);
+            } else {
+                prepared = query;
             }
 
-            /**
-             * @type {string}
-             */
-            let statement = query[1];
-            /**
-             * @type {Object}
-             */
-            let expectedTypes = query[0];
-
-            let encoded = encodeParams(expectedTypes, params, this.#encoder);
+            let encoded = encodeParams(prepared.types, params, this.#encoder);
 
             // Execute query
             result = await this.rustClient.executeSinglePageEncoded(
-                statement,
+                prepared.statement,
                 encoded,
                 rustOptions,
                 pageState,
@@ -629,7 +621,7 @@ class Client extends events.EventEmitter {
      * The query can be prepared (recommended) or not depending on {@link QueryOptions}.prepare flag. Retries on multiple
      * hosts if needed.
      *
-     * @param {string} statement The query to prepare and execute.
+     * @param {string} query The query to prepare and execute.
      * @param {Array|Object} [params] Array of parameter values or an associative array (object) containing parameter names
      * as keys and its value
      * @param {QueryOptions} [options] The query options.
@@ -753,8 +745,8 @@ class Client extends events.EventEmitter {
                     prepared = await this.prepareStatement(statement);
                     preparedCache.storeElement(statement, prepared);
                 }
-                types = prepared[0];
-                statement = prepared[1];
+                types = prepared.types;
+                statement = prepared.statement;
             } else {
                 types = hints[i] || [];
             }
@@ -851,6 +843,7 @@ class Client extends events.EventEmitter {
      * @returns {void}
      */
 }
+
 /**
  * Callback used by execution methods.
  * @callback ResultCallback

--- a/lib/concurrent/index.js
+++ b/lib/concurrent/index.js
@@ -155,7 +155,7 @@ class ArrayBasedExecutor {
         try {
             let prepared = this._cache.getElement(query);
             if (!prepared) {
-                prepared = await (this._client.prepareQuery(query));
+                prepared = await (this._client.prepareStatement(query));
                 this._cache.storeElement(query, prepared);
             }
             await this._client

--- a/lib/new-utils.js
+++ b/lib/new-utils.js
@@ -142,10 +142,12 @@ class PreparedInfo {
     /**
      * @param {Array<type>} types
      * @param {string} statement
+     * @param {Array<string>} boundParamNames
      */
-    constructor(types, statement) {
+    constructor(types, statement, boundParamNames) {
         this.types = types;
         this.statement = statement;
+        this.boundParamNames = boundParamNames;
     }
 }
 

--- a/lib/new-utils.js
+++ b/lib/new-utils.js
@@ -138,9 +138,21 @@ function ensure64SignedInteger(number, name) {
     }
 }
 
+class PreparedInfo {
+    /**
+     * @param {Array<type>} types
+     * @param {string} statement
+     */
+    constructor(types, statement) {
+        this.types = types;
+        this.statement = statement;
+    }
+}
+
 exports.throwNotSupported = throwNotSupported;
 exports.napiErrorHandler = napiErrorHandler;
 exports.bigintToLong = bigintToLong;
 exports.arbitraryValueToBigInt = arbitraryValueToBigInt;
 exports.ensure32SignedInteger = ensure32SignedInteger;
 exports.ensure64SignedInteger = ensure64SignedInteger;
+module.exports.PreparedInfo = PreparedInfo;

--- a/lib/new-utils.js
+++ b/lib/new-utils.js
@@ -151,10 +151,29 @@ class PreparedInfo {
     }
 }
 
+function isNamedParameters(params, execOptions) {
+    if (params && !Array.isArray(params)) {
+        if (!(typeof params == "object")) {
+            throw new customErrors.ArgumentError(
+                `Parameters must be either an array, or named object, found: ${typeof params}`,
+            );
+        }
+        if (!execOptions.isPrepared()) {
+            // This is only a temporary limitation.
+            throw new customErrors.ArgumentError(
+                "Named parameters for simple statements are not supported, use prepare flag",
+            );
+        }
+        return true;
+    }
+    return false;
+}
+
 exports.throwNotSupported = throwNotSupported;
 exports.napiErrorHandler = napiErrorHandler;
 exports.bigintToLong = bigintToLong;
 exports.arbitraryValueToBigInt = arbitraryValueToBigInt;
+exports.isNamedParameters = isNamedParameters;
 exports.ensure32SignedInteger = ensure32SignedInteger;
 exports.ensure64SignedInteger = ensure64SignedInteger;
 module.exports.PreparedInfo = PreparedInfo;

--- a/lib/new-utils.js
+++ b/lib/new-utils.js
@@ -140,7 +140,6 @@ function ensure64SignedInteger(number, name) {
 
 exports.throwNotSupported = throwNotSupported;
 exports.napiErrorHandler = napiErrorHandler;
-exports.throwNotSupported = throwNotSupported;
 exports.bigintToLong = bigintToLong;
 exports.arbitraryValueToBigInt = arbitraryValueToBigInt;
 exports.ensure32SignedInteger = ensure32SignedInteger;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -285,29 +285,23 @@ function validateFn(fn, name) {
 
 /**
  * Adapts the parameters based on the prepared metadata.
- * If the params are passed as an associative array (Object),
- * it adapts the object into an array with the same order as columns
- * @param {Array|Object} params
- * @param {Array} columns
+ * This function assumes params are passed as an associative array (Object),
+ * and it adapts the object into an array with the same order as bound parameters in the prepared statement.
+ * @param {Object} params
+ * @param {PreparedInfo} prepared
  * @returns {Array} Returns an array of parameters.
- * @throws {Error} In case a parameter with a specific name is not defined
+ * @throws {Error} In case a parameter with a specific name is not defined.
  */
-function adaptNamedParamsPrepared(params, columns) {
-    if (!params || Array.isArray(params) || !columns || columns.length === 0) {
-        // params is an array or there aren't parameters
-        return params;
-    }
-    const paramsArray = new Array(columns.length);
+function adaptNamedParamsPrepared(params, prepared) {
+    const paramsArray = new Array(prepared.types.length);
     params = toLowerCaseProperties(params);
-    const keys = {};
-    for (let i = 0; i < columns.length; i++) {
-        const name = columns[i].name;
+    for (let i = 0; i < prepared.types.length; i++) {
+        const name = prepared.boundParamNames[i];
 
         if (!Object.prototype.hasOwnProperty.call(params, name)) {
             throw new errors.ArgumentError(`Parameter "${name}" not defined`);
         }
         paramsArray[i] = params[name];
-        keys[name] = i;
     }
     return paramsArray;
 }

--- a/src/requests/request.rs
+++ b/src/requests/request.rs
@@ -51,12 +51,17 @@ impl QueryOptionsWrapper {
 }
 
 impl PreparedStatementWrapper {
-    /// Get array of expected types for this prepared statement.
-    pub fn get_expected_types(&self) -> Vec<ComplexType<'static>> {
+    /// Get array of (expected type, variable name) pairs for this prepared statement.
+    pub fn get_expected_types(&self) -> Vec<(ComplexType<'static>, String)> {
         self.prepared
             .get_variable_col_specs()
             .iter()
-            .map(|e| ComplexType::new_owned(e.typ().clone()))
+            .map(|e| {
+                (
+                    ComplexType::new_owned(e.typ().clone()),
+                    e.name().to_string(),
+                )
+            })
             .collect()
     }
 }

--- a/src/session.rs
+++ b/src/session.rs
@@ -162,13 +162,13 @@ impl SessionWrapper {
         .await
     }
 
-    /// Prepares a statement through rust driver for a given session
-    /// Return expected types for the prepared statement
-    #[napi(ts_return_type = "Promise<Array<ComplexType>>")]
+    /// Prepares a statement through rust driver for a given session.
+    /// Returns (expected type, variable name) pairs for the prepared statement.
+    #[napi(ts_return_type = "Promise<Array<[ComplexType, string]>>")]
     pub async fn prepare_statement(
         &self,
         statement: String,
-    ) -> JsResult<Vec<ComplexType<'static>>> {
+    ) -> JsResult<Vec<(ComplexType<'static>, String)>> {
         with_custom_error_async(async || {
             let statement: Statement = statement.into();
             let w = PreparedStatementWrapper {
@@ -177,7 +177,8 @@ impl SessionWrapper {
                     .add_prepared_statement(&statement) // TODO: change for add_prepared_statement_to_owned after it is made public
                     .await?,
             };
-            ConvertedResult::Ok(w.get_expected_types())
+            let types = w.get_expected_types();
+            ConvertedResult::Ok(types)
         })
         .await
     }

--- a/src/tests/to_napi_obj_tests.rs
+++ b/src/tests/to_napi_obj_tests.rs
@@ -35,8 +35,8 @@ pub fn tests_named_map_struct() -> Coord {
 /// - `1` -> `{ kind: 1 }` (Green)
 /// - `3` -> `{ kind: 3, r: 128, g: 0, b: 255 }` (Custom)
 #[napi]
-pub fn tests_named_map_enum(case: i32) -> Color {
-    match case {
+pub fn tests_named_map_enum(case_id: i32) -> Color {
+    match case_id {
         0 => Color::Red,
         1 => Color::Green,
         3 => Color::Custom {

--- a/test/integration/supported/client-batch-tests.js
+++ b/test/integration/supported/client-batch-tests.js
@@ -914,9 +914,7 @@ describe("Client @SERVER_API", function () {
                 );
             },
         );
-        // No support for named parameters
-        // TODO: Fix this test
-        /* vit("2.0", "should allow named parameters", function (done) {
+        vit("2.0", "should allow named parameters", function (done) {
             const client = newInstance();
             const id1 = types.Uuid.random();
             const id2 = types.Uuid.random();
@@ -928,6 +926,7 @@ describe("Client @SERVER_API", function () {
                         table1,
                     ),
                     params: {
+                        // eslint-disable-next-line camelcase
                         text_SAMPLE: "named params",
                         paramID: id1,
                         time: types.TimeUuid.now(),
@@ -990,7 +989,7 @@ describe("Client @SERVER_API", function () {
                     );
                 },
             );
-        }); */
+        });
 
         vit(
             "2.0",

--- a/test/integration/supported/client-execute-prepared-tests.js
+++ b/test/integration/supported/client-execute-prepared-tests.js
@@ -540,10 +540,7 @@ describe("Client @SERVER_API", function () {
                 done,
             );
         });
-
-        // No support for named parameters
-        // TODO: fix this test
-        /* describe("with named parameters", function () {
+        describe("with named parameters", function () {
             vit("2.0", "should allow an array of parameters", function (done) {
                 const query = util.format(
                     "SELECT * FROM %s WHERE id1 = :id1",
@@ -626,7 +623,7 @@ describe("Client @SERVER_API", function () {
                     );
                 },
             );
-        }); */
+        });
 
         it("should encode and decode maps using Map polyfills", function (done) {
             const client = newInstance({


### PR DESCRIPTION
This PR introduces support for named parameters in prepared (queries/statements). By reusing handling logic (code in `utils.js`), I aim to keep the API compatibility with DSx driver.

At a later point, we can have a discussion about whether we want to still accept case-insensitive parameters, or do we want to enforce case sensitivity.

This does not fully close​ #99, as the DSx driver had support for named parameters in unprepared (queries/statements) in some special cases (when type hints were used in a specific way). Such support will be added in the following PRs.