### PR TITLE
advertise new driver name to the server

### DIFF
--- a/src/options.rs
+++ b/src/options.rs
@@ -1,2 +1,2 @@
-pub const DEFAULT_DRIVER_NAME: &str = "ScyllaDB NodeJS over Rust Driver";
+pub const DEFAULT_DRIVER_NAME: &str = "ScyllaDB Node.js RS Driver";
 pub const DEFAULT_DRIVER_VERSION: &str = env!("CARGO_PKG_VERSION");


### PR DESCRIPTION
The driver's established name is ScyllaDB Node.js RS Driver, so the name advertised to the server is adjusted accordingly.