### PR TITLE
New node api utils

### DIFF
--- a/src/metadata/host.rs
+++ b/src/metadata/host.rs
@@ -1,15 +1,14 @@
 use napi::bindgen_prelude::Buffer;
-use napi::{JsValue, bindgen_prelude::JsObjectValue};
 
 use crate::{session::SessionWrapper, utils::to_napi_obj::define_rust_to_js_convertible_object};
 
 define_rust_to_js_convertible_object!(
-    HostWrapper {
-        host_id, hostId: Buffer,
-        address, address: String,
-        datacenter, datacenter: Option<String>,
-        rack, rack: Option<String>,
-    }
+pub struct HostWrapper {
+    host_id, hostId: Buffer,
+    address, address: String,
+    datacenter, datacenter: Option<String>,
+    rack, rack: Option<String>,
+}
 );
 
 #[napi]

--- a/src/requests/request.rs
+++ b/src/requests/request.rs
@@ -18,7 +18,7 @@ pub(crate) struct PreparedStatementWrapper {
 // retry?, policies.retry.RetryPolicy;
 // routingKey?, Buffer | Buffer[];
 define_js_to_rust_convertible_object!(
-struct QueryOptionsObj{
+pub struct QueryOptionsObj{
     auto_page, autoPage: bool,
     capture_stack_trace, captureStackTrace: bool,
     consistency, consistency: u16,

--- a/src/session/config.rs
+++ b/src/session/config.rs
@@ -37,7 +37,7 @@ pub enum TlsVersion {
 define_js_to_rust_convertible_object!(
 // We manually implement Debug to avoid accidentally leaking private key and passphrase in logs
 #[derive(PartialEq, Eq)]
-struct SslOptions {
+pub struct SslOptions {
     ca, ca: Vec<String>,
     cert, cert: String,
     sigalgs, sigalgs: String,
@@ -55,7 +55,7 @@ struct SslOptions {
 
 #[rustfmt::skip] // fmt splits each field definition into multiple lines
 define_js_to_rust_convertible_object!(
-struct LoadBalancingConfig {
+pub struct LoadBalancingConfig {
     prefer_datacenter, preferDatacenter: String,
     prefer_rack, preferRack: String,
     token_aware, tokenAware: bool,
@@ -75,13 +75,13 @@ pub enum RetryPolicyKind {
 // For now, we support only fixed address translator.
 // Once we decide to support more, we can come up with more generic configuration.
 define_js_to_rust_convertible_object!(
-struct FixedAddressTranslatorConfig {
+pub struct FixedAddressTranslatorConfig {
     // HashMap cannot be retrieved directly.
     address_mapping, addressMapping: Vec<(SocketAddrWrapper, SocketAddrWrapper)>,
 });
 
 define_js_to_rust_convertible_object!(
-struct SessionOptions {
+pub struct SessionOptions {
     connect_points, connectPoints: Vec<String>,
     keyspace, keyspace: String,
     application_name, applicationName: String,

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -2,4 +2,5 @@ pub mod js_results_tests;
 pub mod option_tests;
 pub mod socket_addr_tests;
 pub mod test_utils;
+pub mod to_napi_obj_tests;
 pub mod utils_tests;

--- a/src/tests/to_napi_obj_tests.rs
+++ b/src/tests/to_napi_obj_tests.rs
@@ -1,0 +1,76 @@
+use std::collections::HashMap;
+
+use crate::utils::to_napi_obj::{NamedMap, define_rust_to_js_convertible_object};
+
+#[rustfmt::skip] // fmt splits each field definition into multiple lines
+define_rust_to_js_convertible_object!(
+pub struct Coord {
+    x, x: i32,
+    y, y: i32,
+});
+
+define_rust_to_js_convertible_object!(
+pub enum Color where
+    VariantName: kind,
+{
+    Red = 0,
+    Green = 1,
+    Custom {
+        r, r: i32,
+        g, g: i32,
+        b, b: i32,
+    } = 3,
+});
+
+/// Returns a plain struct produced by the macro.
+/// Expected JS shape: `{ x: 10, y: 20 }`
+#[napi]
+pub fn tests_named_map_struct() -> Coord {
+    Coord { x: 10, y: 20 }
+}
+
+/// Returns a `Color` enum variant produced by the macro.
+/// Cases:
+/// - `0` -> `{ kind: 0 }` (Red)
+/// - `1` -> `{ kind: 1 }` (Green)
+/// - `3` -> `{ kind: 3, r: 128, g: 0, b: 255 }` (Custom)
+#[napi]
+pub fn tests_named_map_enum(case: i32) -> Color {
+    match case {
+        0 => Color::Red,
+        1 => Color::Green,
+        3 => Color::Custom {
+            r: 128,
+            g: 0,
+            b: 255,
+        },
+        _ => unimplemented!("Unknown test case"),
+    }
+}
+
+/// Returns a `NamedMap` of i32 values (V == W, identity `Into`).
+/// Expected JS shape: `{ a: 1, b: 2, c: 3 }`
+#[napi]
+pub fn tests_named_map_i32() -> NamedMap<String, i32> {
+    let mut m = HashMap::new();
+    m.insert("a".to_string(), 1i32);
+    m.insert("b".to_string(), 2i32);
+    m.insert("c".to_string(), 3i32);
+    NamedMap::new(m)
+}
+
+/// Returns a `NamedMap` whose values are converted via `From` (`i32 -> Coord`).
+/// Expected JS shape: `{ origin: { x: 0, y: 0 }, point: { x: 5, y: -3 } }`
+#[napi]
+pub fn tests_named_map_with_conversion() -> NamedMap<String, (i32, i32), Coord> {
+    let mut m = HashMap::new();
+    m.insert("origin".to_string(), (0i32, 0i32));
+    m.insert("point".to_string(), (5i32, -3i32));
+    NamedMap::new(m)
+}
+
+impl From<(i32, i32)> for Coord {
+    fn from((x, y): (i32, i32)) -> Self {
+        Coord { x, y }
+    }
+}

--- a/src/utils/from_napi_obj.rs
+++ b/src/utils/from_napi_obj.rs
@@ -14,7 +14,7 @@
 /// Calling this macro in a following way:
 /// ```rust
 /// define_js_to_rust_convertible_object!(
-/// struct Example {
+/// pub struct Example {
 ///     some_field, someField: bool,
 ///     other_field, otherField: i32
 /// }
@@ -23,7 +23,7 @@
 ///
 /// Will create the following struct:
 /// ```rust
-/// struct Example {
+/// pub struct Example {
 ///     some_field: Option<bool>,
 ///     other_field: Option<i32>,
 /// }
@@ -43,13 +43,13 @@
 /// ```rust
 /// define_js_to_rust_convertible_object!(
 /// #[derive(PartialEq, Eq)]
-/// struct SslOptions {
+/// pub struct SslOptions {
 /// ...
 /// }
 /// ```
 /// This can be useful, as the Debug, PartialEq, Eq are added by default.
 macro_rules! define_js_to_rust_convertible_object {
-    (#[derive($($derive:ident),*)]struct $struct_name: ident{$($field_name:ident, $js_name:ident: $field_type:ty),*,}) => {
+    (#[derive($($derive:ident),*)]pub struct $struct_name: ident{$($field_name:ident, $js_name:ident: $field_type:ty),*,}) => {
         #[derive($($derive),*)]
         pub struct $struct_name {
             $(
@@ -75,12 +75,12 @@ macro_rules! define_js_to_rust_convertible_object {
         }
 
     };
-    (struct $struct_name: ident{$($field_name:ident, $js_name:ident: $field_type:ty),*,}) =>{
+    (pub struct $struct_name: ident{$($field_name:ident, $js_name:ident: $field_type:ty),*,}) =>{
         // The PartialEq and Eq are used only for testing purposes
         // If at some point those traits become a problem, you can manually implement them.
         define_js_to_rust_convertible_object!(
             #[derive(Debug, PartialEq, Eq)]
-            struct $struct_name {
+            pub struct $struct_name {
                 $($field_name, $js_name: $field_type),*,
             }
         );

--- a/src/utils/to_napi_obj.rs
+++ b/src/utils/to_napi_obj.rs
@@ -11,16 +11,16 @@
 /// Calling this macro in a following way:
 /// ```rust
 /// define_rust_to_js_convertible_object!(
-///     Example {
-///         some_field, someField: bool,
-///         other_field, otherField: i32
-///     }
+/// pub struct Example {
+///     some_field, someField: bool,
+///     other_field, otherField: i32,
+/// }
 /// );
 /// ```
 ///
 /// Will create the following struct:
 /// ```rust
-/// struct Example {
+/// pub struct Example {
 ///     some_field: bool,
 ///     other_field: i32,
 /// }
@@ -31,7 +31,9 @@
 /// {someField: false, otherField: 42}
 /// ```
 macro_rules! define_rust_to_js_convertible_object {
-    ($struct_name: ident{$($field_name:ident, $js_name:ident: $field_type:ty),*,}) => {
+    (pub struct $struct_name: ident{
+        $($field_name:ident, $js_name:ident: $field_type:ty),*,
+    }) => {
         pub struct $struct_name {
             $(
                 pub $field_name: $field_type,
@@ -46,6 +48,7 @@ macro_rules! define_rust_to_js_convertible_object {
                 env: ::napi::sys::napi_env,
                 val: Self,
             ) -> ::napi::Result<napi::sys::napi_value> {
+                use ::napi::{JsValue, bindgen_prelude::JsObjectValue};
                 let env = ::napi::Env::from_raw(env);
                 let mut o = ::napi::bindgen_prelude::Object::new(&env)?;
                 $(o.set_named_property(stringify!($js_name), val.$field_name)?;)*

--- a/src/utils/to_napi_obj.rs
+++ b/src/utils/to_napi_obj.rs
@@ -1,3 +1,10 @@
+use std::{collections::HashMap, marker::PhantomData};
+
+use napi::{
+    Env, JsValue,
+    bindgen_prelude::{JsObjectValue, Object, ToNapiValue},
+};
+
 /// This macro creates a struct with a defined list of field,
 /// that can be used as an return value to JS exposed function.
 ///
@@ -57,6 +64,65 @@ macro_rules! define_rust_to_js_convertible_object {
         }
 
     };
+}
+
+/// Structure that converts a Rust Map into a JS object
+/// You can provide it with values that already implement ToNapiValue,
+/// or values that can be converted to wrappers using Into trait.
+///
+/// - K is the key type, must be convertible to string
+/// - V is the type of value you provided at the construction
+/// - W is the wrapper type, that has to implement From<V> trait (and ToNapiValue)
+///
+/// By default W = V
+pub struct NamedMap<K, V, W = V>
+where
+    // Note, that JS allows objects keyed by something other than strings
+    // For now we do not need such functionality
+    K: AsRef<str>,
+    W: ToNapiValue,
+    V: Into<W>,
+{
+    pub(crate) map: HashMap<K, V>,
+    _p: PhantomData<W>,
+}
+
+impl<K, V, W> NamedMap<K, V, W>
+where
+    K: AsRef<str>,
+    W: ToNapiValue,
+    V: Into<W>,
+{
+    pub(crate) fn new(v: HashMap<K, V>) -> Self {
+        NamedMap {
+            map: v,
+            _p: PhantomData,
+        }
+    }
+}
+
+impl<K, V, W> ToNapiValue for NamedMap<K, V, W>
+where
+    K: AsRef<str>,
+    W: ToNapiValue,
+    V: Into<W>,
+{
+    /// # Safety
+    ///
+    /// Valid pointer to napi env must be provided
+    unsafe fn to_napi_value(
+        env: napi::sys::napi_env,
+        val: Self,
+    ) -> napi::Result<napi::sys::napi_value> {
+        let env = Env::from_raw(env);
+        let mut obj = Object::new(&env)?;
+
+        for (key, val) in val.map.into_iter() {
+            obj.set_named_property(key.as_ref(), val.into())?;
+        }
+
+        Ok(obj.raw())
+    }
 }
 
 pub(crate) use define_rust_to_js_convertible_object;

--- a/src/utils/to_napi_obj.rs
+++ b/src/utils/to_napi_obj.rs
@@ -13,6 +13,8 @@ use napi::{
 /// This is done to keep both the Rust and JS conventions for naming variables.
 /// Each of the fields is passed by value.
 ///
+/// It can be applied on both a struct and enum with named values at variants.
+///
 /// # Example
 ///
 /// Calling this macro in a following way:
@@ -36,6 +38,30 @@ use napi::{
 /// Which will create the following JS Object:
 /// ```js
 /// {someField: false, otherField: 42}
+/// ```
+///
+/// Similarly when creating an enum in a following way:
+/// ```rust
+/// define_rust_to_js_convertible_object!(
+/// pub enum ExampleEnum
+/// where VariantName: kind {
+///     Case1 = 1,
+///     Case2{some_data, someData: bool,} = 2,
+/// });
+/// ```
+/// Will create the following type:
+/// ```rust
+/// pub enum ExampleEnum {
+///     Case1,
+///     Case2{some_data: bool}
+/// }
+/// ```
+///
+/// Which will create the following JS Object:
+///
+/// ```js
+/// {kind: 1} // Case 1
+/// {kind: 2, someData: false} // Case 2
 /// ```
 macro_rules! define_rust_to_js_convertible_object {
     (pub struct $struct_name: ident{
@@ -64,6 +90,51 @@ macro_rules! define_rust_to_js_convertible_object {
         }
 
     };
+    (pub enum $enum_name:ident
+        where VariantName: $variant_val_name: ident$(,)?
+        {
+        $($variant_name:ident
+            $( { $(
+                $field_name:ident, $js_name:ident: $field_type:ty),*,
+            } )?
+        = $val: literal),*,}) => {
+        pub enum $enum_name {
+            $(
+                $variant_name $( {
+                    $(
+                        $field_name: $field_type,
+                    )*
+                } )?,
+            )*
+        }
+
+        impl ::napi::bindgen_prelude::ToNapiValue for $enum_name {
+            /// # Safety
+            ///
+            /// Valid pointer to napi env must be provided
+            unsafe fn to_napi_value(
+                env: ::napi::sys::napi_env,
+                val: Self,
+            ) -> ::napi::Result<napi::sys::napi_value> {
+                use ::napi::{JsValue, bindgen_prelude::JsObjectValue};
+                let env = ::napi::Env::from_raw(env);
+                let mut o = ::napi::bindgen_prelude::Object::new(&env)?;
+                match val{
+                    $(
+                        $enum_name::$variant_name $( {
+                            $( $field_name, )*
+                        } )? => {
+                            o.set_named_property(stringify!($variant_val_name), $val)?;
+                            $(
+                                $(o.set_named_property(stringify!($js_name), $field_name)?;)*
+                            )?
+                        },
+                    )*
+                }
+                Ok(o.raw())
+            }
+        }
+    }
 }
 
 /// Structure that converts a Rust Map into a JS object

--- a/test/unit/to-napi-obj-tests.js
+++ b/test/unit/to-napi-obj-tests.js
@@ -1,0 +1,41 @@
+"use strict";
+const { assert } = require("chai");
+const rust = require("../../index");
+
+describe("define_rust_to_js_convertible_object and NamedMap", function () {
+    describe("struct variant", function () {
+        it("should return a plain object with the correct fields", function () {
+            const result = rust.testsNamedMapStruct();
+            assert.deepEqual(result, { x: 10, y: 20 });
+        });
+    });
+
+    describe("enum variants", function () {
+        const cases = [
+            [0, { kind: 0 }],
+            [1, { kind: 1 }],
+            [3, { kind: 3, r: 128, g: 0, b: 255 }],
+        ];
+
+        cases.forEach(([caseId, expected]) => {
+            it(`case ${caseId} should produce ${JSON.stringify(expected)}`, function () {
+                assert.deepEqual(rust.testsNamedMapEnum(caseId), expected);
+            });
+        });
+    });
+
+    describe("NamedMap<String, i32, i32>", function () {
+        it("should return a plain object keyed by string with numeric values", function () {
+            const result = rust.testsNamedMapI32();
+            assert.deepEqual(result, { a: 1, b: 2, c: 3 });
+        });
+    });
+
+    describe("NamedMap with From conversion (tuple -> struct)", function () {
+        it("should convert values via From and return nested objects", function () {
+            const result = rust.testsNamedMapWithConversion();
+            assert.deepEqual(result.origin, { x: 0, y: 0 });
+            assert.deepEqual(result.point, { x: 5, y: -3 });
+        });
+    });
+});


### PR DESCRIPTION
This PR adds two new utilities designed to help converting Rust objects into JS:

- HashMaps into named objects
- Enums with values into JS objects

Those types will simplify the code when creating Metadata implementation