### PR TITLE
Logging infrastructure

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ regex = "1.11.1"
 thiserror = "2.0.12"
 num-bigint = "0.4.6"
 openssl = "0.10.70"
+tracing = "0.1"
 
 [lints.rust]
 unsafe-op-in-unsafe-fn = "warn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ thiserror = "2.0.12"
 num-bigint = "0.4.6"
 openssl = "0.10.70"
 tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["registry"] }
 
 [lints.rust]
 unsafe-op-in-unsafe-fn = "warn"

--- a/lib/client.js
+++ b/lib/client.js
@@ -62,6 +62,7 @@ class Client extends events.EventEmitter {
      */
     rustClient;
     #encoder;
+    #loggingId;
     /**
      * Creates a new instance of {@link Client}.
      * @param {clientOptions.ClientOptions} options The options for this instance.
@@ -236,6 +237,15 @@ class Client extends events.EventEmitter {
         );
 
         try {
+            {
+                const emitter = this.emit.bind(this, "log");
+                this.#loggingId = rust.setupLogging(
+                    emitter,
+                    // This is only a temporary change. In the following PRs we will configuration for logging.
+                    types.logLevels.warning,
+                );
+            }
+
             this.rustClient = await rust.SessionWrapper.createSession(
                 this.rustOptions,
             );
@@ -244,6 +254,7 @@ class Client extends events.EventEmitter {
             this.connected = false;
             this.connecting = false;
             this.emit("connected", err);
+            this.#closeLogging();
             throw err;
         }
 
@@ -880,6 +891,15 @@ class Client extends events.EventEmitter {
 
         this.connected = false;
         this.isShuttingDown = true;
+
+        this.#closeLogging();
+    }
+
+    #closeLogging() {
+        if (this.#loggingId !== undefined) {
+            rust.removeLogging(this.#loggingId);
+            this.#loggingId = undefined;
+        }
     }
 
     /**

--- a/lib/types/index.d.ts
+++ b/lib/types/index.d.ts
@@ -54,6 +54,15 @@ export enum distance {
   ignored,
 }
 
+export enum logLevels {
+  trace = "trace",
+  debug = "debug",
+  info = "info",
+  warning = "warning",
+  error = "error",
+  off = "off",
+}
+
 export enum responseErrorCodes {
   serverError = 0x0000,
   protocolError = 0x000a,

--- a/lib/types/index.js
+++ b/lib/types/index.js
@@ -209,6 +209,25 @@ const distance = {
 };
 
 /**
+ * Log level values used for the `logLevel` client option and emitted in `'log'` events.
+ * @type {Object}
+ * @property {String} trace Finest-grained diagnostic information (TRACE level events).
+ * @property {String} debug Fine-grained diagnostic information useful during development (DEBUG level events).
+ * @property {String} info High-level informational messages.
+ * @property {String} warning Potentially harmful situations.
+ * @property {String} error Error conditions.
+ * @property {String} off Disables internal driver log forwarding.
+ */
+const logLevels = {
+    trace: "trace",
+    debug: "debug",
+    info: "info",
+    warning: "warning",
+    error: "error",
+    off: "off",
+};
+
+/**
  * Server error codes returned by Cassandra
  * @type {Object}
  * @property {Number} serverError Something unexpected happened.
@@ -491,6 +510,7 @@ exports.consistencyToString = consistencyToString;
 exports.dataTypes = dataTypes;
 exports.getDataTypeNameByCode = getDataTypeNameByCode;
 exports.distance = distance;
+exports.logLevels = logLevels;
 exports.protocolVersion = protocolVersion;
 exports.responseErrorCodes = responseErrorCodes;
 exports.BigDecimal = require("./big-decimal");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@ extern crate napi_derive;
 
 // Link other files
 pub mod errors;
+pub mod logging;
 pub mod metadata;
 pub mod options;
 pub mod paging;

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -1,0 +1,49 @@
+use tracing::Level;
+
+/// Maps a Rust `tracing::Level` to the JS log-level strings.
+pub(crate) fn rust_level_to_js(level: &Level) -> &'static str {
+    match *level {
+        Level::TRACE => "trace",
+        Level::DEBUG => "debug",
+        Level::INFO => "info",
+        Level::WARN => "warning",
+        Level::ERROR => "error",
+    }
+}
+
+/// Parses a JS-side log-level name.
+/// Note: "off" should be filtered at the JS side and should not be passed to Rust.
+pub(crate) fn parse_js_level_to_rust(level: &str) -> Option<Level> {
+    match level {
+        "trace" => Some(Level::TRACE),
+        "debug" => Some(Level::DEBUG),
+        "info" => Some(Level::INFO),
+        "warning" => Some(Level::WARN),
+        "error" => Some(Level::ERROR),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rust_level_to_js_mapping() {
+        assert_eq!(rust_level_to_js(&Level::TRACE), "trace");
+        assert_eq!(rust_level_to_js(&Level::DEBUG), "debug");
+        assert_eq!(rust_level_to_js(&Level::INFO), "info");
+        assert_eq!(rust_level_to_js(&Level::WARN), "warning");
+        assert_eq!(rust_level_to_js(&Level::ERROR), "error");
+    }
+
+    #[test]
+    fn parse_js_level_to_rust_valid() {
+        assert_eq!(parse_js_level_to_rust("trace"), Some(Level::TRACE));
+        assert_eq!(parse_js_level_to_rust("debug"), Some(Level::DEBUG));
+        assert_eq!(parse_js_level_to_rust("info"), Some(Level::INFO));
+        assert_eq!(parse_js_level_to_rust("warning"), Some(Level::WARN));
+        assert_eq!(parse_js_level_to_rust("error"), Some(Level::ERROR));
+        assert_eq!(parse_js_level_to_rust("some garbage"), None);
+    }
+}

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -1,9 +1,12 @@
+use std::fmt;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{OnceLock, RwLock};
 
 use napi::bindgen_prelude::FnArgs;
 use napi::threadsafe_function::{ThreadsafeFunction, ThreadsafeFunctionCallMode};
+use std::fmt::Write;
 use tracing::Level;
+use tracing::field::{Field, Visit};
 use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::{Layer, Registry};
 
@@ -85,6 +88,32 @@ pub(crate) fn parse_js_level_to_rust(level: &str) -> Option<Level> {
     }
 }
 
+struct MessageVisitor {
+    log_message: String,
+}
+
+impl MessageVisitor {
+    fn new() -> Self {
+        Self {
+            log_message: String::new(),
+        }
+    }
+}
+
+// Collects all fields and values in a single log event into a single String, similarly to CPP RS driver
+impl Visit for MessageVisitor {
+    fn record_debug(&mut self, field: &Field, value: &dyn fmt::Debug) {
+        if !self.log_message.is_empty() {
+            write!(self.log_message, ", ").unwrap();
+        }
+        // We filter out for message field to reduce the noise in the logging output
+        if field.name() != "message" {
+            write!(self.log_message, "{field}: ").unwrap();
+        }
+        write!(self.log_message, "{value:?}").unwrap();
+    }
+}
+
 /// A single global `Layer` that, on each event, iterates every registered
 /// per-client callback and forwards the event data to those whose
 /// `min_level` is permissive enough.
@@ -117,7 +146,9 @@ impl<S: tracing::Subscriber> Layer<S> for JsForwardingLayer {
         // At least one callback wants this event — extract the fields.
         let level_str = rust_level_to_js(event_level);
         let target = meta.target();
-        let message = String::new();
+
+        let mut visitor = MessageVisitor::new();
+        event.record(&mut visitor);
 
         for cb in callbacks.iter() {
             if *event_level <= cb.min_level {
@@ -126,7 +157,7 @@ impl<S: tracing::Subscriber> Layer<S> for JsForwardingLayer {
                         data: (
                             level_str.to_owned(),
                             target.to_owned(),
-                            message.to_owned(),
+                            visitor.log_message.clone(),
                             // This maps to JS furtherInfo field, that was sometimes used in the DSx driver,
                             // but is not used here, as we are trying to match the CPP and C# wrappers behavior in logging.
                             "".to_owned(),

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -1,4 +1,65 @@
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{OnceLock, RwLock};
+
+use napi::bindgen_prelude::FnArgs;
+use napi::threadsafe_function::{ThreadsafeFunction, ThreadsafeFunctionCallMode};
 use tracing::Level;
+use tracing_subscriber::layer::SubscriberExt;
+use tracing_subscriber::{Layer, Registry};
+
+use crate::errors::{
+    ConvertedError, ConvertedResult, JsResult, make_js_error, with_custom_error_sync,
+};
+
+/// Shorthand for the NAPI callback type.
+///
+/// Generic parameters: `CalleeHandled = false`, `Weak = true` so that the
+/// callback does not prevent the Node.js event-loop from exiting.
+type LogCallback = ThreadsafeFunction<
+    /* T: */ FnArgs<(String, String, String, String)>,
+    /* Return: */ (),
+    /* CallJsBackArgs: (level, target, message, furtherInfo) */
+    FnArgs<(String, String, String, String)>,
+    /* ErrorStatus: */ napi::Status,
+    /* CalleeHandled: */ false,
+    /* Weak: */ true,
+>;
+
+/// A callback registered by one client, together with the minimum severity
+/// level it is interested in.
+struct RegisteredCallback {
+    id: u64,
+    callback: LogCallback,
+    min_level: Level,
+}
+
+/// Monotonically increasing id counter for registered callbacks.
+static NEXT_ID: AtomicU64 = AtomicU64::new(0);
+
+/// Registry of all currently-active per-client callbacks.
+/// Initialized (and the global subscriber installed) on the first call to
+/// `setup_logging`.
+static CALLBACKS: OnceLock<RwLock<Vec<RegisteredCallback>>> = OnceLock::new();
+
+/// Return the callback registry, lazily installing the global tracing
+/// subscriber the very first time this is called.
+fn get_or_init_callbacks() -> &'static RwLock<Vec<RegisteredCallback>> {
+    CALLBACKS.get_or_init(|| {
+        let subscriber = Registry::default().with(JsForwardingLayer);
+        tracing::subscriber::set_global_default(subscriber).unwrap_or_else(|_| {
+            // This will fail only if we try to call `set_global_default` in other place in the code.
+            // Since we are under OnceLock here, we will not call this function here twice.
+            // For this reason we can safely panic here.
+            panic!("Double tracing initialization detected. This can happen in one of the two cases:\n\
+             - Your code depends on another package that sets up the Rust logging. \
+            If this is the case you need to either disable this driver logging, or disable the other package logging.\n\
+             - This is a bug in the driver. If you believe this is a case, please submit a bug report: \
+            https://github.com/scylladb/nodejs-rs-driver/issues/new. Include all used dependencies in the bug report.\n\
+            ");
+        });
+        RwLock::new(Vec::new())
+    })
+}
 
 /// Maps a Rust `tracing::Level` to the JS log-level strings.
 pub(crate) fn rust_level_to_js(level: &Level) -> &'static str {
