### PR TITLE
Update github actions dependencies

### DIFF
--- a/.github/common/integration/action.yml
+++ b/.github/common/integration/action.yml
@@ -9,7 +9,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: actions/setup-java@v4
+    - uses: actions/setup-java@v5
       with:
         distribution: 'temurin'
         java-version: '8'

--- a/.github/common/integration/action.yml
+++ b/.github/common/integration/action.yml
@@ -9,7 +9,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: actions/setup-java@v5
+    - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
       with:
         distribution: 'temurin'
         java-version: '8'

--- a/.github/common/setup/action.yml
+++ b/.github/common/setup/action.yml
@@ -17,19 +17,19 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
     - name: Setup node
-      uses: actions/setup-node@v6
+      uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
       with:
         node-version: ${{ inputs.node-version }}
         cache: npm
     - name: Install
-      uses: dtolnay/rust-toolchain@stable
+      uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
       with:
         toolchain: stable
         targets: ${{ inputs.target }}
     - name: Cache cargo
-      uses: actions/cache@v5
+      uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
       with:
         path: |
           ~/.cargo/registry/index/

--- a/.github/common/setup/action.yml
+++ b/.github/common/setup/action.yml
@@ -17,9 +17,9 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Setup node
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
         node-version: ${{ inputs.node-version }}
         cache: npm
@@ -29,7 +29,7 @@ runs:
         toolchain: stable
         targets: ${{ inputs.target }}
     - name: Cache cargo
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: |
           ~/.cargo/registry/index/

--- a/.github/workflows/check-docs.yml
+++ b/.github/workflows/check-docs.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
           fetch-depth: 0
@@ -26,7 +26,7 @@ jobs:
       # --- js-doc ---
 
       - name: Set up Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: 20
           cache: npm
@@ -40,7 +40,7 @@ jobs:
       # --- mdBook ---
 
       - name: Set up mdBook
-        uses: peaceiris/actions-mdbook@v2
+        uses: peaceiris/actions-mdbook@ee69d230fe19748b7abf22df32acaa93833fad08 # v2.0.0
         with:
           mdbook-version: 'latest'
 
@@ -51,7 +51,7 @@ jobs:
       # --- Sphinx ---
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: '3.10'
 

--- a/.github/workflows/check-docs.yml
+++ b/.github/workflows/check-docs.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           persist-credentials: false
           fetch-depth: 0
@@ -26,7 +26,7 @@ jobs:
       # --- js-doc ---
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 20
           cache: npm
@@ -51,7 +51,7 @@ jobs:
       # --- Sphinx ---
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.10'
 

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -16,9 +16,9 @@ jobs:
   check-code-quality:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Setup node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 20
           cache: npm

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -16,9 +16,9 @@ jobs:
   check-code-quality:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Setup node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: 20
           cache: npm

--- a/.github/workflows/docs-pages.yml
+++ b/.github/workflows/docs-pages.yml
@@ -16,24 +16,24 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ github.event.repository.default_branch }}
           persist-credentials: false
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: '3.12'
 
       - name: Set up Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: '20'
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v8
+        uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
 
       - name: Set up env
         run: make -C docs setupenv
@@ -53,7 +53,7 @@ jobs:
             .
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: github-pages
           path: ${{ runner.temp }}/artifact.tar
@@ -79,4 +79,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v5
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0

--- a/.github/workflows/docs-pages.yml
+++ b/.github/workflows/docs-pages.yml
@@ -16,24 +16,24 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event.repository.default_branch }}
           persist-credentials: false
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.12'
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '20'
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@v8
 
       - name: Set up env
         run: make -C docs setupenv
@@ -53,7 +53,7 @@ jobs:
             .
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: github-pages
           path: ${{ runner.temp }}/artifact.tar
