### PR TITLE
Fix release process

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -93,12 +93,12 @@ jobs:
           node-version: 24
       - name: Install dependencies
         run: npm i
-      - name: Build TypeScript
-        run: npm run build:ts
       - name: Download artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           merge-multiple: true
+      - name: Build TypeScript
+        run: npm run build:ts
       - name: Setup 3-node Scylla cluster
         run: |
           sudo sh -c "echo 2097152 >> /proc/sys/fs/aio-max-nr"
@@ -136,26 +136,30 @@ jobs:
           cache: npm
       - name: Install dependencies
         run: npm i
-      - name: Build TypeScript
-        run: npm run build:ts
       # This creates the directories for subpackage for specific platforms
       - name: create npm dirs
         run: npm run create-npm-dirs
+      # Download includes both the platform specific binaries, and generic index files
       - name: Download all artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path: artifacts
           merge-multiple: true
+      # napi artifacts copies binaries both to specific platform directories and the main directory
+      # We want to release the binaries only in the platform specific directories
+      # Additionally we need index files for compiling TS code
+      - name: Copy index files
+        run: cp ./artifacts/index.js ./artifacts/index.d.ts .
+      - name: Build TypeScript
+        run: npm run build:ts
       # Copies the downloaded artifacts to proper places in the npm package directories
       - name: Move artifacts
         run: npm run artifacts
       # Not necessary for the release, but useful for debugging in case some binaries are missing
       - name: List packages
         run: ls -R ./npm
-      - name: Copy index files
-        run: cp ./artifacts/index.js ./artifacts/index.d.ts .
-      # napi artifacts copies binaries both to specific platform directories and the main directory
-      # We want to release the binaries only in the platform specific directories
+      # Platform specific binaries will be released only in the sub-packages. 
+      # We do not want them in the main package, where the napi-rs has placed them.
       - name: Clean up binaries 
         run: rm *.node
       - name: Publish

--- a/benchmark/package-lock.json
+++ b/benchmark/package-lock.json
@@ -16,7 +16,7 @@
         },
         "..": {
             "name": "scylladb-driver-alpha",
-            "version": "0.5.0",
+            "version": "0.5.1",
             "license": "Apache-2.0",
             "dependencies": {
                 "@types/node": ">=20",

--- a/examples/package-lock.json
+++ b/examples/package-lock.json
@@ -15,7 +15,7 @@
     },
     "..": {
       "name": "scylladb-driver-alpha",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@types/node": ">=20",

--- a/lib/types/.npmignore
+++ b/lib/types/.npmignore
@@ -1,0 +1,3 @@
+# Empty file to override .gitignore for npm publish.
+# The .gitignore in this directory excludes compiled TypeScript output,
+# but those files need to be included in the published package.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "scylladb-driver-alpha",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "scylladb-driver-alpha",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@types/node": ">=20",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scylladb-driver-alpha",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Async CQL driver for Node.js, built on top of Rust driver, optimized for ScyllaDB!",
   "license": "Apache-2.0",
   "contributors": [


### PR DESCRIPTION
There was a bug in the release process of 0.5.0, due to recent TS changes. This PR fixes those problems.

Additionaly I bump the version from 0.5.0 to 0.5.1, since I had to remove the 0.5.0 release, due to it's incorrect state.
0.5.1 was succesfully release and is working correctly now