### PR TITLE
Experiment with concurrency levels

### DIFF
--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -85,6 +85,10 @@ Each benchmark recreates the table before execution to ensure consistent and iso
 
 Each of the JS benchmarks has an equivalent in Rust. For JS benchmarks, `driver` parameter determines which driver is tested. It can be `scylladb-driver-alpha` or `cassandra-driver`.
 
+For every benchmark you can use default values for either number of queries of concurrency level (supported benchmarks only).
+To use default values in JS benchmarks, provide `default` instead of numerical value for the parameter.
+To use default values in Rust code, do not provide given environment value.
+
 Before running the benchmarks in Rust, remember to build them with flags `--bin -r`.
 
 Concurrent benchmarks in JS first create an array of queries, which are then executed by calling the `executeConcurrent` function.
@@ -92,12 +96,12 @@ Rust benchmarks do not create an array to execute the queries. Queries are gener
 
 - **concurrent insert**
 
-This benchmark uses `executeConcurrent` endpoint to insert `n` rows containing `uuid` and `int` into the database. Afterwards, it checks that the number of rows inserted is correct.
+This benchmark uses `executeConcurrent` endpoint to insert `n` rows containing `uuid` and `int` into the database. Afterwards, it checks that the number of rows inserted is correct. This benchmark can be parametrized by concurrency level.
 
 JS:
 
 ```bash
-node benchmark.js concurrent_insert <driver> <Number of queries>
+node benchmark.js concurrent_insert <driver> <Number of queries> <Concurrency level>
 ```
 
 Rust:
@@ -124,12 +128,14 @@ CNT=<Number of queries> cargo run --bin insert_benchmark -r
 
 - **concurrent_select**
 
-This benchmark first inserts `10` rows containing `uuid` and `int`. Afterwards it uses `executeConcurrent` endpoint to select all of the inserted rows from the database `n` times.
+This benchmark first inserts `10` rows containing `uuid` and `int`.
+Afterwards it uses `executeConcurrent` endpoint to select all of the inserted rows from the database `n` times.
+This benchmark can be parametrized by concurrency level.
 
 JS:
 
 ```bash
-node benchmark.js concurrent_select <driver> <Number of queries>
+node benchmark.js concurrent_select <driver> <Number of queries> <Concurrency level>
 ```
 
 Rust:
@@ -156,12 +162,15 @@ CNT=<Number of queries> cargo run --bin select_benchmark -r
 
 - **concurrent deserialization**
 
-This benchmark uses `executeConcurrent` endpoint to insert `n` rows containing `uuid`, `int`, `timeuuid`, `inet`, `date`, `time` into the database.  Afterwards it uses `executeConcurrent` endpoint to select all (`n`) of the inserted rows from the database `n` times.
+This benchmark uses `executeConcurrent` endpoint to insert `n` rows containing
+`uuid`, `int`, `timeuuid`, `inet`, `date`, `time` into the database.  
+Afterwards it uses `executeConcurrent` endpoint to select all (`n`) of the inserted rows from the database `n` times.
+This benchmark can be parametrized by concurrency level.
 
 JS:
 
 ```bash
-node benchmark.js concurrent_deser <driver> <Number of queries>
+node benchmark.js concurrent_deser <driver> <Number of queries> <Concurrency level>
 ```
 
 Rust:
@@ -188,12 +197,14 @@ CNT=<Number of queries> cargo run --bin deser_benchmark -r
 
 - **concurrent serialization**
 
-This benchmark uses `executeConcurrent` endpoint to insert `n*n` rows containing `uuid`, `int`, `timeuuid`, `inet`, `date`, `time` into the database.
+This benchmark uses `executeConcurrent` endpoint to insert `n*n` rows containing
+`uuid`, `int`, `timeuuid`, `inet`, `date`, `time` into the database.
+This benchmark can be parametrized by concurrency level.
 
 JS:
 
 ```bash
-node benchmark.js concurrent_ser <driver> <Number of queries>
+node benchmark.js concurrent_ser <driver> <Number of queries> <Concurrency level>
 ```
 
 Rust:

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -107,7 +107,7 @@ node benchmark.js concurrent_insert <driver> <Number of queries> <Concurrency le
 Rust:
 
 ```bash
-CNT=<Number of queries> cargo run --bin concurrent_insert_benchmark -r
+CNT=<Number of queries> CONCURRENCY=<Concurrency level> cargo run --bin concurrent_insert_benchmark -r
 ```
 
 - **insert**
@@ -141,7 +141,7 @@ node benchmark.js concurrent_select <driver> <Number of queries> <Concurrency le
 Rust:
 
 ```bash
-CNT=<Number of queries> cargo run --bin concurrent_select_benchmark -r
+CNT=<Number of queries> CONCURRENCY=<Concurrency level> cargo run --bin concurrent_select_benchmark -r
 ```
 
 - **select**
@@ -176,7 +176,7 @@ node benchmark.js concurrent_deser <driver> <Number of queries> <Concurrency lev
 Rust:
 
 ```bash
-CNT=<Number of queries> cargo run --bin concurrent_deser_benchmark -r
+CNT=<Number of queries> CONCURRENCY=<Concurrency level> cargo run --bin concurrent_deser_benchmark -r
 ```
 
 - **deserialization**
@@ -210,7 +210,7 @@ node benchmark.js concurrent_ser <driver> <Number of queries> <Concurrency level
 Rust:
 
 ```bash
-CNT=<Number of queries> cargo run --bin concurrent_ser_benchmark -r
+CNT=<Number of queries> CONCURRENCY=<Concurrency level> cargo run --bin concurrent_ser_benchmark -r
 ```
 
 - **serialization**

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -63,6 +63,8 @@ Result will be saved to `out.svg`. You can read more in the benchmarker document
 
 ## Legacy python script
 
