### PR TITLE
fix: docs publication (multiversion)

### DIFF
--- a/docs/_extensions/jsdoc_content.py
+++ b/docs/_extensions/jsdoc_content.py
@@ -55,9 +55,10 @@ _CATEGORY_ALIASES = {"globals": "global"}
 
 
 def _resolve_jsdoc_dir(config, env):
-    """Return the resolved Path to the JSDoc HTML output directory."""
+    """Return the resolved Path to the JSDoc HTML output directory.
+    """
     rel = config.jsdoc_html_dir or "../../public/docs"
-    return Path(env.app.confdir, rel).resolve()
+    return Path(env.srcdir, rel).resolve()
 
 
 def _parse_nav_index(jsdoc_dir):

--- a/docs/_extensions/jsdoc_content.py
+++ b/docs/_extensions/jsdoc_content.py
@@ -29,7 +29,7 @@ Supported category names:
 
 Configuration in ``conf.py``::
 
-    jsdoc_html_dir = "../../public/docs"   # relative to conf.py
+    jsdoc_html_dir = "../../public/docs"   # relative to the Sphinx source dir
 """
 
 import posixpath

--- a/docs/_extensions/jsdoc_content.py
+++ b/docs/_extensions/jsdoc_content.py
@@ -55,8 +55,7 @@ _CATEGORY_ALIASES = {"globals": "global"}
 
 
 def _resolve_jsdoc_dir(config, env):
-    """Return the resolved Path to the JSDoc HTML output directory.
-    """
+    """Return the resolved Path to the JSDoc HTML output directory."""
     rel = config.jsdoc_html_dir or "../../public/docs"
     return Path(env.srcdir, rel).resolve()
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -48,7 +48,7 @@ pygments_style = "sphinx"
 
 # -- Options for jsdoc_content extension ----------------------------
 
-# Path to JSDoc HTML output (relative to this conf.py)
+# Path to JSDoc HTML output (relative to the Sphinx source dir)
 jsdoc_html_dir = "../../public/docs"
 
 # GitHub repository for source links (e.g. "Source: client.js, line 44")


### PR DESCRIPTION
Closes https://github.com/scylladb/nodejs-rs-driver/issues/433

## Motivation

The `jsdoc-include` extension was looking for JSDoc HTML in the wrong folder during multiversion builds, so API pages came out empty on the published site.

## How to test

Run the following locally:

```
rm -rf ../public/docs && make multiversion
```

This should generate the API reference correctly, whereas previously it did not. Previously, it only worked if you ran `make preview` before.

After merging, verify that the docs are generated at [nodejs-rs-driver.docs.scylladb.com/stable/api/Client.html](https://nodejs-rs-driver.docs.scylladb.com/stable/api/Client.html)