@@ -21,6 +82,102 @@ pub(crate) fn parse_js_level_to_rust(level: &str) -> Option<Level> {
         "warning" => Some(Level::WARN),
         "error" => Some(Level::ERROR),
         _ => None,
+    }
+}
+
+/// A single global `Layer` that, on each event, iterates every registered
+/// per-client callback and forwards the event data to those whose
+/// `min_level` is permissive enough.
+struct JsForwardingLayer;
+
+impl<S: tracing::Subscriber> Layer<S> for JsForwardingLayer {
+    fn on_event(
+        &self,
+        event: &tracing::Event<'_>,
+        _ctx: tracing_subscriber::layer::Context<'_, S>,
+    ) {
+        let Some(lock) = CALLBACKS.get() else {
+            return;
+        };
+        let Ok(callbacks) = lock.read() else {
+            return;
+        };
+
+        let meta = event.metadata();
+        let event_level = meta.level();
+
+        // Quick pre-check: is *any* callback interested in this level?
+        // Level ordering in tracing: TRACE > DEBUG > INFO > WARN > ERROR
+        // (more verbose = greater).  An event passes if it is at most as
+        // verbose as the callback's threshold, i.e. event_level <= min_level.
+        if !callbacks.iter().any(|cb| *event_level <= cb.min_level) {
+            return;
+        }
+
+        // At least one callback wants this event — extract the fields.
+        let level_str = rust_level_to_js(event_level);
+        let target = meta.target();
+        let message = String::new();
+
+        for cb in callbacks.iter() {
+            if *event_level <= cb.min_level {
+                cb.callback.call(
+                    FnArgs {
+                        data: (
+                            level_str.to_owned(),
+                            target.to_owned(),
+                            message.to_owned(),
+                            // This maps to JS furtherInfo field, that was sometimes used in the DSx driver,
+                            // but is not used here, as we are trying to match the CPP and C# wrappers behavior in logging.
+                            "".to_owned(),
+                        ),
+                    },
+                    ThreadsafeFunctionCallMode::NonBlocking,
+                );
+            }
+        }
+    }
+}
+
+/// Register a per-client logging callback.
+///
+/// Each call adds a **new** callback to the global registry, allowing
+/// multiple `Client` instances to receive Rust driver log events
+/// independently.
+///
+/// Returns a numeric `id` that must be passed to [`removeLogging`] when the
+/// client shuts down, so the callback can be unregistered.
+#[napi]
+pub fn setup_logging(callback: LogCallback, min_level: String) -> JsResult<i64> {
+    with_custom_error_sync(|| {
+        let level = parse_js_level_to_rust(&min_level).ok_or(ConvertedError::from(
+            make_js_error(format!("Unknown logging level: {min_level}")),
+        ))?;
+
+        let id = NEXT_ID.fetch_add(1, Ordering::Relaxed);
+
+        let callbacks = get_or_init_callbacks();
+        callbacks.write()?.push(RegisteredCallback {
+            id,
+            callback,
+            min_level: level,
+        });
+
+        ConvertedResult::Ok(id as i64)
+    })
+}
+
+/// Unregister a previously-registered logging callback.
+///
+/// After this call the callback associated with `id` will no longer receive
+/// any tracing events.  If `id` does not match any registered callback the
+/// call is a silent no-op.
+#[napi]
+pub fn remove_logging(id: i64) {
+    if let Some(lock) = CALLBACKS.get() {
+        lock.write()
+            .expect("Since we have use panic=abort, we will never have poisoned locks")
+            .retain(|cb| cb.id != id as u64);
     }
 }
 


### PR DESCRIPTION
This PR extracts the changes from #423. More specificly, this PR constains changes that introduce logging infrastructure (1st commit) split into 3.

Why?
The initial PR has grown a bit to much, and I believe it would be just faster to split it into smaller chunks to get it done faster. 