+This script is no longer updated, so it may be broken.
+
 A file that runs all benchmarks: `runner.py`
 
 The script compares benchmark results for our driver, [Cassandra driver](https://github.com/apache/cassandra-nodejs-driver) and [Rust driver](https://github.com/scylladb/scylla-rust-driver). Parameters for the benchmarks can be modified inside it. The result is a `graph.png` file that presents a graph of time on a logarithmic scale. The graphs are uploaded to the provided discord webhook.
@@ -95,7 +97,7 @@ This benchmark uses `executeConcurrent` endpoint to insert `n` rows containing `
 JS:
 
 ```bash
-node concurrent_insert.js <driver> <Number of queries>
+node benchmark.js concurrent_insert <driver> <Number of queries>
 ```
 
 Rust:
@@ -111,7 +113,7 @@ This benchmark executes `n` `client.execute` queries, that insert a single row c
 JS:
 
 ```bash
-node insert.js <driver> <Number of queries>
+node benchmark.js insert <driver> <Number of queries>
 ```
 
 Rust:
@@ -127,7 +129,7 @@ This benchmark first inserts `10` rows containing `uuid` and `int`. Afterwards i
 JS:
 
 ```bash
-node concurrent_select.js <driver> <Number of queries>
+node benchmark.js concurrent_select <driver> <Number of queries>
 ```
 
 Rust:
@@ -143,7 +145,7 @@ This benchmark first inserts 10 rows containing `uuid` and `int`. Afterwards it 
 JS:
 
 ```bash
-node select.js <driver> <Number of queries>
+node benchmark.js select <driver> <Number of queries>
 ```
 
 Rust:
@@ -156,12 +158,15 @@ CNT=<Number of queries> cargo run --bin select_benchmark -r
 
 This benchmark uses `executeConcurrent` endpoint to insert `n` rows containing `uuid`, `int`, `timeuuid`, `inet`, `date`, `time` into the database.  Afterwards it uses `executeConcurrent` endpoint to select all (`n`) of the inserted rows from the database `n` times.
 
-JS: 
+JS:
+
+```bash
+node benchmark.js concurrent_deser <driver> <Number of queries>
 ```
-node concurrent_deser.js <driver> <Number of queries>
-```
+
 Rust:
-```
+
+```bash
 CNT=<Number of queries> cargo run --bin concurrent_deser_benchmark -r
 ```
 
@@ -169,40 +174,47 @@ CNT=<Number of queries> cargo run --bin concurrent_deser_benchmark -r
 
 This benchmark executes `n` `client.execute` queries, that insert a single row containing `uuid`, `int`, `timeuuid`, `inet`, `date`, `time` waiting for the result of the previous query before executing the next one. Afterwards it executes `n` `client.execute` queries, that select all (`n`) of the inserted rows, waiting for the result of the previous query before executing the next one.
 
-JS: 
+JS:
+
+```bash
+node benchmark.js deser <driver> <Number of queries>
 ```
-node deser.js <driver> <Number of queries>
-```
+
 Rust:
-```
+
+```bash
 CNT=<Number of queries> cargo run --bin deser_benchmark -r
 ```
-
-
 
 - **concurrent serialization**
 
 This benchmark uses `executeConcurrent` endpoint to insert `n*n` rows containing `uuid`, `int`, `timeuuid`, `inet`, `date`, `time` into the database.
 
-JS: 
+JS:
+
+```bash
+node benchmark.js concurrent_ser <driver> <Number of queries>
 ```
-node concurrent_ser.js <driver> <Number of queries>
-```
+
 Rust:
-```
+
+```bash
 CNT=<Number of queries> cargo run --bin concurrent_ser_benchmark -r
 ```
 
 - **serialization**
 
-This benchmark executes `n*n` `client.execute` queries, that insert a single row containing `uuid`, `int`, `timeuuid`, `inet`, `date`, `time` waiting for the result of the previous query before executing the next one. 
+This benchmark executes `n*n` `client.execute` queries, that insert a single row containing `uuid`, `int`, `timeuuid`, `inet`, `date`, `time` waiting for the result of the previous query before executing the next one.
 
-JS: 
+JS:
+
+```bash
+node benchmark.js ser <driver> <Number of queries>
 ```
-node ser.js <driver> <Number of queries>
-```
+
 Rust:
-```
+
+```bash
 CNT=<Number of queries> cargo run --bin ser_benchmark -r
 ```
 
@@ -213,7 +225,7 @@ This benchmark uses `client.batch` endpoint to insert `n` rows containing `uuid`
 JS:
 
 ```bash
-node batch.js <driver> <Number of queries>
+node benchmark.js batch <driver> <Number of queries>
 ```
 
 Rust:

--- a/benchmark/logic/batch.js
+++ b/benchmark/logic/batch.js
@@ -1,50 +1,49 @@
 "use strict";
 const async = require("async");
-// Possible values of argv[2] (driver) are scylladb-driver-alpha and cassandra-driver.
-const cassandra = require(process.argv[2]);
 const utils = require("./utils");
 const { exit } = require("process");
 const assert = require("assert");
 
-const client = new cassandra.Client(utils.getClientArgs());
-const iterCnt = parseInt(process.argv[3]);
-// Expectantly determined max batch size, that doesn't cause database error.
-const step = 3971;
+module.exports = function (cassandra, client, stepCount, _concurrencyLevel) {
+    // REMEMBER: update benchmark config.yml when changing the constant value.
+    const iterCnt = stepCount || 3000000;
+    // Experimentally determined max batch size that doesn't cause database error.
+    const batchSize = 3971;
 
-async.series(
-    [
-        function initialize(next) {
-            utils.prepareDatabase(client, utils.tableSchemaBasic, next);
-        },
-        async function insert(next) {
-            // Limit batch size to step size
-            for (let z = 0; z * step < iterCnt; z++) {
-                let queries = [];
-                for (let i = 0; i < Math.min(iterCnt - (z * step), step); i++) {
-                    queries.push({
-                        query: 'INSERT INTO benchmarks.basic (id, val) VALUES (?, ?)',
-                        params: [cassandra.types.Uuid.random(), 10]
-                    });
+    async.series(
+        [
+            function initialize(next) {
+                utils.prepareDatabase(client, utils.tableSchemaBasic, next);
+            },
+            async function insert(next) {
+                for (let z = 0; z * batchSize < iterCnt; z++) {
+                    let queries = [];
+                    for (let i = 0; i < Math.min(iterCnt - (z * batchSize), batchSize); i++) {
+                        queries.push({
+                            query: 'INSERT INTO benchmarks.basic (id, val) VALUES (?, ?)',
+                            params: [cassandra.types.Uuid.random(), 10]
+                        });
+                    }
+                    try {
+                        await client.batch(queries, { prepare: true });
+                    } catch (err) {
+                        return next(err);
+                    }
                 }
+                next();
+            },
+            async function test(next) {
+                const query = "SELECT COUNT(1) FROM benchmarks.basic USING TIMEOUT 120s;";
                 try {
-                    await client.batch(queries, { prepare: true });
+                    let res = await client.execute(query);
+                    assert(res.rows[0].count == iterCnt);
                 } catch (err) {
                     return next(err);
                 }
+                next();
+            },
+            function r() {
+                exit(0);
             }
-            next();
-        },
-        async function test(next) {
-            const query = "SELECT COUNT(1) FROM benchmarks.basic USING TIMEOUT 120s;";
-            try {
-                let res = await client.execute(query);
-                assert(res.rows[0].count == iterCnt);
-            } catch (err) {
-                return next(err);
-            }
-            next();
-        },
-        function r() {
-            exit(0);
-        }
-    ], utils.onError);
+        ], utils.onError);
+};

--- a/benchmark/logic/batch.js
+++ b/benchmark/logic/batch.js
@@ -2,7 +2,6 @@
 const async = require("async");
 const utils = require("./utils");
 const { exit } = require("process");
-const assert = require("assert");
 
 module.exports = function (cassandra, client, stepCount, _concurrencyLevel) {
     // REMEMBER: update benchmark config.yml when changing the constant value.
@@ -33,14 +32,7 @@ module.exports = function (cassandra, client, stepCount, _concurrencyLevel) {
                 next();
             },
             async function test(next) {
-                const query = "SELECT COUNT(1) FROM benchmarks.basic USING TIMEOUT 120s;";
-                try {
-                    let res = await client.execute(query);
-                    assert(res.rows[0].count == iterCnt);
-                } catch (err) {
-                    return next(err);
-                }
-                next();
+                utils.checkRowCount(client, iterCnt, next);
             },
             function r() {
                 exit(0);

--- a/benchmark/logic/benchmark.js
+++ b/benchmark/logic/benchmark.js
@@ -1,0 +1,33 @@
+// Single entry point for all benchmarks.
+// This file takes the name of the benchmark, including driver name, step count and concurrency level
+// and runs the corresponding benchmark logic, loaded at runtime.
+
+"use strict";
+const { exit } = require("process");
+
+// We need to validate driver name before loading utils, as utils loads the driver.
+const driverName = process.argv[2];
+const benchmarkName = process.argv[3];
+if (!driverName || !benchmarkName) {
+    console.error("Usage: node benchmark.js <driver> <benchmark-name> [step-count] [concurrency]");
+    exit(1);
+}
+
+const utils = require("./utils");
+
+// Default step count is defined in each benchmark.
+// See runner-config/config.yml for more information.
+const defaultStepCount = undefined
+const defaultConcurrencyLevel = 100;
+
+// Each individual benchmark has a default step count defined.
+// See the explanation in config.yml for more details.
+const stepCount = process.argv[4] === undefined || process.argv[4] !== "default" ? parseInt(process.argv[4], 10) : defaultStepCount;
+const concurrencyLevel = process.argv[5] === undefined || process.argv[5] !== "default" ? parseInt(process.argv[5], 10) : defaultConcurrencyLevel;
+
+
+const cassandra = require(driverName);
+const client = new cassandra.Client(utils.getClientArgs());
+
+const benchmark = require(`./${benchmarkName}`);
+benchmark(cassandra, client, stepCount, concurrencyLevel);

--- a/benchmark/logic/concurrent_deser.js
+++ b/benchmark/logic/concurrent_deser.js
@@ -1,52 +1,51 @@
 "use strict";
 const async = require("async");
-// Possible values of argv[2] (driver) are scylladb-driver-alpha and cassandra-driver.
-const cassandra = require(process.argv[2]);
 const utils = require("./utils");
 const { exit } = require("process");
 const assert = require("assert");
 
-const client = new cassandra.Client(utils.getClientArgs());
-const iterCnt = parseInt(process.argv[3]);
+module.exports = function (cassandra, client, stepCount, concurrencyLevel) {
+    // REMEMBER: update benchmark config.yml when changing the constant value.
+    const iterCnt = stepCount || 2000;
 
-async.series(
-    [
-        function initialize(next) {
-            utils.prepareDatabase(client, utils.tableSchemaDeSer, next);
-        },
-        async function insert(next) {
-            let allParameters = utils.insertConcurrentDeSer(cassandra, iterCnt);
-            try {
-                const _result = await cassandra.concurrent.executeConcurrent(client, allParameters, { prepare: true });
-            } catch (err) {
-                return next(err);
-            }
-            next();
-        },
-        async function select(next) {
-            let remaining = iterCnt;
-            while (remaining > 0) {
-                let currentStep = Math.min(remaining, 500);
-                remaining -= currentStep;
-                let allParameters = [];
-                for (let i = 0; i < currentStep; i++) {
-                    allParameters.push({
-                        query: 'SELECT * FROM benchmarks.basic',
-                    });
-                }
+    async.series(
+        [
+            function initialize(next) {
+                utils.prepareDatabase(client, utils.tableSchemaDeSer, next);
+            },
+            async function insert(next) {
+                let allParameters = utils.insertConcurrentDeSer(cassandra, iterCnt);
                 try {
-                    const result = await cassandra.concurrent.executeConcurrent(client, allParameters, { prepare: true, collectResults: true });
-                    for (let singleResult of result.resultItems) {
-                        assert.equal(singleResult.rowLength, iterCnt);
-                    }
+                    const _result = await cassandra.concurrent.executeConcurrent(client, allParameters, { prepare: true, concurrencyLevel });
                 } catch (err) {
                     return next(err);
                 }
+                next();
+            },
+            async function select(next) {
+                let remaining = iterCnt;
+                while (remaining > 0) {
+                    let currentStep = Math.min(remaining, 500);
+                    remaining -= currentStep;
+                    let allParameters = [];
+                    for (let i = 0; i < currentStep; i++) {
+                        allParameters.push({
+                            query: 'SELECT * FROM benchmarks.basic',
+                        });
+                    }
+                    try {
+                        const result = await cassandra.concurrent.executeConcurrent(client, allParameters, { prepare: true, collectResults: true, concurrencyLevel });
+                        for (let singleResult of result.resultItems) {
+                            assert.equal(singleResult.rowLength, iterCnt);
+                        }
+                    } catch (err) {
+                        return next(err);
+                    }
+                }
+                next();
+            },
+            function r() {
+                exit(0);
             }
-            next();
-        },
-        function r() {
-            exit(0);
-        }
-    ], utils.onError);
-
+        ], utils.onError);
+};

--- a/benchmark/logic/concurrent_insert.js
+++ b/benchmark/logic/concurrent_insert.js
@@ -1,42 +1,41 @@
 "use strict";
 const async = require("async");
-// Possible values of argv[2] (driver) are scylladb-driver-alpha and cassandra-driver.
-const cassandra = require(process.argv[2]);
 const utils = require("./utils");
 const { exit } = require("process");
 
-const client = new cassandra.Client(utils.getClientArgs());
-const iterCnt = parseInt(process.argv[3]);
+module.exports = function (cassandra, client, stepCount, concurrencyLevel) {
+    // REMEMBER: update benchmark config.yml when changing the constant value.
+    const iterCnt = stepCount || 4000000;
 
-async.series(
-    [
-        function initialize(next) {
-            utils.prepareDatabase(client, utils.tableSchemaBasic, next);
-        },
-        async function insert(next) {
-            let limited = async function (steps) {
-                let allParameters = [];
-                for (let i = 0; i < steps; i++) {
-                    allParameters.push({
-                        query: 'INSERT INTO benchmarks.basic (id, val) VALUES (?, ?)',
-                        params: [cassandra.types.Uuid.random(), 10]
-                    });
+    async.series(
+        [
+            function initialize(next) {
+                utils.prepareDatabase(client, utils.tableSchemaBasic, next);
+            },
+            async function insert(next) {
+                let limited = async function (steps) {
+                    let allParameters = [];
+                    for (let i = 0; i < steps; i++) {
+                        allParameters.push({
+                            query: 'INSERT INTO benchmarks.basic (id, val) VALUES (?, ?)',
+                            params: [cassandra.types.Uuid.random(), 10]
+                        });
+                    }
+                    try {
+                        const _result = await cassandra.concurrent.executeConcurrent(client, allParameters, { prepare: true, concurrencyLevel });
+                    } catch (err) {
+                        return next(err);
+                    }
                 }
-                try {
-                    const _result = await cassandra.concurrent.executeConcurrent(client, allParameters, { prepare: true });
-                } catch (err) {
-                    return next(err);
-                }
+                await utils.repeatCapped(limited, iterCnt);
+
+                next();
+            },
+            async function test(next) {
+                utils.checkRowCount(client, iterCnt, next);
+            },
+            function r() {
+                exit(0);
             }
-            await utils.repeatCapped(limited, iterCnt);
-
-            next();
-        },
-        async function test(next) {
-            utils.checkRowCount(client, iterCnt, next);
-        },
-        function r() {
-            exit(0);
-        }
-    ], utils.onError);
-
+        ], utils.onError);
+};

--- a/benchmark/logic/concurrent_paging.js
+++ b/benchmark/logic/concurrent_paging.js
@@ -1,48 +1,46 @@
 "use strict";
 const async = require("async");
-// Possible values of argv[2] (driver) are scylladb-nodejs-rs-driver and cassandra-driver.
-const cassandra = require(process.argv[2]);
 const utils = require("./utils");
 const { exit } = require("process");
-const { assert } = require("console");
+const assert = require("assert");
 
-const client = new cassandra.Client(utils.getClientArgs());
-const iterCnt = parseInt(process.argv[3]);
-const concurrencyLevel = 20;
+module.exports = function (cassandra, client, stepCount, concurrencyLevel) {
+    // REMEMBER: update benchmark config.yml when changing the constant value.
+    const iterCnt = stepCount || 1280;
 
-async.series(
-    [
-        function initialize(next) {
-            utils.prepareDatabase(client, utils.tableSchemaBasic, next);
-        },
-        async function insert(next) {
-            utils.insertSimple(client, 50, next);
-        },
-        async function select(next) {
-            let limited = async function (steps) {
-                for (let i = 0; i < steps; i++) {
-                    try {
-                        let s = 0;
-                        let q = await client.execute('SELECT * FROM benchmarks.basic', [], { prepare: true, fetchSize: 1 });
-                        for await (const row of q) {
-                            s += row['val'];
+    async.series(
+        [
+            function initialize(next) {
+                utils.prepareDatabase(client, utils.tableSchemaBasic, next);
+            },
+            async function insert(next) {
+                utils.insertSimple(client, 50, next);
+            },
+            async function select(next) {
+                let limited = async function (steps) {
+                    for (let i = 0; i < steps; i++) {
+                        try {
+                            let s = 0;
+                            let q = await client.execute('SELECT * FROM benchmarks.basic', [], { prepare: true, fetchSize: 1 });
+                            for await (const row of q) {
+                                s += row['val'];
+                            }
+                            assert(s === 5000);
+                        } catch (err) {
+                            return next(err);
                         }
-                        assert(s === 5000);
-                    } catch (err) {
-                        return next(err);
                     }
-
                 }
+                await utils.executeMultipleRepeatCapped(limited, iterCnt, concurrencyLevel);
+                next();
+            },
+            function r() {
+                exit(0);
             }
-            await utils.executeMultipleRepeatCapped(limited, iterCnt, concurrencyLevel);
-            next();
-        },
-        function r() {
-            exit(0);
-        }
-    ], function (err) {
-        if (err) {
-            console.error("Error: ", err.message, err.stack);
-            exit(1);
-        }
-    },);
+        ], function (err) {
+            if (err) {
+                console.error("Error: ", err.message, err.stack);
+                exit(1);
+            }
+        });
+};

--- a/benchmark/logic/concurrent_select.js
+++ b/benchmark/logic/concurrent_select.js
@@ -1,43 +1,43 @@
 "use strict";
 const async = require("async");
-// Possible values of argv[2] (driver) are scylladb-driver-alpha and cassandra-driver.
-const cassandra = require(process.argv[2]);
 const utils = require("./utils");
 const { exit } = require("process");
 const assert = require("assert");
 
-const client = new cassandra.Client(utils.getClientArgs());
-const iterCnt = parseInt(process.argv[3]);
+module.exports = function (cassandra, client, stepCount, concurrencyLevel) {
+    // REMEMBER: update benchmark config.yml when changing the constant value.
+    const iterCnt = stepCount || 400000;
 
-async.series(
-    [
-        function initialize(next) {
-            utils.prepareDatabase(client, utils.tableSchemaBasic, next);
-        },
-        async function insert(next) {
-            utils.insertSimple(client, 10, next);
-        },
-        async function select(next) {
-            let limited = async function (steps) {
-                let allParameters = [];
-                for (let i = 0; i < steps; i++) {
-                    allParameters.push({
-                        query: 'SELECT * FROM benchmarks.basic',
-                    });
-                }
-                try {
-                    const result = await cassandra.concurrent.executeConcurrent(client, allParameters, { prepare: true, collectResults: true });
-                    for (let singleResult of result.resultItems) {
-                        assert.equal(singleResult.rowLength, 10);
+    async.series(
+        [
+            function initialize(next) {
+                utils.prepareDatabase(client, utils.tableSchemaBasic, next);
+            },
+            async function insert(next) {
+                utils.insertSimple(client, 10, next);
+            },
+            async function select(next) {
+                let limited = async function (steps) {
+                    let allParameters = [];
+                    for (let i = 0; i < steps; i++) {
+                        allParameters.push({
+                            query: 'SELECT * FROM benchmarks.basic',
+                        });
                     }
-                } catch (err) {
-                    return next(err);
+                    try {
+                        const result = await cassandra.concurrent.executeConcurrent(client, allParameters, { prepare: true, collectResults: true, concurrencyLevel });
+                        for (let singleResult of result.resultItems) {
+                            assert.equal(singleResult.rowLength, 10);
+                        }
+                    } catch (err) {
+                        return next(err);
+                    }
                 }
+                await utils.repeatCapped(limited, iterCnt);
+                next();
+            },
+            function r() {
+                exit(0);
             }
-            await utils.repeatCapped(limited, iterCnt);
-            next();
-        },
-        function r() {
-            exit(0);
-        }
-    ], utils.onError);
+        ], utils.onError);
+};

--- a/benchmark/logic/concurrent_ser.js
+++ b/benchmark/logic/concurrent_ser.js
@@ -1,32 +1,31 @@
 "use strict";
 const async = require("async");
-// Possible values of argv[2] (driver) are scylladb-driver-alpha and cassandra-driver.
-const cassandra = require(process.argv[2]);
 const utils = require("./utils");
 const { exit } = require("process");
 
-const client = new cassandra.Client(utils.getClientArgs());
-const iterCnt = parseInt(process.argv[3]);
+module.exports = function (cassandra, client, stepCount, concurrencyLevel) {
+    // REMEMBER: update benchmark config.yml when changing the constant value.
+    const iterCnt = stepCount || 1200;
 
-async.series(
-    [
-        function initialize(next) {
-            utils.prepareDatabase(client, utils.tableSchemaDeSer, next);
-        },
-        async function insert(next) {
-            let allParameters = utils.insertConcurrentDeSer(cassandra, iterCnt * iterCnt);
-            try {
-                await cassandra.concurrent.executeConcurrent(client, allParameters, { prepare: true });
-            } catch (err) {
-                return next(err);
+    async.series(
+        [
+            function initialize(next) {
+                utils.prepareDatabase(client, utils.tableSchemaDeSer, next);
+            },
+            async function insert(next) {
+                let allParameters = utils.insertConcurrentDeSer(cassandra, iterCnt * iterCnt);
+                try {
+                    await cassandra.concurrent.executeConcurrent(client, allParameters, { prepare: true, concurrencyLevel });
+                } catch (err) {
+                    return next(err);
+                }
+                next();
+            },
+            async function test(next) {
+                utils.checkRowCount(client, iterCnt * iterCnt, next);
+            },
+            function r() {
+                exit(0);
             }
-            next();
-        },
-        async function test(next) {
-            utils.checkRowCount(client, iterCnt * iterCnt, next);
-        },
-        function r() {
-            exit(0);
-        }
-    ], utils.onError);
-
+        ], utils.onError);
+};

--- a/benchmark/logic/deser.js
+++ b/benchmark/logic/deser.js
@@ -1,26 +1,25 @@
 "use strict";
 const async = require("async");
-// Possible values of argv[2] (driver) are scylladb-driver-alpha and cassandra-driver.
-const cassandra = require(process.argv[2]);
 const utils = require("./utils");
 const { exit } = require("process");
 
-const client = new cassandra.Client(utils.getClientArgs());
-const iterCount = parseInt(process.argv[3]);
+module.exports = function (cassandra, client, stepCount, _concurrencyLevel) {
+    // REMEMBER: update benchmark config.yml when changing the constant value.
+    const iterCount = stepCount || 2000;
 
-async.series(
-    [
-        function initialize(next) {
-            utils.prepareDatabase(client, utils.tableSchemaDeSer, next);
-        },
-        async function insert(next) {
-            utils.executeInsertDeSer(client, iterCount, cassandra, next);
-        },
-        async function query(next) {
-            await utils.queryWithRowCheck(client, iterCount, iterCount, next);
-        },
-        function r() {
-            exit(0);
-        }
-    ], utils.onError);
-
+    async.series(
+        [
+            function initialize(next) {
+                utils.prepareDatabase(client, utils.tableSchemaDeSer, next);
+            },
+            async function insert(next) {
+                utils.executeInsertDeSer(client, iterCount, cassandra, next);
+            },
+            async function query(next) {
+                await utils.queryWithRowCheck(client, iterCount, iterCount, next);
+            },
+            function r() {
+                exit(0);
+            }
+        ], utils.onError);
+};

--- a/benchmark/logic/insert.js
+++ b/benchmark/logic/insert.js
@@ -1,36 +1,35 @@
 "use strict";
 const async = require("async");
-// Possible values of argv[2] (driver) are scylladb-driver-alpha and cassandra-driver.
-const cassandra = require(process.argv[2]);
 const utils = require("./utils");
 const { exit } = require("process");
 
-const client = new cassandra.Client(utils.getClientArgs());
-const iterCnt = parseInt(process.argv[3]);
+module.exports = function (cassandra, client, stepCount, _concurrencyLevel) {
+    // REMEMBER: update benchmark config.yml when changing the constant value.
+    const iterCnt = stepCount || 400000;
 
-async.series(
-    [
-        function initialize(next) {
-            utils.prepareDatabase(client, utils.tableSchemaBasic, next);
-        },
-        async function insert(next) {
-            for (let i = 0; i < iterCnt; i++) {
-                const id = cassandra.types.Uuid.random();
-                const query =
-                    "INSERT INTO benchmarks.basic (id, val) VALUES (?, ?)";
-                try {
-                    await client.execute(query, [id, 100], { prepare: true });
-                } catch (err) {
-                    return next(err);
+    async.series(
+        [
+            function initialize(next) {
+                utils.prepareDatabase(client, utils.tableSchemaBasic, next);
+            },
+            async function insert(next) {
+                for (let i = 0; i < iterCnt; i++) {
+                    const id = cassandra.types.Uuid.random();
+                    const query =
+                        "INSERT INTO benchmarks.basic (id, val) VALUES (?, ?)";
+                    try {
+                        await client.execute(query, [id, 100], { prepare: true });
+                    } catch (err) {
+                        return next(err);
+                    }
                 }
+                next();
+            },
+            async function test(next) {
+                utils.checkRowCount(client, iterCnt, next);
+            },
+            function r() {
+                exit(0);
             }
-            next();
-        },
-        async function test(next) {
-            utils.checkRowCount(client, iterCnt, next);
-        },
-        function r() {
-            exit(0);
-        }
-    ], utils.onError);
-
+        ], utils.onError);
+};

--- a/benchmark/logic/large_select.js
+++ b/benchmark/logic/large_select.js
@@ -1,5 +1,8 @@
 "use strict";
-
 const selectWithRows = require("./parametrized_select");
 
-selectWithRows(5000);
+module.exports = function (cassandra, client, stepCount, _concurrencyLevel) {
+    // REMEMBER: update benchmark config.yml when changing the constant value.
+    stepCount = stepCount || 4000;
+    selectWithRows(cassandra, client, 5000, stepCount);
+};

--- a/benchmark/logic/paging.js
+++ b/benchmark/logic/paging.js
@@ -1,42 +1,41 @@
 "use strict";
 const async = require("async");
-// Possible values of argv[2] (driver) are scylladb-nodejs-rs-driver and cassandra-driver.
-const cassandra = require(process.argv[2]);
 const utils = require("./utils");
 const { exit } = require("process");
 const assert = require("assert");
 
-const client = new cassandra.Client(utils.getClientArgs());
-const iterCnt = parseInt(process.argv[3]);
+module.exports = function (cassandra, client, stepCount, _concurrencyLevel) {
+    // REMEMBER: update benchmark config.yml when changing the constant value.
+    const iterCnt = stepCount || 4000;
 
-async.series(
-    [
-        function initialize(next) {
-            utils.prepareDatabase(client, utils.tableSchemaBasic, next);
-        },
-        async function insert(next) {
-            utils.insertSimple(client, 50, next);
-        },
-        async function select(next) {
-            let limited = async function (steps) {
-                for (let i = 0; i < steps; i++) {
-                    try {
-                        let s = 0;
-                        let q = await client.execute('SELECT * FROM benchmarks.basic', [], { prepare: true, fetchSize: 1 });
-                        for await (const row of q) {
-                            s += row['val'];
+    async.series(
+        [
+            function initialize(next) {
+                utils.prepareDatabase(client, utils.tableSchemaBasic, next);
+            },
+            async function insert(next) {
+                utils.insertSimple(client, 50, next);
+            },
+            async function select(next) {
+                let limited = async function (steps) {
+                    for (let i = 0; i < steps; i++) {
+                        try {
+                            let s = 0;
+                            let q = await client.execute('SELECT * FROM benchmarks.basic', [], { prepare: true, fetchSize: 1 });
+                            for await (const row of q) {
+                                s += row['val'];
+                            }
+                            assert.equal(s, 5000);
+                        } catch (err) {
+                            return next(err);
                         }
-                        assert.equal(s, 5000);
-                    } catch (err) {
-                        return next(err);
                     }
-
                 }
+                await utils.repeatCapped(limited, iterCnt);
+                next();
+            },
+            function r() {
+                exit(0);
             }
-            await utils.repeatCapped(limited, iterCnt);
-            next();
-        },
-        function r() {
-            exit(0);
-        }
-    ], utils.onError);
+        ], utils.onError);
+};

--- a/benchmark/logic/parametrized_select.js
+++ b/benchmark/logic/parametrized_select.js
@@ -1,31 +1,26 @@
 "use strict";
 const async = require("async");
-// Possible values of argv[2] (driver) are scylladb-driver-alpha and cassandra-driver.
-const cassandra = require(process.argv[2]);
 const utils = require("./utils");
 const { exit } = require("process");
 
-const client = new cassandra.Client(utils.getClientArgs());
-const iterCnt = parseInt(process.argv[3]);
+function selectWithRows(cassandra, client, rowCount, stepCount) {
+    const iterCnt = stepCount;
 
-function selectWithRows(number) {
     async.series(
         [
             function initialize(next) {
                 utils.prepareDatabase(client, utils.tableSchemaBasic, next);
             },
             async function insert(next) {
-                utils.insertSimple(client, 10, next);
+                utils.insertSimple(client, rowCount, next);
             },
             async function query(next) {
-                await utils.queryWithRowCheck(client, number, iterCnt, next);
+                await utils.queryWithRowCheck(client, rowCount, iterCnt, next);
             },
             function r() {
                 exit(0);
             }
-
         ], utils.onError);
 }
-
 
 module.exports = selectWithRows;

--- a/benchmark/logic/select.js
+++ b/benchmark/logic/select.js
@@ -1,5 +1,8 @@
 "use strict";
-
 const selectWithRows = require("./parametrized_select");
 
-selectWithRows(10);
+module.exports = function (cassandra, client, stepCount, _concurrencyLevel) {
+    // REMEMBER: update benchmark config.yml when changing the constant value.
+    stepCount = stepCount || 100000;
+    selectWithRows(cassandra, client, 10, stepCount);
+};

--- a/benchmark/logic/ser.js
+++ b/benchmark/logic/ser.js
@@ -1,26 +1,25 @@
 "use strict";
 const async = require("async");
-// Possible values of argv[2] (driver) are scylladb-driver-alpha and cassandra-driver.
-const cassandra = require(process.argv[2]);
 const utils = require("./utils");
 const { exit } = require("process");
 
-const client = new cassandra.Client(utils.getClientArgs());
-const iterCount = parseInt(process.argv[3]);
+module.exports = function (cassandra, client, stepCount, _concurrencyLevel) {
+    // REMEMBER: update benchmark config.yml when changing the constant value.
+    const iterCount = stepCount || 900;
 
-async.series(
-    [
-        function initialize(next) {
-            utils.prepareDatabase(client, utils.tableSchemaDeSer, next);
-        },
-        async function insert(next) {
-            utils.executeInsertDeSer(client, iterCount * iterCount, cassandra, next);
-        },
-        async function test(next) {
-            utils.checkRowCount(client, iterCount * iterCount, next);
-        },
-        function r() {
-            exit(0);
-        }
-    ], utils.onError);
-
+    async.series(
+        [
+            function initialize(next) {
+                utils.prepareDatabase(client, utils.tableSchemaDeSer, next);
+            },
+            async function insert(next) {
+                utils.executeInsertDeSer(client, iterCount * iterCount, cassandra, next);
+            },
+            async function test(next) {
+                utils.checkRowCount(client, iterCount * iterCount, next);
+            },
+            function r() {
+                exit(0);
+            }
+        ], utils.onError);
+};

--- a/benchmark/logic_rust/common.rs
+++ b/benchmark/logic_rust/common.rs
@@ -106,11 +106,28 @@ pub(crate) fn get_deser_data() -> (
     (id, 100, tuuid, ip, date, time, tuple, udt, set, duration)
 }
 
+#[allow(dead_code)]
 pub(crate) fn get_cnt() -> i32 {
     env::var("CNT")
         .ok()
         .and_then(|s: String| s.parse::<i32>().ok())
         .expect("CNT parameter is required.")
+}
+
+#[allow(dead_code)]
+pub(crate) fn get_cnt_with_default(default: i32) -> i32 {
+    env::var("CNT")
+        .ok()
+        .and_then(|s: String| s.parse::<i32>().ok())
+        .unwrap_or(default)
+}
+
+#[allow(dead_code)]
+pub(crate) fn get_concurrency(default: usize) -> usize {
+    env::var("CONCURRENCY")
+        .ok()
+        .and_then(|s: String| s.parse::<usize>().ok())
+        .unwrap_or(default)
 }
 
 // This may be imported by binaries that use only one of the helpers

--- a/benchmark/logic_rust/concurrent_deser.rs
+++ b/benchmark/logic_rust/concurrent_deser.rs
@@ -8,12 +8,11 @@ use crate::common::DESER_INSERT_QUERY;
 
 mod common;
 
-const CONCURRENCY: usize = 100;
-
 async fn insert_data(
     session: Arc<Session>,
     start_index: usize,
     n: i32,
+    concurrency: usize,
     insert_query: &PreparedStatement,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let mut index = start_index;
@@ -22,7 +21,7 @@ async fn insert_data(
         session
             .execute_unpaged(insert_query, common::get_deser_data())
             .await?;
-        index += CONCURRENCY;
+        index += concurrency;
     }
 
     Ok(())
@@ -32,6 +31,7 @@ async fn select_data(
     session: Arc<Session>,
     start_index: usize,
     n: i32,
+    concurrency: usize,
     select_query: &PreparedStatement,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let mut index = start_index;
@@ -44,7 +44,7 @@ async fn select_data(
             .rows::<Row>()?
             .collect::<Vec<_>>();
         assert_eq!(r.len() as i32, n);
-        index += CONCURRENCY;
+        index += concurrency;
     }
 
     Ok(())
@@ -52,7 +52,9 @@ async fn select_data(
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let n: i32 = common::get_cnt();
+    // REMEMBER: update benchmark config.yml when changing the constant value.
+    let n: i32 = common::get_cnt_with_default(2_048);
+    let concurrency = common::get_concurrency(100);
 
     let session = common::init_deser_table().await?;
 
@@ -61,11 +63,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut handles = vec![];
     let session = Arc::new(session);
 
-    for i in 0..CONCURRENCY {
+    for i in 0..concurrency {
         let session_clone = Arc::clone(&session);
         let insert_query_clone = insert_query.clone();
         handles.push(tokio::spawn(async move {
-            insert_data(session_clone, i, n, &insert_query_clone)
+            insert_data(session_clone, i, n, concurrency, &insert_query_clone)
                 .await
                 .unwrap();
         }));
@@ -81,11 +83,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let mut handles = vec![];
 
-    for i in 0..CONCURRENCY {
+    for i in 0..concurrency {
         let session_clone = Arc::clone(&session);
         let select_query_clone = select_query.clone();
         handles.push(tokio::spawn(async move {
-            select_data(session_clone, i, n, &select_query_clone)
+            select_data(session_clone, i, n, concurrency, &select_query_clone)
                 .await
                 .unwrap();
         }));

--- a/benchmark/logic_rust/concurrent_insert.rs
+++ b/benchmark/logic_rust/concurrent_insert.rs
@@ -8,12 +8,11 @@ use crate::common::SIMPLE_INSERT_QUERY;
 
 mod common;
 
-const CONCURRENCY: usize = 100;
-
 async fn insert_data(
     session: Arc<Session>,
     start_index: usize,
     n: i32,
+    concurrency: usize,
     insert_query: &PreparedStatement,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let mut index = start_index;
@@ -21,7 +20,7 @@ async fn insert_data(
     while index < n as usize {
         let id = Uuid::new_v4();
         session.execute_unpaged(insert_query, (id, 100)).await?;
-        index += CONCURRENCY;
+        index += concurrency;
     }
 
     Ok(())
@@ -29,7 +28,9 @@ async fn insert_data(
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let n: i32 = common::get_cnt();
+    // REMEMBER: update benchmark config.yml when changing the constant value.
+    let n: i32 = common::get_cnt_with_default(4_000_000);
+    let concurrency = common::get_concurrency(100);
 
     let session = common::init_simple_table().await?;
 
@@ -38,11 +39,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut handles = vec![];
     let session = Arc::new(session);
 
-    for i in 0..CONCURRENCY {
+    for i in 0..concurrency {
         let session_clone = Arc::clone(&session);
         let insert_query_clone = insert_query.clone();
         handles.push(tokio::spawn(async move {
-            insert_data(session_clone, i, n, &insert_query_clone)
+            insert_data(session_clone, i, n, concurrency, &insert_query_clone)
                 .await
                 .unwrap();
         }));

--- a/benchmark/logic_rust/concurrent_paging.rs
+++ b/benchmark/logic_rust/concurrent_paging.rs
@@ -1,18 +1,17 @@
 use scylla::{response::PagingState, statement::Statement};
-use std::{env, ops::ControlFlow, sync::Arc};
+use std::{ops::ControlFlow, sync::Arc};
 use uuid::Uuid;
 
 use crate::common::SIMPLE_INSERT_QUERY;
 
 mod common;
 
-const CONCURRENCY_LEVEL: usize = 20;
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let n: i32 = env::var("CNT")
-        .ok()
-        .and_then(|s: String| s.parse::<i32>().ok())
-        .expect("CNT parameter is required.");
+    // REMEMBER: update benchmark config.yml when changing the constant value.
+    let n: i32 = common::get_cnt_with_default(1_280);
+
+    let concurrency = common::get_concurrency(20);
 
     let session = Arc::new(common::init_simple_table_caching().await?);
 
@@ -29,7 +28,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             .await?;
     }
     let mut tasks = vec![];
-    for _ in 0..(CONCURRENCY_LEVEL) {
+    for _ in 0..concurrency {
         let session = session.clone();
         tasks.push(tokio::task::spawn(async move {
             let mut select_query = Statement::new("SELECT * FROM benchmarks.basic");

--- a/benchmark/logic_rust/concurrent_select.rs
+++ b/benchmark/logic_rust/concurrent_select.rs
@@ -9,12 +9,11 @@ use crate::common::SIMPLE_INSERT_QUERY;
 
 mod common;
 
-const CONCURRENCY: usize = 100;
-
 async fn select_data(
     session: Arc<Session>,
     start_index: usize,
     n: i32,
+    concurrency: usize,
     select_query: &PreparedStatement,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let mut index = start_index;
@@ -27,7 +26,7 @@ async fn select_data(
             .rows::<Row>()?
             .collect::<Vec<_>>();
         assert_eq!(r.len() as i32, 10);
-        index += CONCURRENCY;
+        index += concurrency;
     }
 
     Ok(())
@@ -35,7 +34,9 @@ async fn select_data(
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let n: i32 = common::get_cnt();
+    // REMEMBER: update benchmark config.yml when changing the constant value.
+    let n: i32 = common::get_cnt_with_default(400_000);
+    let concurrency = common::get_concurrency(100);
 
     let session = common::init_simple_table().await?;
 
@@ -50,11 +51,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut handles = vec![];
     let session = Arc::new(session);
 
-    for i in 0..CONCURRENCY {
+    for i in 0..concurrency {
         let session_clone = Arc::clone(&session);
         let select_query_clone = select_query.clone();
         handles.push(tokio::spawn(async move {
-            select_data(session_clone, i, n, &select_query_clone)
+            select_data(session_clone, i, n, concurrency, &select_query_clone)
                 .await
                 .unwrap();
         }));

--- a/benchmark/logic_rust/concurrent_ser.rs
+++ b/benchmark/logic_rust/concurrent_ser.rs
@@ -7,12 +7,11 @@ use crate::common::DESER_INSERT_QUERY;
 
 mod common;
 
-const CONCURRENCY: usize = 100;
-
 async fn insert_data(
     session: Arc<Session>,
     start_index: usize,
     n: i32,
+    concurrency: usize,
     insert_query: &PreparedStatement,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let mut index = start_index;
@@ -21,7 +20,7 @@ async fn insert_data(
         session
             .execute_unpaged(insert_query, common::get_deser_data())
             .await?;
-        index += CONCURRENCY;
+        index += concurrency;
     }
 
     Ok(())
@@ -29,7 +28,9 @@ async fn insert_data(
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let n: i32 = common::get_cnt();
+    // REMEMBER: update benchmark config.yml when changing the constant value.
+    let n: i32 = common::get_cnt_with_default(1_216);
+    let concurrency = common::get_concurrency(100);
 
     let session = common::init_deser_table().await?;
 
@@ -38,11 +39,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut handles = vec![];
     let session = Arc::new(session);
 
-    for i in 0..CONCURRENCY {
+    for i in 0..concurrency {
         let session_clone = Arc::clone(&session);
         let insert_query_clone = insert_query.clone();
         handles.push(tokio::spawn(async move {
-            insert_data(session_clone, i, n * n, &insert_query_clone)
+            insert_data(session_clone, i, n * n, concurrency, &insert_query_clone)
                 .await
                 .unwrap();
         }));

--- a/benchmark/runner-config/cassandra-driver/config.yml
+++ b/benchmark/runner-config/cassandra-driver/config.yml
@@ -4,37 +4,37 @@ defaults:
 
 backends:
   - benchmark-name: insert
-    run-command: ./benchmark/runner-config/run-js-benchmark.sh insert.js cassandra-driver
+    run-command: ./benchmark/runner-config/run-js-benchmark.sh insert cassandra-driver
 
   - benchmark-name: concurrent_insert
-    run-command: ./benchmark/runner-config/run-js-benchmark.sh concurrent_insert.js cassandra-driver
+    run-command: ./benchmark/runner-config/run-js-benchmark.sh concurrent_insert cassandra-driver
 
   - benchmark-name: select
-    run-command: ./benchmark/runner-config/run-js-benchmark.sh select.js cassandra-driver
+    run-command: ./benchmark/runner-config/run-js-benchmark.sh select cassandra-driver
 
   - benchmark-name: concurrent_select
-    run-command: ./benchmark/runner-config/run-js-benchmark.sh concurrent_select.js cassandra-driver
+    run-command: ./benchmark/runner-config/run-js-benchmark.sh concurrent_select cassandra-driver
 
   - benchmark-name: batch
-    run-command: ./benchmark/runner-config/run-js-benchmark.sh batch.js cassandra-driver
+    run-command: ./benchmark/runner-config/run-js-benchmark.sh batch cassandra-driver
 
   - benchmark-name: paging
-    run-command: ./benchmark/runner-config/run-js-benchmark.sh paging.js cassandra-driver
+    run-command: ./benchmark/runner-config/run-js-benchmark.sh paging cassandra-driver
 
   - benchmark-name: concurrent_paging
-    run-command: ./benchmark/runner-config/run-js-benchmark.sh concurrent_paging.js cassandra-driver
+    run-command: ./benchmark/runner-config/run-js-benchmark.sh concurrent_paging cassandra-driver
 
   - benchmark-name: large_select
-    run-command: ./benchmark/runner-config/run-js-benchmark.sh large_select.js cassandra-driver
+    run-command: ./benchmark/runner-config/run-js-benchmark.sh large_select cassandra-driver
 
   - benchmark-name: deser
-    run-command: ./benchmark/runner-config/run-js-benchmark.sh deser.js cassandra-driver
+    run-command: ./benchmark/runner-config/run-js-benchmark.sh deser cassandra-driver
 
   - benchmark-name: concurrent_deser
-    run-command: ./benchmark/runner-config/run-js-benchmark.sh concurrent_deser.js cassandra-driver
+    run-command: ./benchmark/runner-config/run-js-benchmark.sh concurrent_deser cassandra-driver
 
   - benchmark-name: ser
-    run-command: ./benchmark/runner-config/run-js-benchmark.sh ser.js cassandra-driver
+    run-command: ./benchmark/runner-config/run-js-benchmark.sh ser cassandra-driver
 
   - benchmark-name: concurrent_ser
-    run-command: ./benchmark/runner-config/run-js-benchmark.sh concurrent_ser.js cassandra-driver
+    run-command: ./benchmark/runner-config/run-js-benchmark.sh concurrent_ser cassandra-driver

--- a/benchmark/runner-config/cassandra-driver/config.yml
+++ b/benchmark/runner-config/cassandra-driver/config.yml
@@ -9,11 +9,17 @@ backends:
   - benchmark-name: concurrent_insert
     run-command: ./benchmark/runner-config/run-js-benchmark.sh concurrent_insert cassandra-driver
 
+  - benchmark-name: concurrency_parametrized_insert
+    run-command: ./benchmark/runner-config/run-js-concurrency-benchmark.sh concurrent_insert cassandra-driver
+
   - benchmark-name: select
     run-command: ./benchmark/runner-config/run-js-benchmark.sh select cassandra-driver
 
   - benchmark-name: concurrent_select
     run-command: ./benchmark/runner-config/run-js-benchmark.sh concurrent_select cassandra-driver
+
+  - benchmark-name: concurrency_parametrized_select
+    run-command: ./benchmark/runner-config/run-js-concurrency-benchmark.sh concurrent_select cassandra-driver
 
   - benchmark-name: batch
     run-command: ./benchmark/runner-config/run-js-benchmark.sh batch cassandra-driver
@@ -24,6 +30,9 @@ backends:
   - benchmark-name: concurrent_paging
     run-command: ./benchmark/runner-config/run-js-benchmark.sh concurrent_paging cassandra-driver
 
+  - benchmark-name: concurrency_parametrized_paging
+    run-command: ./benchmark/runner-config/run-js-concurrency-benchmark.sh concurrent_paging cassandra-driver
+
   - benchmark-name: large_select
     run-command: ./benchmark/runner-config/run-js-benchmark.sh large_select cassandra-driver
 
@@ -33,8 +42,14 @@ backends:
   - benchmark-name: concurrent_deser
     run-command: ./benchmark/runner-config/run-js-benchmark.sh concurrent_deser cassandra-driver
 
+  - benchmark-name: concurrency_parametrized_deser
+    run-command: ./benchmark/runner-config/run-js-concurrency-benchmark.sh concurrent_deser cassandra-driver
+
   - benchmark-name: ser
     run-command: ./benchmark/runner-config/run-js-benchmark.sh ser cassandra-driver
 
   - benchmark-name: concurrent_ser
     run-command: ./benchmark/runner-config/run-js-benchmark.sh concurrent_ser cassandra-driver
+
+  - benchmark-name: concurrency_parametrized_ser
+    run-command: ./benchmark/runner-config/run-js-concurrency-benchmark.sh concurrent_ser cassandra-driver

--- a/benchmark/runner-config/config.yml
+++ b/benchmark/runner-config/config.yml
@@ -21,23 +21,43 @@ benchmarks:
     starting-step: 6250
   - name: concurrent_insert
     starting-step: 62500
+  - name: concurrency_parametrized_insert
+    starting-step: 16
+    step-progress: 2
+    no-steps: 8
   - name: select
     starting-step: 1563
   - name: concurrent_select
     starting-step: 6250
+  - name: concurrency_parametrized_select
+    starting-step: 16
+    step-progress: 2
+    no-steps: 8
   - name: batch
     starting-step: 46875
   - name: paging
     starting-step: 63
   - name: concurrent_paging
     starting-step: 20
+  - name: concurrency_parametrized_paging
+    starting-step: 16
+    step-progress: 2
+    no-steps: 8
   - name: large_select
     starting-step: 63
   - name: deser
     starting-step: 32
   - name: concurrent_deser
     starting-step: 32
+  - name: concurrency_parametrized_deser
+    starting-step: 16
+    step-progress: 2
+    no-steps: 8
   - name: ser
     starting-step: 15
   - name: concurrent_ser
     starting-step: 19
+  - name: concurrency_parametrized_ser
+    starting-step: 16
+    step-progress: 2
+    no-steps: 8

--- a/benchmark/runner-config/config.yml
+++ b/benchmark/runner-config/config.yml
@@ -6,6 +6,16 @@ defaults:
   measure: time
   timeout: "200s"
 
+# We want to have the benchmark run for about 30-90 seconds at the highest step count.
+# If, at some point (ex. due to driver optimizations), the benchmark starts to run faster,
+# it's best to increase the default step count, to keep the benchmark results relevant and consistent.
+# The last step is defined in each benchmark code file. Ex. for insert benchmark (insert.js):
+# const iterCnt = stepCount || 400000;
+# At this value the benchmark takes ~40 seconds to run. We then want to define the starting step in this config file.
+# This definition should be picked in a way that matches the last step:
+# Ex. insert: last step = starting step * (step-progress ** (no-steps - 1)) = 6250 * (4 ** 3) = 400000
+# We chose 6250 as starting step, which is the exact value that sets the last step to 400000.
+
 benchmarks:
   - name: insert
     starting-step: 6250

--- a/benchmark/runner-config/run-js-benchmark.sh
+++ b/benchmark/runner-config/run-js-benchmark.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Wrapper on the command for benchmark runner
-# Usage: run-js-benchmark.sh <benchmark-js> <driver> <N>
+# Usage: run-js-benchmark.sh <benchmark-name> <driver> <N>
 set -euo pipefail
 
 BENCHMARK="$1"
@@ -10,4 +10,4 @@ N="$3"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 BENCHMARK_DIR="$SCRIPT_DIR/.."
 
-node "$BENCHMARK_DIR/logic/$BENCHMARK" "$DRIVER" "$N"
+node "$BENCHMARK_DIR/logic/benchmark.js" "$DRIVER" "$BENCHMARK" "$N" "default"

--- a/benchmark/runner-config/run-js-concurrency-benchmark.sh
+++ b/benchmark/runner-config/run-js-concurrency-benchmark.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# Runner for scenarios where we parametrize concurrency level, rather than number of queries.
+# Wrapper for fixed-query-count benchmarks where step count controls concurrency.
+# Usage: run-js-concurrency-benchmark.sh <benchmark-name> <driver> <concurrency>
+set -euo pipefail
+
+BENCHMARK="$1"
+DRIVER="$2"
+CONCURRENCY="$3"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BENCHMARK_DIR="$SCRIPT_DIR/.."
+
+# Step count omitted (uses module default); N passed as concurrency level.
+node "$BENCHMARK_DIR/logic/benchmark.js" "$DRIVER" "$BENCHMARK" "default" "$CONCURRENCY"

--- a/benchmark/runner-config/run-rust-concurrency-benchmark.sh
+++ b/benchmark/runner-config/run-rust-concurrency-benchmark.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# Runner for scenarios where we parametrize concurrency level, rather than number of queries.
+# Step count omitted (uses binary default); N passed as concurrency level.
+# Usage: run-rust-concurrency-benchmark.sh <binary-name> <concurrency>
+set -euo pipefail
+
+BINARY="$1"
+CONCURRENCY="$2"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$SCRIPT_DIR/../.."
+
+CONCURRENCY="$CONCURRENCY" "$REPO_ROOT/target/release/$BINARY"

--- a/benchmark/runner-config/rust-driver/config.yml
+++ b/benchmark/runner-config/rust-driver/config.yml
@@ -10,6 +10,10 @@ backends:
     build-command: cargo build -p benchmark --bin concurrent_insert_benchmark -r
     run-command: ./benchmark/runner-config/run-rust-benchmark.sh concurrent_insert_benchmark
 
+  - benchmark-name: concurrency_parametrized_insert
+    build-command: cargo build -p benchmark --bin concurrent_insert_benchmark -r
+    run-command: ./benchmark/runner-config/run-rust-concurrency-benchmark.sh concurrent_insert_benchmark
+
   - benchmark-name: select
     build-command: cargo build -p benchmark --bin select_benchmark -r
     run-command: ./benchmark/runner-config/run-rust-benchmark.sh select_benchmark
@@ -17,6 +21,10 @@ backends:
   - benchmark-name: concurrent_select
     build-command: cargo build -p benchmark --bin concurrent_select_benchmark -r
     run-command: ./benchmark/runner-config/run-rust-benchmark.sh concurrent_select_benchmark
+
+  - benchmark-name: concurrency_parametrized_select
+    build-command: cargo build -p benchmark --bin concurrent_select_benchmark -r
+    run-command: ./benchmark/runner-config/run-rust-concurrency-benchmark.sh concurrent_select_benchmark
 
   - benchmark-name: batch
     build-command: cargo build -p benchmark --bin batch_benchmark -r
@@ -30,6 +38,10 @@ backends:
     build-command: cargo build -p benchmark --bin concurrent_paging_benchmark -r
     run-command: ./benchmark/runner-config/run-rust-benchmark.sh concurrent_paging_benchmark
 
+  - benchmark-name: concurrency_parametrized_paging
+    build-command: cargo build -p benchmark --bin concurrent_paging_benchmark -r
+    run-command: ./benchmark/runner-config/run-rust-concurrency-benchmark.sh concurrent_paging_benchmark
+
   - benchmark-name: large_select
     build-command: cargo build -p benchmark --bin large_select_benchmark -r
     run-command: ./benchmark/runner-config/run-rust-benchmark.sh large_select_benchmark
@@ -42,6 +54,10 @@ backends:
     build-command: cargo build -p benchmark --bin concurrent_deser_benchmark -r
     run-command: ./benchmark/runner-config/run-rust-benchmark.sh concurrent_deser_benchmark
 
+  - benchmark-name: concurrency_parametrized_deser
+    build-command: cargo build -p benchmark --bin concurrent_deser_benchmark -r
+    run-command: ./benchmark/runner-config/run-rust-concurrency-benchmark.sh concurrent_deser_benchmark
+
   - benchmark-name: ser
     build-command: cargo build -p benchmark --bin ser_benchmark -r
     run-command: ./benchmark/runner-config/run-rust-benchmark.sh ser_benchmark
@@ -49,3 +65,7 @@ backends:
   - benchmark-name: concurrent_ser
     build-command: cargo build -p benchmark --bin concurrent_ser_benchmark -r
     run-command: ./benchmark/runner-config/run-rust-benchmark.sh concurrent_ser_benchmark
+
+  - benchmark-name: concurrency_parametrized_ser
+    build-command: cargo build -p benchmark --bin concurrent_ser_benchmark -r
+    run-command: ./benchmark/runner-config/run-rust-concurrency-benchmark.sh concurrent_ser_benchmark

--- a/benchmark/runner-config/scylladb-driver/config.yml
+++ b/benchmark/runner-config/scylladb-driver/config.yml
@@ -9,11 +9,17 @@ backends:
   - benchmark-name: concurrent_insert
     run-command: ./benchmark/runner-config/run-js-benchmark.sh concurrent_insert scylladb-driver-alpha
 
+  - benchmark-name: concurrency_parametrized_insert
+    run-command: ./benchmark/runner-config/run-js-concurrency-benchmark.sh concurrent_insert scylladb-driver-alpha
+
   - benchmark-name: select
     run-command: ./benchmark/runner-config/run-js-benchmark.sh select scylladb-driver-alpha
 
   - benchmark-name: concurrent_select
     run-command: ./benchmark/runner-config/run-js-benchmark.sh concurrent_select scylladb-driver-alpha
+
+  - benchmark-name: concurrency_parametrized_select
+    run-command: ./benchmark/runner-config/run-js-concurrency-benchmark.sh concurrent_select scylladb-driver-alpha
 
   - benchmark-name: batch
     run-command: ./benchmark/runner-config/run-js-benchmark.sh batch scylladb-driver-alpha
@@ -24,6 +30,9 @@ backends:
   - benchmark-name: concurrent_paging
     run-command: ./benchmark/runner-config/run-js-benchmark.sh concurrent_paging scylladb-driver-alpha
 
+  - benchmark-name: concurrency_parametrized_paging
+    run-command: ./benchmark/runner-config/run-js-concurrency-benchmark.sh concurrent_paging scylladb-driver-alpha
+
   - benchmark-name: large_select
     run-command: ./benchmark/runner-config/run-js-benchmark.sh large_select scylladb-driver-alpha
 
@@ -33,8 +42,14 @@ backends:
   - benchmark-name: concurrent_deser
     run-command: ./benchmark/runner-config/run-js-benchmark.sh concurrent_deser scylladb-driver-alpha
 
+  - benchmark-name: concurrency_parametrized_deser
+    run-command: ./benchmark/runner-config/run-js-concurrency-benchmark.sh concurrent_deser scylladb-driver-alpha
+
   - benchmark-name: ser
     run-command: ./benchmark/runner-config/run-js-benchmark.sh ser scylladb-driver-alpha
 
   - benchmark-name: concurrent_ser
     run-command: ./benchmark/runner-config/run-js-benchmark.sh concurrent_ser scylladb-driver-alpha
+
+  - benchmark-name: concurrency_parametrized_ser
+    run-command: ./benchmark/runner-config/run-js-concurrency-benchmark.sh concurrent_ser scylladb-driver-alpha

--- a/benchmark/runner-config/scylladb-driver/config.yml
+++ b/benchmark/runner-config/scylladb-driver/config.yml
@@ -4,37 +4,37 @@ defaults:
 
 backends:
   - benchmark-name: insert
-    run-command: ./benchmark/runner-config/run-js-benchmark.sh insert.js scylladb-driver-alpha
+    run-command: ./benchmark/runner-config/run-js-benchmark.sh insert scylladb-driver-alpha
 
   - benchmark-name: concurrent_insert
-    run-command: ./benchmark/runner-config/run-js-benchmark.sh concurrent_insert.js scylladb-driver-alpha
+    run-command: ./benchmark/runner-config/run-js-benchmark.sh concurrent_insert scylladb-driver-alpha
 
   - benchmark-name: select
-    run-command: ./benchmark/runner-config/run-js-benchmark.sh select.js scylladb-driver-alpha
+    run-command: ./benchmark/runner-config/run-js-benchmark.sh select scylladb-driver-alpha
 
   - benchmark-name: concurrent_select
-    run-command: ./benchmark/runner-config/run-js-benchmark.sh concurrent_select.js scylladb-driver-alpha
+    run-command: ./benchmark/runner-config/run-js-benchmark.sh concurrent_select scylladb-driver-alpha
 
   - benchmark-name: batch
-    run-command: ./benchmark/runner-config/run-js-benchmark.sh batch.js scylladb-driver-alpha
+    run-command: ./benchmark/runner-config/run-js-benchmark.sh batch scylladb-driver-alpha
 
   - benchmark-name: paging
-    run-command: ./benchmark/runner-config/run-js-benchmark.sh paging.js scylladb-driver-alpha
+    run-command: ./benchmark/runner-config/run-js-benchmark.sh paging scylladb-driver-alpha
 
   - benchmark-name: concurrent_paging
-    run-command: ./benchmark/runner-config/run-js-benchmark.sh concurrent_paging.js scylladb-driver-alpha
+    run-command: ./benchmark/runner-config/run-js-benchmark.sh concurrent_paging scylladb-driver-alpha
 
   - benchmark-name: large_select
-    run-command: ./benchmark/runner-config/run-js-benchmark.sh large_select.js scylladb-driver-alpha
+    run-command: ./benchmark/runner-config/run-js-benchmark.sh large_select scylladb-driver-alpha
 
   - benchmark-name: deser
-    run-command: ./benchmark/runner-config/run-js-benchmark.sh deser.js scylladb-driver-alpha
+    run-command: ./benchmark/runner-config/run-js-benchmark.sh deser scylladb-driver-alpha
 
   - benchmark-name: concurrent_deser
-    run-command: ./benchmark/runner-config/run-js-benchmark.sh concurrent_deser.js scylladb-driver-alpha
+    run-command: ./benchmark/runner-config/run-js-benchmark.sh concurrent_deser scylladb-driver-alpha
 
   - benchmark-name: ser
-    run-command: ./benchmark/runner-config/run-js-benchmark.sh ser.js scylladb-driver-alpha
+    run-command: ./benchmark/runner-config/run-js-benchmark.sh ser scylladb-driver-alpha
 
   - benchmark-name: concurrent_ser
-    run-command: ./benchmark/runner-config/run-js-benchmark.sh concurrent_ser.js scylladb-driver-alpha
+    run-command: ./benchmark/runner-config/run-js-benchmark.sh concurrent_ser scylladb-driver-alpha


### PR DESCRIPTION
Refs: #73 

With planned changes that touch the concurrency, we would want to see the driver performance across different concurrency levels.

This PR introduces a refactor to the current benchmarks, which would allow us to add benchmarks parameterised on the concurrency level easily, and adds those benchmarks.

I would recommend reviewing the first commit in vscode (or similar), to better see what changes and what's kept unchanged

Introduces changes that were generated with LLM.

Example results [with not yet published PR] (x axis is the concurrency level on the benchmark) - I  need to add beter labeling support to the benchmarking tool)


<img width="1920" height="1080" alt="throughput_vs_concurrency_lelel_deser" src="https://github.com/user-attachments/assets/6322736b-0c19-4190-87c2-8374922f14c3" />
<img width="1920" height="1080" alt="throughput_vs_concurrency_lelel" src="https://github.com/user-attachments/assets/45b92700-feb1-4f96-a388-407f21e013c9" />