@@ -79,4 +79,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -36,7 +36,7 @@ jobs:
     name: Build and run examples - ${{ matrix.target }} - node@${{ matrix.node }}
     runs-on: ${{ matrix.host }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./.github/common/setup
         with:
           host: ${{ matrix.host }}

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -36,7 +36,7 @@ jobs:
     name: Build and run examples - ${{ matrix.target }} - node@${{ matrix.node }}
     runs-on: ${{ matrix.host }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/common/setup
         with:
           host: ${{ matrix.host }}

--- a/.github/workflows/extended-ci.yml
+++ b/.github/workflows/extended-ci.yml
@@ -33,7 +33,7 @@ jobs:
     name: Build and run examples - ${{ matrix.target }} - node@${{ matrix.node }}
     runs-on: ${{ matrix.host }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./.github/common/setup
         with:
           host: ${{ matrix.host }}
@@ -55,7 +55,7 @@ jobs:
     runs-on: ${{ matrix.settings.host }}
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./.github/common/setup
         with:
           host: ${{ matrix.settings.host }}

--- a/.github/workflows/extended-ci.yml
+++ b/.github/workflows/extended-ci.yml
@@ -33,7 +33,7 @@ jobs:
     name: Build and run examples - ${{ matrix.target }} - node@${{ matrix.node }}
     runs-on: ${{ matrix.host }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/common/setup
         with:
           host: ${{ matrix.host }}
@@ -55,7 +55,7 @@ jobs:
     runs-on: ${{ matrix.settings.host }}
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/common/setup
         with:
           host: ${{ matrix.settings.host }}

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -31,7 +31,7 @@ jobs:
     runs-on: ${{ matrix.settings.host }}
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/common/setup
         with:
           host: ${{ matrix.settings.host }}

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -31,7 +31,7 @@ jobs:
     runs-on: ${{ matrix.settings.host }}
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./.github/common/setup
         with:
           host: ${{ matrix.settings.host }}

--- a/.github/workflows/milestone-sync.yml
+++ b/.github/workflows/milestone-sync.yml
@@ -20,7 +20,7 @@ permissions:
 jobs:
   sync-manual:
     if: github.event_name == 'workflow_dispatch'
-    uses: scylladb-actions/workflows/.github/workflows/milestone-sync-reusable.yml@main
+    uses: scylladb-actions/workflows/.github/workflows/milestone-sync-reusable.yml@4cda14e83ac08a816ba24700bddf2254a9dcd3dc
     with:
       milestone: ${{ inputs.milestone }}
       config-path: milestone-sync/config.yaml
@@ -29,7 +29,7 @@ jobs:
 
   sync-automatic:
     if: github.event_name != 'workflow_dispatch'
-    uses: scylladb-actions/workflows/.github/workflows/milestone-sync-reusable.yml@main
+    uses: scylladb-actions/workflows/.github/workflows/milestone-sync-reusable.yml@4cda14e83ac08a816ba24700bddf2254a9dcd3dc
     with:
       config-path: milestone-sync/config.yaml
       github-event-name: ${{ github.event_name }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Build ${{ matrix.settings.target }}
         run: ${{ matrix.settings.build }}
       - name: Upload artifact - ${{ matrix.settings.target }}
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: bindings-${{ matrix.settings.target }}
           path: ${{ matrix.settings.files }}
@@ -55,11 +55,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@v6
         with:
           node-version: 24
       - name: Download artifact
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@v8
         with:
           name: bindings-x86_64-unknown-linux-gnu
       - name: Install dependencies
@@ -86,13 +86,13 @@ jobs:
     runs-on: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@v6
         with:
           node-version: 24
       - name: Install dependencies
         run: npm i
       - name: Download artifact
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@v8
         with:
           merge-multiple: true
       - name: Setup 3-node Scylla cluster
@@ -125,7 +125,7 @@ jobs:
       id-token: write
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@v6
         with:
           node-version: 24
           registry-url: "https://registry.npmjs.org"
@@ -136,7 +136,7 @@ jobs:
       - name: create npm dirs
         run: npm run create-npm-dirs
       - name: Download all artifacts
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@v8
         with:
           path: artifacts
           merge-multiple: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
     name: Build for release stable - ${{ matrix.settings.target }}
     runs-on: ${{ matrix.settings.host }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/common/setup
         with:
           node-version: 24
@@ -43,7 +43,7 @@ jobs:
       - name: Build ${{ matrix.settings.target }}
         run: ${{ matrix.settings.build }}
       - name: Upload artifact - ${{ matrix.settings.target }}
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: bindings-${{ matrix.settings.target }}
           path: ${{ matrix.settings.files }}
@@ -54,12 +54,12 @@ jobs:
     name: test built package - x86_64-unknown-linux-gnu
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: 24
       - name: Download artifact
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: bindings-x86_64-unknown-linux-gnu
       - name: Install dependencies
@@ -85,14 +85,14 @@ jobs:
     name: test examples - aarch64-unknown-linux-gnu - node@24
     runs-on: ubuntu-24.04-arm
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: 24
       - name: Install dependencies
         run: npm i
       - name: Download artifact
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           merge-multiple: true
       - name: Setup 3-node Scylla cluster
@@ -124,8 +124,8 @@ jobs:
       contents: write
       id-token: write
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: 24
           registry-url: "https://registry.npmjs.org"
@@ -136,7 +136,7 @@ jobs:
       - name: create npm dirs
         run: npm run create-npm-dirs
       - name: Download all artifacts
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path: artifacts
           merge-multiple: true

--- a/.github/workflows/typescript-tests.yml
+++ b/.github/workflows/typescript-tests.yml
@@ -19,7 +19,7 @@ jobs:
     name: Build and run typescript tests - node@20
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./.github/common/setup
         with:
           host: ubuntu-latest

--- a/.github/workflows/typescript-tests.yml
+++ b/.github/workflows/typescript-tests.yml
@@ -19,7 +19,7 @@ jobs:
     name: Build and run typescript tests - node@20
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/common/setup
         with:
           host: ubuntu-latest

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -22,7 +22,7 @@ jobs:
     name: Build and run unit tests - node@20
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./.github/common/setup
         with:
           host: ubuntu-latest

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -22,7 +22,7 @@ jobs:
     name: Build and run unit tests - node@20
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/common/setup
         with:
           host: ubuntu-latest

--- a/MAINTENANCE.md
+++ b/MAINTENANCE.md
@@ -118,3 +118,18 @@ but we still want to resolve those alerts.
 When bumping version with `npm update` packages will be updated according to `package.json` semantics.
 Updating this way will only update the lock file.
 If this is not enough, you can manually update `package.json` or `package-lock.json`.
+
+### Updating workflows
+
+Note: There is no need to update workflows every release - this is used only for development purposes.
+This part should only be done if the current setup is insufficient
+(ex. there is a discovered vulnerability in current version, or there is a new feature).
+
+Currently GitHub workflows are fixed to specific commits. This is done to reduce the supply chain attack surface in this repository.
+When updating those workflows, to find the correct commit SHA for a new version, go to the action's repository on GitHub,
+navigate to the desired release tag, and copy the full commit SHA from the tag's commit page.
+Remember to ensure the commit you are pinning to is not
+an [impostor commit](https://www.chainguard.dev/unchained/what-the-fork-imposter-commits-in-github-actions-and-ci-cd) - open the commit on GitHub page
+and ensure there is no `This commit does not belong to any branch on this repository` message at the top of the page.
+When updating the workflow you need to update both the `uses:` directive in workflow files and
+`Actions -> General -> Allow or block specified actions and reusable workflows` option in repository options.


### PR DESCRIPTION
This PR updates all GH actions dependencies and pins them to a specific version.

Pinning is done for every action in the repo. I also updated repo settings to allow only those actions to run (meaning that any hash change should require updating settings not just code)

(You can see [this failed run log](https://github.com/scylladb/nodejs-rs-driver/actions/runs/24187570065/attempts/2?pr=430) - I purposely removed one dependency from settings to ensure this check is triggered)