### PR TITLE
Single threaded tokio

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+use napi::bindgen_prelude::create_custom_tokio_runtime;
+
 #[macro_use]
 extern crate napi_derive;
 
@@ -12,3 +14,13 @@ pub mod session;
 pub mod tests;
 pub mod types;
 pub mod utils;
+
+#[napi_derive::module_init]
+fn init() {
+    let rt = tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(1)
+        .enable_all()
+        .build()
+        .unwrap();
+    create_custom_tokio_runtime(rt);
+}


### PR DESCRIPTION
This commit updates the napi, to use a single threaded tokio runtime. This is one of the approaches presented in #414 PR. Since there is still some work left to merge that PR, this is a temporary improvement for the driver performance.