### PR TITLE
Docs/add openssl system dependency

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,6 +4,14 @@ Thank you for your interest in contributing to our driver!
 
 ## Local installation and build process
 
+### System dependencies
+
+The Rust build requires OpenSSL development headers and `pkg-config`. Install them before building:
+
+- **Ubuntu/Debian:** `sudo apt install libssl-dev pkg-config`
+- **Fedora/RHEL:** `sudo dnf install openssl-devel pkgconf`
+- **Arch:** `sudo pacman -S openssl pkgconf`
+
 ### Install dependencies
 
 You can install required packages with the following command:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,12 +20,6 @@ You can install required packages with the following command:
 npm install
 ```
 
-You also need to install [NAPI-RS cli](https://napi.rs/docs/introduction/getting-started#install-cli):
-
-```bash
-npm install -g @napi-rs/cli
-```
-
 ### Building
 
 For build process use this command:


### PR DESCRIPTION
## Motivation :brain: 
The build requires OpenSSL development headers and `pkg-config`, but this was not documented anywhere. Without these packages, `npm run build:debug` (and `npm run build`) fails with:
```shell
warning: openssl-sys@0.9.113: Could not find directory of OpenSSL installation, and this `-sys` crate cannot proceed without this knowledge. If OpenSSL is installed and this crate had trouble finding it,  you can set the `OPENSSL_DIR` environment variable for the compilation process. See stderr section below for further information.
error: failed to run custom build command for `openssl-sys v0.9.113`
```
This PR adds a "System dependencies" section to `CONTRIBUTING.md` listing the required system packages for common Linux distributions.

Additionally, `CONTRIBUTING.md` instructed developers to install `@napi-rs/cli` globally, but this is unnecessary - it is already listed as a devDependency in `package.json` and npm makes it available automatically when running scripts.

## Changes :wrench: 

- Add "System dependencies" section documenting required OpenSSL packages for common Linux distributions :heavy_plus_sign: 
- Remove redundant `npm install -g @napi-rs/cli step` 🗑️

## Testing :checkered_flag: 
Tested on: Ubuntu 24.04.4 LTS - confirmed the build fails without libssl-dev & pkg-config, and succeeds after installing them.