### PR TITLE
Client refactors

### DIFF
--- a/lib/client-options.js
+++ b/lib/client-options.js
@@ -477,7 +477,7 @@ function defaultOptions() {
  * Extends and validates the user options
  * @param {Object} [baseOptions] The source object instance that will be overridden
  * @param {Object} userOptions
- * @returns {Object}
+ * @returns {ClientOptions}
  */
 function extend(baseOptions, userOptions) {
     if (arguments.length === 1) {

--- a/lib/client.js
+++ b/lib/client.js
@@ -299,9 +299,7 @@ class Client extends events.EventEmitter {
             const execOptions = this.createOptions(options);
             if (execOptions.isPaged()) {
                 return promiseUtils.optionalCallback(
-                    this.#rustyPaged(query, params, execOptions).then(
-                        (e) => e[1],
-                    ),
+                    this.#rustyPaged(query, params, execOptions),
                     callback,
                 );
             }
@@ -458,8 +456,7 @@ class Client extends events.EventEmitter {
 
         /**
          * @param {Error} err
-         * @param {Array<rust.PagingStateResponseWrapper, ResultSet>} result
-         * Should be [rust.PagingStateResponseWrapper, ResultSet]
+         * @param {ResultSet} result
          */
         function pageCallback(err, result) {
             if (err) {
@@ -468,32 +465,29 @@ class Client extends events.EventEmitter {
             /**
              * Next requests in case paging (auto or explicit) is used
              */
-            let lastPagingState = result[0];
-            let queryResult = result[1];
+            rowLength += result.rowLength;
 
-            rowLength += queryResult.rowLength;
-
-            if (queryResult.rows) {
-                queryResult.rows.forEach((value, index) => {
+            if (result.rows) {
+                result.rows.forEach((value, index) => {
                     rowCallback(index, value);
                 });
             }
 
-            if (lastPagingState) {
+            if (result.innerPageState) {
                 // Use new page state as next request page state
-                pagingState = lastPagingState;
+                pagingState = result.innerPageState;
 
                 if (execOptions.isAutoPage()) {
                     // Issue next request for the next page
                     return nextPage();
                 }
                 // Allows for explicit (manual) paging, in case the caller needs it
-                queryResult.nextPage = nextPage;
+                result.nextPage = nextPage;
             }
 
             // Finished auto-paging
-            queryResult.rowLength = rowLength;
-            callback(null, queryResult);
+            result.rowLength = rowLength;
+            callback(null, result);
         }
 
         promiseUtils.toCallback(
@@ -508,7 +502,7 @@ class Client extends events.EventEmitter {
      * @param {Array | Object} params
      * @param {ExecutionOptions} execOptions
      * @param {rust.PagingStateWrapper|Buffer} [pageState]
-     * @returns {Promise<Array<rust.PagingStateResponseWrapper, ResultSet>>} should be Promise<[rust.PagingStateResponseWrapper, ResultSet]>
+     * @returns {Promise<ResultSet>}
      * @private
      */
     async #rustyPaged(query, params, execOptions, pageState) {
@@ -597,9 +591,7 @@ class Client extends events.EventEmitter {
                 );
             };
         }
-        result[1] = resultSet;
-
-        return result;
+        return resultSet;
     }
 
     /**

--- a/lib/client.js
+++ b/lib/client.js
@@ -332,6 +332,7 @@ class Client extends events.EventEmitter {
         // This should probably be re-worked when stabilizing the API. For now I do not want to restrict the API to avoid
         // accidentally breaking compatibility...
         const paged = pageState !== undefined;
+        pageState = normalizePagingState(pageState, execOptions);
 
         let withNamedParameters = isNamedParameters(params, execOptions);
 
@@ -339,23 +340,6 @@ class Client extends events.EventEmitter {
             // TODO: Check this logic and decide if it's needed. Probably do it while implementing (better) connection
             // // Micro optimization to avoid an async execution for a simple check
             await this.#connect();
-        }
-
-        if (paged) {
-            if (pageState instanceof Buffer) {
-                pageState = rust.PagingStateWrapper.fromBuffer(pageState);
-            } else if (pageState == null) {
-                // Take the page state option into account only when we don't pass it explicitly (it's done only in eachRow)
-                if (execOptions.getPageState() instanceof Buffer) {
-                    pageState = rust.PagingStateWrapper.fromBuffer(
-                        execOptions.getPageState(),
-                    );
-                } else if (typeof execOptions.pageState === "string") {
-                    pageState = rust.PagingStateWrapper.fromBuffer(
-                        Buffer.from(execOptions.getPageState(), "hex"),
-                    );
-                }
-            }
         }
 
         let rustOptions = execOptions.getRustOptions();
@@ -798,6 +782,49 @@ class Client extends events.EventEmitter {
      * @param {ResultSet | PromiseLike<ResultSet>} value
      * @returns {void}
      */
+}
+
+/**
+ * This function normalizes the type, and combines all possible page state sources.
+ *
+ * Page state can come from two sources:
+ * - pageState variable: when we execute the following page of the query
+ * - execOptions: when the user start a new query from requested state
+ *
+ * PageState has a priority over execOptions, as execOptions.pageState
+ * will not be cleared for the following pages of the execution.
+ *
+ * @param {rust.PagingStateWrapper|Buffer|null|undefined} pageState
+ * @param {ExecutionOptions} execOptions
+ * @returns {rust.PagingStateWrapper|undefined}
+ */
+function normalizePagingState(pageState, execOptions) {
+    let optionsPageState = execOptions.getPageState();
+    switch (true) {
+        // Paging is disabled, so we do not care about value of paging state
+        case pageState === undefined:
+            return undefined;
+        // Paging is enabled, but no one has provided starting page state - undefined represents such case
+        case pageState === null && optionsPageState == undefined:
+            return undefined;
+        // Normalize pageState first, since it has a priority over execOptions
+        case pageState instanceof rust.PagingStateWrapper:
+            return pageState;
+        case pageState instanceof Buffer:
+            return rust.PagingStateWrapper.fromBuffer(pageState);
+        // If we have paging enabled, but no page state from last page, normalize exec options page state
+        case pageState === null && optionsPageState instanceof Buffer:
+            return rust.PagingStateWrapper.fromBuffer(optionsPageState);
+        case pageState === null && typeof optionsPageState === "string":
+            return rust.PagingStateWrapper.fromBuffer(
+                Buffer.from(optionsPageState, "hex"),
+            );
+        default:
+            // Only cases with invalid types will be caught here: all accepted types are accepted in the earlier branches
+            throw new TypeError(
+                `Invalid paging state. Provided PageState ${pageState}, execOptions pageState ${optionsPageState}`,
+            );
+    }
 }
 
 /**

--- a/lib/client.js
+++ b/lib/client.js
@@ -345,85 +345,33 @@ class Client extends events.EventEmitter {
         let rustOptions = execOptions.getRustOptions();
 
         /**
-         * @type {rust.QueryResultWrapper}
+         * @type {rust.PagingResultWithExecutor}
          */
-        let result;
-        /**
-         * @type {rust.PagingStateWrapper?}
-         */
-        let resultPageState;
-        /**
-         * @type {rust.QueryExecutor?}
-         */
-        let executor;
+        let resultTuple;
 
         if (execOptions.isPrepared()) {
-            /**
-             * @type {PreparedInfo}
-             */
-            let prepared;
-            // If the statement is already prepared, skip the preparation process
-            // Otherwise call Rust part to prepare a statement
-            if (typeof query === "string") {
-                prepared = await this.prepareStatement(query);
-            } else {
-                prepared = query;
-            }
-
-            if (withNamedParameters) {
-                params = utils.adaptNamedParamsPrepared(params, prepared);
-            }
-
-            let encoded = encodeParams(prepared.types, params, this.#encoder);
-
-            if (paged) {
-                let temp = await this.rustClient.executeSinglePageEncoded(
-                    prepared.statement,
-                    encoded,
-                    rustOptions,
-                    pageState,
-                );
-                result = temp[1];
-                resultPageState = temp[0];
-                executor = temp[2];
-            } else {
-                result = await this.rustClient.executePreparedUnpagedEncoded(
-                    prepared.statement,
-                    encoded,
-                    rustOptions,
-                );
-            }
-        } else {
-            // We do not accept already prepared statements for unprepared queries
-            if (typeof query !== "string") {
-                throw new Error("Expected to obtain a string query");
-            }
-
-            // Parse parameters according to provided hints, with type guessing
-            let encoded = encodeParams(
-                execOptions.getHints() || [],
+            resultTuple = await this.#rustyExecutePrepared(
+                query,
                 params,
-                this.#encoder,
+                rustOptions,
+                withNamedParameters,
+                paged,
+                pageState,
             );
-
-            if (paged) {
-                let temp = await this.rustClient.querySinglePageEncoded(
-                    query,
-                    encoded,
-                    rustOptions,
-                    pageState,
-                );
-                result = temp[1];
-                resultPageState = temp[0];
-                executor = temp[2];
-            } else {
-                result = await this.rustClient.queryUnpagedEncoded(
-                    query,
-                    encoded,
-                    rustOptions,
-                );
-            }
+        } else {
+            resultTuple = await this.#rustyExecuteUnprepared(
+                query,
+                params,
+                execOptions,
+                rustOptions,
+                paged,
+                pageState,
+            );
         }
+
+        let result = resultTuple[1];
+        let resultPageState = resultTuple[0];
+        let executor = resultTuple[2];
 
         let resultSet = new ResultSet(result, this.#encoder, resultPageState);
         if (resultPageState) {
@@ -435,6 +383,110 @@ class Client extends events.EventEmitter {
             };
         }
         return resultSet;
+    }
+
+    /**
+     * @param {string | PreparedInfo} query
+     * @param {Array<any> | Object} params
+     * @param {rust.QueryOptionsWrapper} rustOptions
+     * @param {boolean} withNamedParameters
+     * @param {boolean} paged
+     * @param {rust.PagingStateWrapper} [pageState]
+     * @returns {Promise<rust.PagingResultWithExecutor>}
+     */
+    async #rustyExecutePrepared(
+        query,
+        params,
+        rustOptions,
+        withNamedParameters,
+        paged,
+        pageState,
+    ) {
+        /**
+         * @type {PreparedInfo}
+         */
+        let prepared;
+        // If the statement is already prepared, skip the preparation process
+        // Otherwise call Rust part to prepare a statement
+        if (typeof query === "string") {
+            prepared = await this.prepareStatement(query);
+        } else {
+            prepared = query;
+        }
+
+        if (withNamedParameters) {
+            params = utils.adaptNamedParamsPrepared(params, prepared);
+        }
+
+        let encoded = encodeParams(prepared.types, params, this.#encoder);
+
+        if (paged) {
+            return this.rustClient.executeSinglePageEncoded(
+                prepared.statement,
+                encoded,
+                rustOptions,
+                pageState,
+            );
+        }
+        return [
+            undefined,
+            await this.rustClient.executePreparedUnpagedEncoded(
+                prepared.statement,
+                encoded,
+                rustOptions,
+            ),
+            undefined,
+        ];
+    }
+
+    /**
+     *
+     * @param {string | PreparedInfo} query
+     * @param {Array<any> | Object} params
+     * @param {ExecutionOptions} execOptions
+     * @param {rust.QueryOptionsWrapper} rustOptions
+     * @param {boolean} paged
+     * @param {rust.PagingStateWrapper} [pageState]
+     * @returns {Promise<rust.PagingResultWithExecutor>}
+     */
+    async #rustyExecuteUnprepared(
+        query,
+        params,
+        execOptions,
+        rustOptions,
+        paged,
+        pageState,
+    ) {
+        // We do not accept already prepared statements for unprepared queries
+        if (typeof query !== "string") {
+            throw new Error("Expected to obtain a string query");
+        }
+
+        // Parse parameters according to provided hints, with type guessing
+        let encoded = encodeParams(
+            execOptions.getHints() || [],
+            params,
+            this.#encoder,
+        );
+
+        if (paged) {
+            return this.rustClient.querySinglePageEncoded(
+                query,
+                encoded,
+                rustOptions,
+                pageState,
+            );
+        }
+
+        return [
+            undefined,
+            await this.rustClient.queryUnpagedEncoded(
+                query,
+                encoded,
+                rustOptions,
+            ),
+            undefined,
+        ];
     }
 
     /**

--- a/lib/client.js
+++ b/lib/client.js
@@ -9,6 +9,7 @@ const {
     PreparedInfo,
 } = require("./new-utils.js");
 
+const assert = require("assert");
 const utils = require("./utils.js");
 const errors = require("./errors.js");
 const types = require("./types");
@@ -41,7 +42,7 @@ const { QueryOptions } = require("./query-options.js");
  * The `Client` uses [policies]{@link module:policies} to decide which nodes to connect to, which node
  * to use per each query execution, when it should retry failed or timed-out executions and how reconnection to down
  * nodes should be made.
- * @extends EventEmitter
+ * @extends events.EventEmitter
  * @example <caption>Creating a new client instance</caption>
  * const client = new Client({
  *   contactPoints: ['10.0.1.101', '10.0.1.102'],
@@ -85,7 +86,7 @@ class Client extends events.EventEmitter {
         /**
          * Gets the schema and cluster metadata information.
          * TODO: This field is currently not supported
-         * @type {Metadata}
+         * @type {Metadata | undefined}
          */
         this.metadata = undefined;
 
@@ -128,7 +129,7 @@ class Client extends events.EventEmitter {
      * @type {string | undefined}
      */
     get keyspace() {
-        return this.rustClient.getKeyspace();
+        return this.rustClient.getKeyspace() || undefined;
     }
 
     set keyspace(_) {
@@ -204,7 +205,6 @@ class Client extends events.EventEmitter {
 
     /**
      * Async-only version of {@link Client#connect()}.
-     * @private
      */
     async #connect() {
         if (this.connected) {
@@ -231,6 +231,8 @@ class Client extends events.EventEmitter {
                 description,
                 version,
             ),
+            undefined,
+            undefined,
         );
 
         try {
@@ -262,7 +264,7 @@ class Client extends events.EventEmitter {
      * It returns a `Promise` when a `callback` is not provided.
      *
      * @param {string} query The query to execute.
-     * @param {Array|Object} [params] Array of parameter values or an associative array (object) containing parameter names
+     * @param {Array<any> | Object} [params] Array of parameter values or an associative array (object) containing parameter names
      * as keys and its value.
      * @param {QueryOptions} [options] The query options for the execution.
      * @param {ResultCallback} [callback] Executes callback(err, result) when execution completed. When not defined, the
@@ -288,10 +290,10 @@ class Client extends events.EventEmitter {
             // Set default argument values for optional parameters
             if (typeof options === "function") {
                 callback = options;
-                options = null;
+                options = undefined;
             } else if (typeof params === "function") {
                 callback = params;
-                params = null;
+                params = undefined;
             }
         }
 
@@ -300,16 +302,24 @@ class Client extends events.EventEmitter {
             // The rusty execute will take the page state from options, but we need to indicate whether it's a paged query.
             let pageState = execOptions.isPaged() ? null : undefined;
             return promiseUtils.optionalCallback(
-                this.rustyExecute(query, params, execOptions, pageState),
+                this.rustyExecute(query, params || [], execOptions, pageState),
                 callback,
             );
         } catch (err) {
+            let updatedErr;
+            if (!(err instanceof Error)) {
+                updatedErr = Error(
+                    `Improperly thrown error, got ${err}. This is an internal driver error.`,
+                );
+            } else {
+                updatedErr = err;
+            }
             // There was an error when parsing the user options
             if (callback) {
-                return callback(err);
+                return callback(updatedErr);
             }
 
-            return Promise.reject(err);
+            return Promise.reject(updatedErr);
         }
     }
 
@@ -318,7 +328,7 @@ class Client extends events.EventEmitter {
      * When called with a pageState argument (including null), executes a single-page query.
      * When called without pageState, executes an unpaged query.
      * @param {string | PreparedInfo} query
-     * @param {Array | Object} params
+     * @param {Array<any> | Object} params
      * @param {ExecutionOptions} execOptions
      * @param {rust.PagingStateWrapper|Buffer|null} [pageState] When provided (including null), enables paged execution.
      * When unprovided (undefined), executes an unpaged query.
@@ -334,7 +344,8 @@ class Client extends events.EventEmitter {
         const paged = pageState !== undefined;
         pageState = normalizePagingState(pageState, execOptions);
 
-        let withNamedParameters = isNamedParameters(params, execOptions);
+        // Called only to ensure proper types are provided
+        isNamedParameters(params, execOptions);
 
         if (!this.connected) {
             // TODO: Check this logic and decide if it's needed. Probably do it while implementing (better) connection
@@ -354,7 +365,6 @@ class Client extends events.EventEmitter {
                 query,
                 params,
                 rustOptions,
-                withNamedParameters,
                 paged,
                 pageState,
             );
@@ -375,12 +385,18 @@ class Client extends events.EventEmitter {
 
         let resultSet = new ResultSet(result, this.#encoder, resultPageState);
         if (resultPageState) {
-            resultSet.rawNextPageAsync = async (pageState) => {
-                return await executor.fetchNextPage(
-                    this.rustClient,
-                    rust.PagingStateWrapper.fromBuffer(pageState),
-                );
-            };
+            // If resultPageState then executor must be defined according to type definition.
+            assert(executor instanceof rust.QueryExecutor);
+
+            resultSet.rawNextPageAsync =
+                /** @type {function(Buffer): Promise<rust.PagingResult>} */ async (
+                    pageState,
+                ) => {
+                    return await executor.fetchNextPage(
+                        this.rustClient,
+                        rust.PagingStateWrapper.fromBuffer(pageState),
+                    );
+                };
         }
         return resultSet;
     }
@@ -389,19 +405,11 @@ class Client extends events.EventEmitter {
      * @param {string | PreparedInfo} query
      * @param {Array<any> | Object} params
      * @param {rust.QueryOptionsWrapper} rustOptions
-     * @param {boolean} withNamedParameters
      * @param {boolean} paged
      * @param {rust.PagingStateWrapper} [pageState]
      * @returns {Promise<rust.PagingResultWithExecutor>}
      */
-    async #rustyExecutePrepared(
-        query,
-        params,
-        rustOptions,
-        withNamedParameters,
-        paged,
-        pageState,
-    ) {
+    async #rustyExecutePrepared(query, params, rustOptions, paged, pageState) {
         /**
          * @type {PreparedInfo}
          */
@@ -414,11 +422,21 @@ class Client extends events.EventEmitter {
             prepared = query;
         }
 
-        if (withNamedParameters) {
-            params = utils.adaptNamedParamsPrepared(params, prepared);
+        /**
+         * @type {Array<any>}
+         */
+        let unifiedParams;
+        if (Array.isArray(params)) {
+            unifiedParams = params;
+        } else {
+            unifiedParams = utils.adaptNamedParamsPrepared(params, prepared);
         }
 
-        let encoded = encodeParams(prepared.types, params, this.#encoder);
+        let encoded = encodeParams(
+            prepared.types,
+            unifiedParams,
+            this.#encoder,
+        );
 
         if (paged) {
             return this.rustClient.executeSinglePageEncoded(
@@ -428,6 +446,7 @@ class Client extends events.EventEmitter {
                 pageState,
             );
         }
+        // We add the undefined values here to make the value match PagingResultWithExecutor type
         return [
             undefined,
             await this.rustClient.executePreparedUnpagedEncoded(
@@ -477,7 +496,7 @@ class Client extends events.EventEmitter {
                 pageState,
             );
         }
-
+        // We add the undefined values here to make the value match PagingResultWithExecutor type
         return [
             undefined,
             await this.rustClient.queryUnpagedEncoded(
@@ -503,7 +522,7 @@ class Client extends events.EventEmitter {
      * The query can be prepared (recommended) or not depending on the [prepare]{@linkcode QueryOptions} flag.
      *
      * @param {string} query The query to execute
-     * @param {Array|Object} [params] Array of parameter values or an associative array (object) containing parameter names
+     * @param {Array<any>|Object} [params] Array of parameter values or an associative array (object) containing parameter names
      * as keys and its value.
      * @param {QueryOptions} [options] The query options.
      * @param {function} rowCallback Executes `rowCallback(n, row)` per each row received, where n is the row
@@ -524,18 +543,22 @@ class Client extends events.EventEmitter {
      * client.eachRow(query, params, options, rowCallback, callback);
      */
     eachRow(query, params, options, rowCallback, callback) {
+        /**
+         * @type {Function}
+         */
+        let cleanCallback;
         if (!callback && rowCallback && typeof options === "function") {
-            callback = utils.validateFn(rowCallback, "rowCallback");
+            cleanCallback = utils.validateFn(rowCallback, "rowCallback");
             rowCallback = options;
         } else {
-            callback = callback || utils.noop;
+            cleanCallback = callback || utils.noop;
             rowCallback = utils.validateFn(
                 rowCallback || options || params,
                 "rowCallback",
             );
         }
 
-        params = typeof params !== "function" ? params : null;
+        params = typeof params !== "function" ? params : undefined;
 
         /**
          * @type {ExecutionOptions}
@@ -544,15 +567,23 @@ class Client extends events.EventEmitter {
         try {
             execOptions = DefaultExecutionOptions.create(options, this);
         } catch (e) {
-            return callback(e);
+            return cleanCallback(e);
         }
 
         let rowLength = 0;
+        /**
+         * @type {rust.PagingStateWrapper|null|undefined}
+         */
         let pagingState = null;
 
         const nextPage = () => {
             promiseUtils.toCallback(
-                this.rustyExecute(query, params, execOptions, pagingState),
+                this.rustyExecute(
+                    query,
+                    params || [],
+                    execOptions,
+                    pagingState,
+                ),
                 pageCallback,
             );
         };
@@ -563,7 +594,7 @@ class Client extends events.EventEmitter {
          */
         function pageCallback(err, result) {
             if (err) {
-                return callback(err);
+                return cleanCallback(err);
             }
             /**
              * Next requests in case paging (auto or explicit) is used
@@ -590,11 +621,11 @@ class Client extends events.EventEmitter {
 
             // Finished auto-paging
             result.rowLength = rowLength;
-            callback(null, result);
+            cleanCallback(null, result);
         }
 
         promiseUtils.toCallback(
-            this.rustyExecute(query, params, execOptions, pagingState),
+            this.rustyExecute(query, params || [], execOptions, pagingState),
             pageCallback,
         );
     }
@@ -610,18 +641,22 @@ class Client extends events.EventEmitter {
      * hosts if needed.
      *
      * @param {string} query The query to prepare and execute.
-     * @param {Array|Object} [params] Array of parameter values or an associative array (object) containing parameter names
+     * @param {Array<any>|Object} [params] Array of parameter values or an associative array (object) containing parameter names
      * as keys and its value
      * @param {QueryOptions} [options] The query options.
      * @param {function} [callback] executes callback(err) after all rows have been received or if there is an error
      * @returns {ResultStream}
      */
     stream(query, params, options, callback) {
-        callback = callback || utils.noop;
+        let cleanCallback = callback || utils.noop;
         // NOTE: the nodejs stream maintains yet another internal buffer
         // we rely on the default stream implementation to keep memory
         // usage reasonable.
         const resultStream = new ResultStream({ objectMode: 1 });
+        /**
+         * @param {any} err
+         * @param {{nextPage: function}} result
+         */
         function onFinish(err, result) {
             if (err) {
                 resultStream.emit("error", err);
@@ -641,17 +676,20 @@ class Client extends events.EventEmitter {
             // Explicitly dropping the valve (closure)
             resultStream._valve(null);
             resultStream.add(null);
-            callback(err);
+            cleanCallback(err);
         }
         let sync = true;
         this.eachRow(
             query,
             params,
             options,
-            function rowCallback(n, row) {
+            function rowCallback(/** @type {any} */ n, /** @type {any} */ row) {
                 resultStream.add(row);
             },
-            function eachRowFinished(err, result) {
+            function eachRowFinished(
+                /** @type {any} */ err,
+                /** @type {{nextPage: function}} */ result,
+            ) {
                 if (sync) {
                     // Prevent sync callback
                     return setImmediate(function eachRowFinishedImmediate() {
@@ -670,7 +708,7 @@ class Client extends events.EventEmitter {
      *
      * It returns a `Promise` when a `callback` is not provided.
      *
-     * @param {Array.<string | {query: string, params: (Array|Object)?}>} queries The queries to execute as an Array of strings or as an array
+     * @param {Array.<string | {query: string, params: (Array<any>|Object)?}>} queries The queries to execute as an Array of strings or as an array
      * of object containing the query and params.
      * @param {QueryOptions} [options] The query options.
      * @param {ResultCallback} [callback] Executes callback(err, result) when the batch was executed
@@ -678,7 +716,7 @@ class Client extends events.EventEmitter {
     batch(queries, options, callback) {
         if (!callback && typeof options === "function") {
             callback = options;
-            options = null;
+            options = undefined;
         }
 
         return promiseUtils.optionalCallback(
@@ -689,10 +727,9 @@ class Client extends events.EventEmitter {
 
     /**
      * Async-only version of {@link Client#batch()} .
-     * @param {Array.<string | {query: string, params: (Array|Object)?}>} queries
-     * @param {QueryOptions} options
+     * @param {Array.<string | {query: string, params: (Array<any>|Object)?}>} queries
+     * @param {QueryOptions} [options]
      * @returns {Promise<ResultSet>}
-     * @private
      */
     async #rustyBatch(queries, options) {
         if (!Array.isArray(queries)) {
@@ -720,12 +757,23 @@ class Client extends events.EventEmitter {
             }
             let statement =
                 typeof element === "string" ? element : element.query;
-            let params = element.params || [];
+            /**
+             * @type {Object | Array<any>}
+             */
+            let params =
+                typeof element !== "string" ? element.params || [] : [];
+            /**
+             * @type {Array<any>}
+             */
+            let cleanParams;
             let types;
 
             if (!statement) {
                 throw new errors.ArgumentError(`Invalid query at index ${i}`);
             }
+
+            // Called only to ensure proper types are provided
+            isNamedParameters(params, execOptions);
 
             if (shouldBePrepared) {
                 let prepared = preparedCache.getElement(statement);
@@ -736,18 +784,26 @@ class Client extends events.EventEmitter {
                 types = prepared.types;
                 statement = prepared.statement;
 
-                if (isNamedParameters(params, execOptions)) {
-                    params = utils.adaptNamedParamsPrepared(params, prepared);
+                if (Array.isArray(params)) {
+                    cleanParams = params;
+                } else {
+                    cleanParams = utils.adaptNamedParamsPrepared(
+                        params,
+                        prepared,
+                    );
                 }
             } else {
+                // This assertion will always pass, since we (for now) disallow named parameters in unprepared statements
+                assert(Array.isArray(params));
+                cleanParams = params;
                 types = hints[i] || [];
             }
 
-            if (params) {
-                params = encodeParams(types, params, this.#encoder);
+            if (cleanParams) {
+                cleanParams = encodeParams(types, cleanParams, this.#encoder);
             }
             allQueries.push(statement);
-            parametersRows.push(params);
+            parametersRows.push(cleanParams);
         }
 
         let rustOptions = execOptions.getRustOptions();
@@ -796,12 +852,13 @@ class Client extends events.EventEmitter {
         return promiseUtils.optionalCallback(this.#shutdown(), callback);
     }
 
-    /** @private */
     async #shutdown() {
         this.log(
             "warning",
             "Explicit shutdown is deprecated and may be removed in the future.\n" +
                 "Drop this client to close the connection to the database.",
+            undefined,
+            undefined,
         );
 
         if (!this.connected) {
@@ -810,7 +867,12 @@ class Client extends events.EventEmitter {
         }
 
         if (this.connecting) {
-            this.log("warning", "Shutting down while connecting");
+            this.log(
+                "warning",
+                "Shutting down while connecting",
+                undefined,
+                undefined,
+            );
             // wait until finish connecting for easier troubleshooting
             await promiseUtils.fromEvent(this, "connected");
         }

--- a/lib/client.js
+++ b/lib/client.js
@@ -297,15 +297,10 @@ class Client extends events.EventEmitter {
 
         try {
             const execOptions = this.createOptions(options);
-            if (execOptions.isPaged()) {
-                return promiseUtils.optionalCallback(
-                    this.#rustyPaged(query, params, execOptions),
-                    callback,
-                );
-            }
-
+            // The rusty execute will take the page state from options, but we need to indicate whether it's a paged query.
+            let pageState = execOptions.isPaged() ? null : undefined;
             return promiseUtils.optionalCallback(
-                this.rustyExecute(query, params, execOptions),
+                this.rustyExecute(query, params, execOptions, pageState),
                 callback,
             );
         } catch (err) {
@@ -319,14 +314,25 @@ class Client extends events.EventEmitter {
     }
 
     /**
-     * Wrapper for executing queries by rust driver
+     * Wrapper for executing queries by rust driver.
+     * When called with a pageState argument (including null), executes a single-page query.
+     * When called without pageState, executes an unpaged query.
      * @param {string | PreparedInfo} query
      * @param {Array | Object} params
      * @param {ExecutionOptions} execOptions
+     * @param {rust.PagingStateWrapper|Buffer|null} [pageState] When provided (including null), enables paged execution.
+     * When unprovided (undefined), executes an unpaged query.
      * @returns {Promise<ResultSet>}
      * @package
      */
-    async rustyExecute(query, params, execOptions) {
+    async rustyExecute(query, params, execOptions, pageState) {
+        // Why not just take execOptions.isPaged()?
+        // When executing through eachRow, users may not set the isPaged query option properly
+        // (they may set it to false - this is not checked in any place when going through eachRow API at the moment).
+        // This should probably be re-worked when stabilizing the API. For now I do not want to restrict the API to avoid
+        // accidentally breaking compatibility...
+        const paged = pageState !== undefined;
+
         let withNamedParameters = isNamedParameters(params, execOptions);
 
         if (!this.connected) {
@@ -335,8 +341,37 @@ class Client extends events.EventEmitter {
             await this.#connect();
         }
 
+        if (paged) {
+            if (pageState instanceof Buffer) {
+                pageState = rust.PagingStateWrapper.fromBuffer(pageState);
+            } else if (pageState == null) {
+                // Take the page state option into account only when we don't pass it explicitly (it's done only in eachRow)
+                if (execOptions.getPageState() instanceof Buffer) {
+                    pageState = rust.PagingStateWrapper.fromBuffer(
+                        execOptions.getPageState(),
+                    );
+                } else if (typeof execOptions.pageState === "string") {
+                    pageState = rust.PagingStateWrapper.fromBuffer(
+                        Buffer.from(execOptions.getPageState(), "hex"),
+                    );
+                }
+            }
+        }
+
         let rustOptions = execOptions.getRustOptions();
+
+        /**
+         * @type {rust.QueryResultWrapper}
+         */
         let result;
+        /**
+         * @type {rust.PagingStateWrapper?}
+         */
+        let resultPageState;
+        /**
+         * @type {rust.QueryExecutor?}
+         */
+        let executor;
 
         if (execOptions.isPrepared()) {
             /**
@@ -357,12 +392,23 @@ class Client extends events.EventEmitter {
 
             let encoded = encodeParams(prepared.types, params, this.#encoder);
 
-            // Execute query
-            result = await this.rustClient.executePreparedUnpagedEncoded(
-                prepared.statement,
-                encoded,
-                rustOptions,
-            );
+            if (paged) {
+                let temp = await this.rustClient.executeSinglePageEncoded(
+                    prepared.statement,
+                    encoded,
+                    rustOptions,
+                    pageState,
+                );
+                result = temp[1];
+                resultPageState = temp[0];
+                executor = temp[2];
+            } else {
+                result = await this.rustClient.executePreparedUnpagedEncoded(
+                    prepared.statement,
+                    encoded,
+                    rustOptions,
+                );
+            }
         } else {
             // We do not accept already prepared statements for unprepared queries
             if (typeof query !== "string") {
@@ -376,14 +422,35 @@ class Client extends events.EventEmitter {
                 this.#encoder,
             );
 
-            // Execute query
-            result = await this.rustClient.queryUnpagedEncoded(
-                query,
-                encoded,
-                rustOptions,
-            );
+            if (paged) {
+                let temp = await this.rustClient.querySinglePageEncoded(
+                    query,
+                    encoded,
+                    rustOptions,
+                    pageState,
+                );
+                result = temp[1];
+                resultPageState = temp[0];
+                executor = temp[2];
+            } else {
+                result = await this.rustClient.queryUnpagedEncoded(
+                    query,
+                    encoded,
+                    rustOptions,
+                );
+            }
         }
-        return new ResultSet(result, this.#encoder);
+
+        let resultSet = new ResultSet(result, this.#encoder, resultPageState);
+        if (resultPageState) {
+            resultSet.rawNextPageAsync = async (pageState) => {
+                return await executor.fetchNextPage(
+                    this.rustClient,
+                    rust.PagingStateWrapper.fromBuffer(pageState),
+                );
+            };
+        }
+        return resultSet;
     }
 
     /**
@@ -449,7 +516,7 @@ class Client extends events.EventEmitter {
 
         const nextPage = () => {
             promiseUtils.toCallback(
-                this.#rustyPaged(query, params, execOptions, pagingState),
+                this.rustyExecute(query, params, execOptions, pagingState),
                 pageCallback,
             );
         };
@@ -491,107 +558,9 @@ class Client extends events.EventEmitter {
         }
 
         promiseUtils.toCallback(
-            this.#rustyPaged(query, params, execOptions, pagingState),
+            this.rustyExecute(query, params, execOptions, pagingState),
             pageCallback,
         );
-    }
-
-    /**
-     * Execute a single page of query
-     * @param {string} query
-     * @param {Array | Object} params
-     * @param {ExecutionOptions} execOptions
-     * @param {rust.PagingStateWrapper|Buffer} [pageState]
-     * @returns {Promise<ResultSet>}
-     * @private
-     */
-    async #rustyPaged(query, params, execOptions, pageState) {
-        let withNamedParameters = isNamedParameters(params, execOptions);
-
-        if (!this.connected) {
-            // TODO: Check this logic and decide if it's needed. Probably do it while implementing (better) connection
-            // // Micro optimization to avoid an async execution for a simple check
-            await this.#connect();
-        }
-
-        if (pageState instanceof Buffer) {
-            pageState = rust.PagingStateWrapper.fromBuffer(pageState);
-        } else if (pageState == undefined) {
-            // Take the page state option into account only when we don't pass it explicitly (it's done only in eachRow)
-            if (execOptions.getPageState() instanceof Buffer) {
-                pageState = rust.PagingStateWrapper.fromBuffer(
-                    execOptions.getPageState(),
-                );
-            } else if (typeof execOptions.pageState === "string") {
-                pageState = rust.PagingStateWrapper.fromBuffer(
-                    Buffer.from(execOptions.getPageState(), "hex"),
-                );
-            }
-        }
-        const rustOptions = execOptions.getRustOptions();
-        let result;
-        if (execOptions.isPrepared()) {
-            /**
-             * @type {PreparedInfo}
-             */
-            let prepared;
-            // If the statement is already prepared, skip the preparation process
-            // Otherwise call Rust part to prepare a statement
-            if (typeof query === "string") {
-                prepared = await this.prepareStatement(query);
-            } else {
-                prepared = query;
-            }
-
-            if (withNamedParameters) {
-                params = utils.adaptNamedParamsPrepared(params, prepared);
-            }
-
-            let encoded = encodeParams(prepared.types, params, this.#encoder);
-
-            // Execute query
-            result = await this.rustClient.executeSinglePageEncoded(
-                prepared.statement,
-                encoded,
-                rustOptions,
-                pageState,
-            );
-        } else {
-            // We do not accept already prepared statements for unprepared queries
-            if (typeof query !== "string") {
-                throw new Error("Expected to obtain a string query");
-            }
-            // Parse parameters according to provided hints, with type guessing
-            let encoded = encodeParams(
-                execOptions.getHints() || [],
-                params,
-                this.#encoder,
-            );
-
-            // Execute query
-            result = await this.rustClient.querySinglePageEncoded(
-                query,
-                encoded,
-                rustOptions,
-                pageState,
-            );
-        }
-        /**
-         * @type {rust.QueryExecutor}
-         */
-        let executor = result[2];
-        // result[0] - information about page state
-        // result[1] - object representing result itself
-        let resultSet = new ResultSet(result[1], this.#encoder, result[0]);
-        if (result[0]) {
-            resultSet.rawNextPageAsync = async (pageState) => {
-                return await executor.fetchNextPage(
-                    this.rustClient,
-                    rust.PagingStateWrapper.fromBuffer(pageState),
-                );
-            };
-        }
-        return resultSet;
     }
 
     /**

--- a/lib/client.js
+++ b/lib/client.js
@@ -439,7 +439,7 @@ class Client extends events.EventEmitter {
         );
 
         if (paged) {
-            return this.rustClient.executeSinglePageEncoded(
+            return this.rustClient.executeSinglePage(
                 prepared.statement,
                 encoded,
                 rustOptions,
@@ -449,7 +449,7 @@ class Client extends events.EventEmitter {
         // We add the undefined values here to make the value match PagingResultWithExecutor type
         return [
             undefined,
-            await this.rustClient.executePreparedUnpagedEncoded(
+            await this.rustClient.executePreparedUnpaged(
                 prepared.statement,
                 encoded,
                 rustOptions,
@@ -489,7 +489,7 @@ class Client extends events.EventEmitter {
         );
 
         if (paged) {
-            return this.rustClient.querySinglePageEncoded(
+            return this.rustClient.querySinglePage(
                 query,
                 encoded,
                 rustOptions,
@@ -499,11 +499,7 @@ class Client extends events.EventEmitter {
         // We add the undefined values here to make the value match PagingResultWithExecutor type
         return [
             undefined,
-            await this.rustClient.queryUnpagedEncoded(
-                query,
-                encoded,
-                rustOptions,
-            ),
+            await this.rustClient.queryUnpaged(query, encoded, rustOptions),
             undefined,
         ];
     }
@@ -808,10 +804,7 @@ class Client extends events.EventEmitter {
 
         let rustOptions = execOptions.getRustOptions();
         let batch = this.rustClient.createBatch(allQueries, rustOptions);
-        let wrappedResult = await this.rustClient.batchEncoded(
-            batch,
-            parametersRows,
-        );
+        let wrappedResult = await this.rustClient.batch(batch, parametersRows);
         return new ResultSet(wrappedResult, this.#encoder);
     }
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -416,10 +416,18 @@ class Client extends events.EventEmitter {
         let prepared;
         // If the statement is already prepared, skip the preparation process
         // Otherwise call Rust part to prepare a statement
-        if (typeof query === "string") {
-            prepared = await this.prepareStatement(query);
-        } else {
-            prepared = query;
+
+        switch (true) {
+            case typeof query === "string":
+                prepared = await this.prepareStatement(query);
+                break;
+            case query instanceof PreparedInfo:
+                prepared = query;
+                break;
+            default:
+                throw new TypeError(
+                    `Invalid type for query. Got ${query}, expected string or internal prepared info`,
+                );
         }
 
         /**

--- a/lib/concurrent/index.js
+++ b/lib/concurrent/index.js
@@ -159,7 +159,7 @@ class ArrayBasedExecutor {
                 this._cache.storeElement(query, prepared);
             }
             await this._client
-                .rustyExecute(prepared, params, this._queryOptions)
+                .rustyExecute(prepared, params || [], this._queryOptions)
                 .then((rs) => this._result.setResultItem(index, rs));
         } catch (err) {
             this._setError(index, err);

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -28,7 +28,7 @@ class DriverError extends Error {
  */
 class NoHostAvailableError extends DriverError {
     /**
-     * @param {Object} innerErrors An object map containing the error per host tried.
+     * @param {Object?} innerErrors An object map containing the error per host tried.
      * @param {string} [message]
      */
     constructor(innerErrors, message) {

--- a/lib/metadata/client-state.js
+++ b/lib/metadata/client-state.js
@@ -39,6 +39,7 @@ class ClientState {
 
     static from(_client) {
         this.log("warning", deprecatedMsg);
+        return new ClientState();
     }
 }
 

--- a/lib/new-utils.js
+++ b/lib/new-utils.js
@@ -12,48 +12,6 @@ function throwNotSupported(name) {
     throw new ReferenceError(`${name} is not supported by our driver`);
 }
 
-const errorTypeMap = {
-    ...customErrors,
-    Error,
-    RangeError,
-    ReferenceError,
-    SyntaxError,
-    TypeError,
-};
-
-const concatenationMark = "#";
-
-/**
- * A wrapper function to map napi errors to Node.js errors or custom errors.
- * Because NAPI-RS does not support throwing errors different that Error, for example
- * TypeError, RangeError, etc. or custom, driver-specific errors, this function is used
- * to catch the original error and throw a new one with the appropriate type.
- * This should be used to wrap all NAPI-RS functions that may throw errors.
- *
- * @param {Function} fn The original function to be wrapped.
- * @returns {Function} A wrapped function with error handling logic.
- */
-function napiErrorHandler(fn) {
-    return function (...args) {
-        try {
-            return fn.apply(this, args);
-        } catch (error) {
-            // Check if message is of format errorType#errorMessage, if so map it to
-            // appropriate error, otherwise throw the original error.
-            const [errorType, ...messageParts] =
-                error.message.split(concatenationMark);
-            const message = messageParts.join(concatenationMark);
-
-            if (errorTypeMap[errorType]) {
-                const newError = new errorTypeMap[errorType](message);
-                newError.stack = error.stack;
-                throw newError;
-            }
-            throw error;
-        }
-    };
-}
-
 // maxInt value is based on how does Long split values between internal high and low fields.
 const maxInt = BigInt(0x100000000);
 const minusOne = BigInt(-1);
@@ -174,7 +132,6 @@ function isNamedParameters(params, execOptions) {
 }
 
 exports.throwNotSupported = throwNotSupported;
-exports.napiErrorHandler = napiErrorHandler;
 exports.bigintToLong = bigintToLong;
 exports.arbitraryValueToBigInt = arbitraryValueToBigInt;
 exports.isNamedParameters = isNamedParameters;

--- a/lib/new-utils.js
+++ b/lib/new-utils.js
@@ -6,7 +6,6 @@ const util = require("util");
 const Long = require("long");
 
 /**
- * @param {String} entity
  * @param {String} name
  */
 function throwNotSupported(name) {
@@ -151,6 +150,11 @@ class PreparedInfo {
     }
 }
 
+/**
+ * @param {Array<any> | Object} params
+ * @param {ExecutionOptions} execOptions
+ * @returns {boolean}
+ */
 function isNamedParameters(params, execOptions) {
     if (params && !Array.isArray(params)) {
         if (!(typeof params == "object")) {

--- a/lib/promise-utils.js
+++ b/lib/promise-utils.js
@@ -92,7 +92,7 @@ function newQueryPlan(lbp, keyspace, executionOptions) {
  * When callback is undefined it returns the promise.
  * When using a callback, it will use it as handlers of the continuation of the promise.
  * @param {Promise} promise
- * @param {Function?} callback
+ * @param {Function} [callback]
  * @returns {Promise|undefined}
  */
 function optionalCallback(promise, callback) {

--- a/lib/types/result-set.js
+++ b/lib/types/result-set.js
@@ -45,7 +45,7 @@ class ResultSet {
     /**
      * @param {rust.QueryResultWrapper} result
      * @param {_Encoder} encoder
-     * @param {rust.PagingStateResponseWrapper} [pagingState]
+     * @param {rust.PagingStateWrapper} [pagingState]
      */
     constructor(result, encoder, pagingState) {
         // Old constructor logic only for purpose of unit tests.

--- a/lib/types/result-set.js
+++ b/lib/types/result-set.js
@@ -43,6 +43,13 @@ class ResultSet {
     #encoder;
 
     /**
+     * Internal representation of the page state, used for fetching the next page of results.
+     * @type {rust.PagingStateWrapper?}
+     * @package
+     */
+    innerPageState;
+
+    /**
      * @param {rust.QueryResultWrapper} result
      * @param {_Encoder} encoder
      * @param {rust.PagingStateWrapper} [pagingState]
@@ -104,6 +111,7 @@ class ResultSet {
         this.pageState = null;
 
         if (pagingState) {
+            this.innerPageState = pagingState;
             let rawPageState = pagingState.getRawPageState();
             this.pageState = rawPageState.toString("hex");
             Object.defineProperty(this, "rawPageState", {

--- a/lib/types/result-set.js
+++ b/lib/types/result-set.js
@@ -52,7 +52,7 @@ class ResultSet {
     /**
      * @param {rust.QueryResultWrapper} result
      * @param {_Encoder} encoder
-     * @param {rust.PagingStateWrapper} [pagingState]
+     * @param {rust.PagingStateWrapper | null} [pagingState]
      */
     constructor(result, encoder, pagingState) {
         // Old constructor logic only for purpose of unit tests.
@@ -94,7 +94,7 @@ class ResultSet {
 
         /**
          * Gets the row length of the result, regardless if the result has been buffered or not
-         * @type {Number|undefined}
+         * @type {Number}
          */
         this.rowLength = this.rows ? this.rows.length : 0;
 

--- a/lib/types/result-stream.js
+++ b/lib/types/result-stream.js
@@ -37,7 +37,7 @@ class ResultStream extends Readable {
 
     /**
      * Allows for throttling, helping nodejs keep the internal buffers reasonably sized.
-     * @param {function} readNext function that triggers reading the next result chunk
+     * @param {function?} readNext function that triggers reading the next result chunk
      * @ignore
      */
     _valve(readNext) {

--- a/src/custom-types.d.ts
+++ b/src/custom-types.d.ts
@@ -29,8 +29,12 @@ export type PagingResult = [PagingStateWrapper | null, QueryResultWrapper]
  * Result of a paged query that can be continued via a QueryExecutor.
  * Serialized as a 3-element tuple: [pagingState, result, executor].
  * - pagingState is null when there are no more pages.
+ * 
+ * This type can also be used to represent an unpaged query result, to allow for better code reuse.
+ * This kind of result can be represented by setting pagingState and executor to undefined.
  */
 export type PagingResultWithExecutor = [PagingStateWrapper | null, QueryResultWrapper, QueryExecutor]
+  | [undefined, QueryResultWrapper, undefined]
 
 
 /**

--- a/src/session.rs
+++ b/src/session.rs
@@ -143,7 +143,7 @@ impl SessionWrapper {
     /// -- each value must be tuple of its ComplexType and the value itself.
     /// If the provided types will not be correct, this query will fail.
     #[napi(ts_return_type = "Promise<QueryResultWrapper>")]
-    pub async fn query_unpaged_encoded(
+    pub async fn query_unpaged(
         &self,
         query: String,
         params: Vec<EncodedValuesWrapper>,
@@ -194,7 +194,7 @@ impl SessionWrapper {
     /// Currently `execute_unpaged` from rust driver is used, so no paging is done
     /// and there is no support for any query options
     #[napi(ts_return_type = "Promise<QueryResultWrapper>")]
-    pub async fn execute_prepared_unpaged_encoded(
+    pub async fn execute_prepared_unpaged(
         &self,
         query: String,
         params: Vec<EncodedValuesWrapper>,
@@ -211,7 +211,7 @@ impl SessionWrapper {
     ///
     /// Returns a wrapper of the result provided by the rust driver
     #[napi(ts_return_type = "Promise<QueryResultWrapper>")]
-    pub async fn batch_encoded(
+    pub async fn batch(
         &self,
         batch: &BatchWrapper,
         params: Vec<Vec<EncodedValuesWrapper>>,
@@ -229,7 +229,7 @@ impl SessionWrapper {
     /// For the following pages you need to provide page state
     /// received from the previous page
     #[napi(ts_return_type = "Promise<PagingResultWithExecutor>")]
-    pub async fn query_single_page_encoded(
+    pub async fn query_single_page(
         &self,
         query: String,
         params: Vec<EncodedValuesWrapper>,
@@ -258,7 +258,7 @@ impl SessionWrapper {
     /// For the following pages you need to provide page state
     /// received from the previous page
     #[napi(ts_return_type = "Promise<PagingResultWithExecutor>")]
-    pub async fn execute_single_page_encoded(
+    pub async fn execute_single_page(
         &self,
         query: String,
         params: Vec<EncodedValuesWrapper>,

--- a/test/integration/supported/concurrent/execute-concurrent-tests.js
+++ b/test/integration/supported/concurrent/execute-concurrent-tests.js
@@ -253,6 +253,35 @@ describe("executeConcurrent()", function () {
     });
 
     describe("with different queries and parameters", () => {
+        it("should execute queries with undefined params", () => {
+            const id1 = Uuid.random();
+            const id2 = Uuid.random();
+            const id3 = Uuid.random();
+            const queryAndParameters = [
+                {
+                    query: `INSERT INTO table2 (id, value) VALUES (${id1}, 'no-params')`,
+                    params: undefined,
+                },
+                {
+                    query: `INSERT INTO table2 (id, value) VALUES (${id2}, 'no-params')`,
+                    params: null,
+                },
+                {
+                    query: `INSERT INTO table2 (id, value) VALUES (${id3}, 'no-params')`,
+                },
+            ];
+
+            return executeConcurrent(client, queryAndParameters).then(
+                (result) => {
+                    assert.strictEqual(
+                        result.totalExecuted,
+                        queryAndParameters.length,
+                    );
+                    assert.strictEqual(result.errors.length, 0);
+                },
+            );
+        });
+
         it("should execute the different queries", () => {
             const id = Uuid.random();
             const queryAndParameters = [

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,8 @@
         "noEmit": true,
         "esModuleInterop": true,
         /* Necessary for retrieving driver version from package.json */
-        "resolveJsonModule": true
+        "resolveJsonModule": true,
+        "types": ["node"]
     },
     "include": ["lib/**/*.js", "lib/**/*.ts"]
 }


### PR DESCRIPTION
The main motivation for this refactor is that in the integration tests, we only tested the rusty paged version of the internal interface. This increases the chance of improper updates to the code, as we need to remember to update 2 places instead of 1, and we do not need to unnecessarily extend integration tests to handle both branches.  